### PR TITLE
Build the terminal engine off the main thread so the splash screen dismisses

### DIFF
--- a/app/src/main/java/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/app/src/main/java/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -4,15 +4,25 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.hereliesaz.hg2gui.managers.xml.XMLPrefsManager
 import com.hereliesaz.hg2gui.terminal.TerminalEngine
 import com.hereliesaz.hg2gui.tuils.interfaces.Reloadable
 import com.hereliesaz.hg2gui.ui.HG2GuiTheme
 import com.hereliesaz.hg2gui.ui.TerminalScreen
 import com.hereliesaz.hg2gui.ui.menu.CommandTree
+import com.hereliesaz.hg2gui.ui.menu.MenuNode
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 /*
  * The entry point. This is a terminal app, not a launcher:
@@ -25,35 +35,69 @@ import com.hereliesaz.hg2gui.ui.menu.CommandTree
  */
 class TerminalActivity : ComponentActivity(), Reloadable {
 
-    private lateinit var main: MainManager
-    private lateinit var engine: TerminalEngine
+    // Null until background init finishes. Building these before the first frame held the
+    // splash screen up indefinitely: MainManager's constructor runs a contacts query, a full
+    // package-manager scan, OkHttp setup, a changelog fetch and a shell spawn, and the command
+    // tree comes from a full APK-wide class scan (CommandGroup -> DexFile.entries()) — none of
+    // it async, all of it between onCreate and setContent. Android never had a frame to
+    // dismiss the splash with. Both are only ever written from the main dispatcher (after the
+    // background withContext block returns, not inside it), so no synchronization is needed to
+    // read them safely from onDestroy.
+    private var main: MainManager? = null
+    private var engine: TerminalEngine? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
-        main = MainManager(this, this)
-        engine = TerminalEngine(this, main, main.mainPack?.currentDirectory)
-
-        val tree = CommandTree.from(
-            main.mainPack?.commandGroup?.commands?.toList().orEmpty()
-        )
-
         setContent {
             HG2GuiTheme {
+                var tree by remember { mutableStateOf<List<MenuNode>?>(null) }
                 // The shell reports where it ended up after every command, so `cd` is visible
                 // in the header rather than being silently swallowed.
-                var cwd by remember { mutableStateOf(engine.workingDirectory) }
+                var cwd by remember { mutableStateOf("") }
 
-                TerminalScreen(
-                    tree = tree,
-                    cwd = cwd,
-                    onRun = { line ->
-                        val result = engine.run(line)
-                        cwd = engine.workingDirectory
-                        result
+                LaunchedEffect(Unit) {
+                    val (builtMain, builtEngine, builtTree) = withContext(Dispatchers.Default) {
+                        // Must happen before MainManager reads a single XMLPrefsSave, or every
+                        // preference read falls back to its default through
+                        // exception-swallowing logic instead of the user's saved value — this
+                        // activity used to skip it entirely.
+                        XMLPrefsManager.loadCommons(this@TerminalActivity)
+
+                        val builtMain = MainManager(this@TerminalActivity, this@TerminalActivity)
+                        val builtEngine = TerminalEngine(
+                            this@TerminalActivity, builtMain, builtMain.mainPack?.currentDirectory
+                        )
+                        val builtTree = CommandTree.from(
+                            builtMain.mainPack?.commandGroup?.commands?.toList().orEmpty()
+                        )
+                        Triple(builtMain, builtEngine, builtTree)
                     }
-                )
+
+                    main = builtMain
+                    engine = builtEngine
+                    cwd = builtEngine.workingDirectory
+                    tree = builtTree
+                }
+
+                val currentEngine = engine
+                val currentTree = tree
+                if (currentEngine != null && currentTree != null) {
+                    TerminalScreen(
+                        tree = currentTree,
+                        cwd = cwd,
+                        onRun = { line ->
+                            val result = currentEngine.run(line)
+                            cwd = currentEngine.workingDirectory
+                            result
+                        }
+                    )
+                } else {
+                    Box(Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                        Text("Loading…")
+                    }
+                }
             }
         }
     }
@@ -70,8 +114,8 @@ class TerminalActivity : ComponentActivity(), Reloadable {
     }
 
     override fun onDestroy() {
-        engine.destroy()
-        main.destroy()
+        engine?.destroy()
+        main?.destroy()
         super.onDestroy()
     }
 }


### PR DESCRIPTION
The app sat on the splash screen forever, with nothing to distinguish a slow device from a genuine hang.

## Root cause

`TerminalActivity.onCreate` built `MainManager` and `TerminalEngine`, and derived the command tree, before ever calling `setContent` — so no frame existed for Android to dismiss the splash with until all of it finished. On the main thread, that construction does:

- a contacts query, a full package-manager scan, OkHttp client setup, a changelog fetch, and a shell spawn (`MainManager`)
- a full **APK-wide class scan** via `dalvik.system.DexFile.entries()` to discover the command tree (`CommandGroup`)

None of it is async. The app's dependency graph — Compose, AndroidX, OkHttp, Kotlin stdlib — is far larger than it was when that scan was written, since it has to walk every class in the APK looking for the ones under one package. That enumeration alone plausibly accounts for most of the wait.

## Fix

`setContent` now runs immediately, with a "Loading…" placeholder. The same construction happens inside a `LaunchedEffect` on `Dispatchers.Default`, and state flips once it completes — so the UI is responsive from frame one regardless of how slow any of that turns out to be on a given device, and regardless of which specific call is the actual bottleneck.

`MainManager` and `TerminalEngine`'s constructors, and `CommandGroup`'s scan, do only broadcast-receiver registration (safe off the main thread via `LocalBroadcastManager` / `registerReceiver`'s default handler), process spawning, file I/O, and reflection — nothing that assumes the calling thread. The activity's `main`/`engine` fields are written only after the background block returns (back on the main dispatcher), never from inside it, so `onDestroy` can read them without synchronization.

## Also fixed

Restored `XMLPrefsManager.loadCommons(this)`, dropped when the launcher was replaced by this terminal activity. Every preference read had been silently falling back to its default through exception-swallowing logic instead of the user's saved value — a real but separate regression from the same migration, found while tracing this bug.

## Verification

- Compiles clean (`compileFdroidDebugKotlin`)
- `assembleFdroidDebug` succeeds
- Existing unit tests pass (`testFdroidDebugUnitTest`)

This branch is rebuilt on top of #39 (merged) — the version-wiring changes are intact here, only `TerminalActivity.kt` changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdfiMKAr36j4PKVBwA9RX4)_

## Summary by Sourcery

Initialize the terminal engine and command tree on a background dispatcher while showing an immediate loading UI, avoiding splash screen hangs on slow devices.

New Features:
- Display a centered "Loading…" placeholder in the terminal UI while the engine and command tree are being initialized.

Bug Fixes:
- Prevent the splash screen from blocking indefinitely by deferring terminal engine and command tree construction off the main thread.
- Restore XML preference loading via XMLPrefsManager.loadCommons so user settings are correctly applied instead of silently falling back to defaults.
- Guard terminal destruction in onDestroy against null engine and manager instances to avoid potential crashes.

Enhancements:
- Refactor TerminalActivity to hold nullable MainManager and TerminalEngine instances that are safely initialized after the first frame.
- Wire terminal UI state (working directory and command tree) to update once background initialization completes.