### PR TITLE
Stop declaring android.permission.FLASHLIGHT, which blocks install

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,12 +18,18 @@
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK"  />
 
-    <permission
-        android:name="android.permission.FLASHLIGHT"
-        android:description="@string/help_flash"
-        android:label="@string/help_flash"
-        android:permissionGroup="android.permission-group.HARDWARE_CONTROLS"
-        android:protectionLevel="normal" />
+<!--
+      No <permission> declarations here.
+
+      This manifest used to define android.permission.FLASHLIGHT. That name belongs to the
+      platform, and an app that redefines a permission another package already owns is
+      rejected at install time with INSTALL_FAILED_DUPLICATE_PERMISSION — surfaced to the
+      user as a bare "App not installed" with no reason given. Its permissionGroup,
+      android.permission-group.HARDWARE_CONTROLS, no longer exists either.
+
+      Nothing needed it: the torch is driven through CameraManager, and `flash` requests
+      android.permission.CAMERA at runtime.
+    -->
 
     <!-- features -->
     <uses-feature


### PR DESCRIPTION
Fixes "App not installed".

## The defect

The manifest **defined** a permission named `android.permission.FLASHLIGHT`:

```xml
<permission
    android:name="android.permission.FLASHLIGHT"
    android:permissionGroup="android.permission-group.HARDWARE_CONTROLS"
    android:protectionLevel="normal" />
```

That name belongs to the platform. An app that redefines a permission another package already owns is rejected at install time with `INSTALL_FAILED_DUPLICATE_PERMISSION` — and the installer UI doesn't surface the reason, it just says **"App not installed"**. That matches the reported symptom exactly: both flavours, every attempt, no explanation.

`android.permission-group.HARDWARE_CONTROLS` hasn't existed for several releases either.

## Why removing it is safe

It's inherited from T-UI and is entirely vestigial:

- no code references `FLASHLIGHT` — `grep` across `app/src` returns nothing outside the manifest
- the torch is driven through `CameraManager`
- `flash` requests `android.permission.CAMERA` at runtime, which is unaffected

Note this is a `<permission>` *declaration*, not a `<uses-permission>`. Removing it doesn't drop a capability — it stops the app claiming ownership of a name it never owned.

## Verification

The rebuilt APK now declares only `com.hereliesaz.hg2gui.DYNAMIC_RECEIVER_NOT_EXPORTED_PERMISSION`, generated by androidx and namespaced to the application id, so it cannot collide.

I also checked the other install-time rejection paths while in here, and they're all clean:

| check | result |
|---|---|
| required `uses-feature` | none — all optional, only an implied portrait feature |
| provider authorities | `…FILE_PROVIDER`, `…androidx-startup` — both namespaced under the application id |
| native ABIs | `arm64-v8a`, `armeabi-v7a`, `x86`, `x86_64` — no `NO_MATCHING_ABIS` risk |
| `sharedUserId` | not set |
| package name | `com.hereliesaz.hg2gui` — already correct, unchanged |

Clean `assembleDebug` for both flavours, both unit test variants pass.

**Not confirmed on a device.** This is a genuine manifest defect with a failure mode that matches the symptom precisely, but I can't prove it was the cause without an install attempt. If it still fails after this, `adb install` will give the real `INSTALL_FAILED_*` code and the next suspects are the signature of any existing install, then `targetSdk 37`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdfiMKAr36j4PKVBwA9RX4)_

## Summary by Sourcery

Bug Fixes:
- Stop declaring the platform-owned android.permission.FLASHLIGHT permission, preventing INSTALL_FAILED_DUPLICATE_PERMISSION and "App not installed" errors during installation.