### PR TITLE
Derive versionCode and versionName from the build number

### DIFF
--- a/.github/workflows/merged-build.yml
+++ b/.github/workflows/merged-build.yml
@@ -92,6 +92,34 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
 
+      # Computed before the build so the same numbers reach both the APK and the release
+      # filename. This used to be worked out after the build, in the release step, which meant
+      # the version the workflow advertised was never the version compiled into the APK.
+      - name: Compute Version
+        run: |
+          BUILD_NUMBER=$(git rev-list --count HEAD)
+
+          MAJOR=$(grep 'versionMajor=' version.properties | cut -d'=' -f2)
+          MINOR=$(grep 'versionMinor=' version.properties | cut -d'=' -f2)
+
+          # Patch counts commits since versionMinor last changed.
+          MINOR_COMMIT=$(git blame -L '/versionMinor=/',+1 version.properties 2>/dev/null | awk '{print $1}' | tr -d '^' || true)
+          if [ -n "$MINOR_COMMIT" ]; then
+            PATCH=$(git rev-list --count "$MINOR_COMMIT"..HEAD)
+          else
+            PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2)
+          fi
+
+          VERSION_NAME="$MAJOR.$MINOR.$PATCH.$BUILD_NUMBER"
+
+          {
+            echo "BUILD_NUMBER=$BUILD_NUMBER"
+            echo "VERSION_NAME=$VERSION_NAME"
+            echo "TAG_NAME=latest-debug-v${MAJOR}.${MINOR}"
+          } >> "$GITHUB_ENV"
+
+          echo "versionName=$VERSION_NAME versionCode=$BUILD_NUMBER"
+
       - name: Build with Gradle
         id: gradle-build
         env:
@@ -100,10 +128,10 @@ jobs:
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
         run: |
           set +e
-          export BUILD_NUMBER=$(git rev-list --count HEAD)
-          
-          # Build the APK
-          ./gradlew assembleDebug -PversionBuild=$BUILD_NUMBER --build-cache \
+
+          # Build the APK. versionName/versionBuild come from the Compute Version step, so the
+          # APK reports exactly what the release filename claims.
+          ./gradlew assembleDebug -PversionBuild=$BUILD_NUMBER -PversionName=$VERSION_NAME --build-cache \
             -Pandroid.injected.signing.store.file=$(pwd)/app/keystore.jks \
             -Pandroid.injected.signing.store.password=$KEYSTORE_PASSWORD \
             -Pandroid.injected.signing.key.alias=$KEY_ALIAS \
@@ -166,24 +194,9 @@ jobs:
         if: success() && github.event_name == 'push' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
         id: release_vars
         run: |
-          export BUILD_NUMBER=$(git rev-list --count HEAD)
-          
-          # Extract version info from properties file
-          MAJOR=$(grep 'versionMajor=' version.properties | cut -d'=' -f2)
-          MINOR=$(grep 'versionMinor=' version.properties | cut -d'=' -f2)
+          # VERSION_NAME and TAG_NAME come from the Compute Version step, which ran before the
+          # build. Recomputing them here would risk advertising a version the APK doesn't carry.
 
-          # Calculate Patch version programmatically based on commits since Minor update
-          MINOR_COMMIT=$(git blame -L '/versionMinor=/',+1 version.properties | awk '{print $1}' | tr -d '^')
-          if [ -n "$MINOR_COMMIT" ]; then
-            PATCH=$(git rev-list --count $MINOR_COMMIT..HEAD)
-          else
-            PATCH=$(grep 'versionPatch=' version.properties | cut -d'=' -f2)
-          fi
-
-          VERSION_NAME="$MAJOR.$MINOR.$PATCH.$BUILD_NUMBER"
-          
-          TAG_NAME="latest-debug-v${MAJOR}.${MINOR}"
-          
           # Dynamic App Name from settings.gradle
           if [ -f "settings.gradle.kts" ]; then
              APP_NAME=$(grep 'rootProject.name' settings.gradle.kts | sed -E "s/.*=.*[\"'](.*)[\"']/\1/")
@@ -213,7 +226,6 @@ jobs:
           # Rename for release
           mv "$APK_ORIGINAL" "$TARGET_NAME"
           
-          echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
           echo "APK_FILE=$TARGET_NAME" >> $GITHUB_ENV
           
           # Package Build Tools (Optional)

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,6 +2,39 @@ apply plugin: 'com.android.application'
 apply plugin: 'org.jetbrains.kotlin.android'
 apply plugin: 'org.jetbrains.kotlin.plugin.compose'
 
+// Version wiring.
+//
+// versionCode and versionName used to be hardcoded here, so every build published the same
+// versionCode (205). Android refuses to install a package whose versionCode is not greater
+// than the installed one, so releases could never upgrade in place — you had to uninstall
+// first — even though the release filename advertised a new build number every time.
+//
+// CI computes the build number (git commit count) and passes -PversionBuild, and passes the
+// full -PversionName so the in-app version matches the published filename exactly.
+def versionProps = new Properties()
+def versionPropsFile = rootProject.file('version.properties')
+if (versionPropsFile.exists()) {
+    versionPropsFile.withInputStream { versionProps.load(it) }
+}
+
+// Legacy hardcoded value. Any generated versionCode must clear it, or devices carrying an
+// older build could not upgrade to a new one.
+def legacyVersionCode = 205
+
+// Local builds get no -PversionBuild, and their clone is often shallow (CI uses
+// fetch-depth: 0), which makes a locally derived commit count both smaller and meaningless.
+// Falling back to the floor keeps local installs upgradable without pretending to be a
+// release build.
+def buildNumber = (project.findProperty('versionBuild') ?: '0').toString() as int
+def resolvedVersionCode = Math.max(buildNumber, legacyVersionCode + 1)
+
+def resolvedVersionName = project.findProperty('versionName') ?: String.format(
+        '%s.%s.%s.%d',
+        versionProps.getProperty('versionMajor', '0'),
+        versionProps.getProperty('versionMinor', '0'),
+        versionProps.getProperty('versionPatch', '0'),
+        buildNumber)
+
 android {
     namespace "com.hereliesaz.hg2gui"
     // The platform SDK is now minor-versioned (android-37.0); `compileSdk 37` alone resolves
@@ -16,8 +49,8 @@ android {
         minSdk 24
         targetSdk 37
 
-        versionName "v6.15"
-        versionCode 205
+        versionName resolvedVersionName
+        versionCode resolvedVersionCode
     }
     buildTypes {
         release {


### PR DESCRIPTION
`app/build.gradle` hardcoded `versionCode 205` and `versionName "v6.15"`, so every build published an identical versionCode. Android refuses to install a package whose versionCode isn't greater than the installed one — so **no release could ever upgrade in place**; you had to uninstall first, while the release filename advertised a new build number every time.

## versionCode

CI already computed the build number and already passed `-PversionBuild`. Nothing read it. The build now consumes it.

## versionName

Wired the same way, and it fixes a second mismatch: the workflow computed the version *after* the build, so the name in the filename was never the name compiled into the APK. The release published as `0.5.46.288` reports itself internally as `v6.15`.

That computation moves to a **Compute Version** step ahead of the build and is passed in as `-PversionName`, so filename and in-app version match by construction rather than coincidence. The duplicate computation in the release step is removed — it now consumes the same values instead of independently recomputing them.

## Local builds

Local builds get no `-PversionBuild`, and their clone is usually shallow (CI uses `fetch-depth: 0`). A locally derived commit count is therefore both smaller and meaningless — this repo shows **124 shallow against 288 full**. 124 is *below* the legacy 205 and would be rejected as a downgrade, so generated codes are floored just above the legacy value.

## Verification

Probed the actual configured Android extension, not just the arithmetic:

| invocation | versionCode | versionName |
|---|---|---|
| CI-style (`-PversionBuild=288 -PversionName=0.5.46.288`) | `288` | `0.5.46.288` |
| local, no properties | `206` | `0.5.0.0` |

Both clear 205, so both are installable over the current release. Gradle configuration succeeds in both cases.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdfiMKAr36j4PKVBwA9RX4)_

## Summary by Sourcery

Derive Android app versionCode and versionName from CI-computed build metadata so APK internals match published release artifacts and remain upgradable.

New Features:
- Introduce CI-side Compute Version step that calculates BUILD_NUMBER-based versionCode and a structured VERSION_NAME before the Gradle build.
- Allow Gradle builds to accept versionBuild and versionName properties so CI and local builds can generate dynamic versioning without manual updates.

Bug Fixes:
- Ensure each release uses a monotonically increasing versionCode derived from the build number, allowing Android installs to upgrade in place.
- Align the APK’s internal versionName with the version advertised in release filenames by sharing the same computed value across build and release steps.
- Prevent local debug installs from being rejected as downgrades by flooring auto-generated versionCodes above the legacy hardcoded value.

Enhancements:
- Centralize version computation in CI and reuse the result across build and release steps instead of recomputing it.
- Refactor app Gradle configuration to derive versionName from version.properties and build metadata when not supplied explicitly.

CI:
- Add a dedicated Compute Version step in the merged-build workflow to compute BUILD_NUMBER, VERSION_NAME, and TAG_NAME for downstream steps.
- Update the Gradle build and release steps in the workflow to consume precomputed version metadata from environment variables instead of recalculating it.