### PR TITLE
Fix APK release path in CI and build.gradle

### DIFF
--- a/.github/workflows/merged-build.yml
+++ b/.github/workflows/merged-build.yml
@@ -182,7 +182,7 @@ jobs:
           fi
           
           # Locate built APK
-          APK_ORIGINAL=$(find app/build/outputs/apk/debug -name "*.apk" | head -n 1)
+          APK_ORIGINAL=$(find app/build/outputs/apk -type f -name "*.apk" | head -n 1)
           
           if [ -z "$APK_ORIGINAL" ]; then
              echo "Error: No APK found to release!"

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -38,13 +38,6 @@ android {
     lintOptions {
         checkReleaseBuilds false
     }
-    android.applicationVariants.all { variant ->
-        def formattedDate = new Date().format('hh.mm')
-
-        variant.outputs.all {
-            outputFileName = "./${variant.versionName}/${variant.applicationId}_${variant.getFlavorName()}_${variant.versionCode}_${formattedDate}.apk"
-        }
-    }
 }
 dependencies {
     testImplementation 'junit:junit:4.13.2'


### PR DESCRIPTION
## Summary by Sourcery

Adjust APK artifact handling for CI builds.

Build:
- Remove custom Gradle logic that renamed APK outputs based on variant metadata and timestamp.
- Update CI workflow to search for APKs in all app/build/outputs/apk subdirectories instead of only the debug folder.