### PR TITLE
Fix the fatal crash after the splash screen: scoped storage rejects the t-ui folder

### DIFF
--- a/app/src/main/java/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/app/src/main/java/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import com.hereliesaz.hg2gui.managers.xml.XMLPrefsManager
 import com.hereliesaz.hg2gui.terminal.TerminalEngine
+import com.hereliesaz.hg2gui.tuils.Tuils
 import com.hereliesaz.hg2gui.tuils.interfaces.Reloadable
 import com.hereliesaz.hg2gui.ui.HG2GuiTheme
 import com.hereliesaz.hg2gui.ui.TerminalScreen
@@ -49,6 +50,12 @@ class TerminalActivity : ComponentActivity(), Reloadable {
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
+
+        // Must run before anything below resolves the t-ui folder (loadCommons, and every
+        // manager MainManager builds). Tuils.getTuiFolder() needs an application context to
+        // resolve an app-scoped storage path; without it there is nowhere sanctioned to fall
+        // back to.
+        Tuils.init(applicationContext)
 
         setContent {
             HG2GuiTheme {

--- a/app/src/main/java/com/hereliesaz/hg2gui/managers/AppsManager.java
+++ b/app/src/main/java/com/hereliesaz/hg2gui/managers/AppsManager.java
@@ -44,6 +44,7 @@ import com.hereliesaz.hg2gui.UIManager;
 import com.hereliesaz.hg2gui.commands.main.MainPack;
 import com.hereliesaz.hg2gui.managers.xml.XMLPrefsManager;
 import com.hereliesaz.hg2gui.managers.xml.classes.XMLPrefsElement;
+import com.hereliesaz.hg2gui.managers.xml.classes.XMLPrefsEntry;
 import com.hereliesaz.hg2gui.managers.xml.classes.XMLPrefsList;
 import com.hereliesaz.hg2gui.managers.xml.classes.XMLPrefsSave;
 import com.hereliesaz.hg2gui.managers.xml.options.Apps;
@@ -1232,7 +1233,14 @@ public class AppsManager implements XMLPrefsElement {
 
                 final String PREFIX = "default_app_n";
                 for(int count = 0; count < 5; count++) {
-                    String vl = values.get(Apps.valueOf(PREFIX + (count + 1))).value;
+                    // values.get() returns null for a key with no stored entry — every other
+                    // preference read (XMLPrefsManager.get()) falls back to a default when
+                    // that happens; this one didn't, and an unresolved values map (an empty
+                    // storage folder, for instance) turned a missing suggestion slot into an
+                    // uncaught NullPointerException that killed the whole process on a
+                    // background thread.
+                    XMLPrefsEntry entry = values.get(Apps.valueOf(PREFIX + (count + 1)));
+                    String vl = entry != null ? entry.value : Apps.NULL;
 
                     if(vl.equals(Apps.NULL)) continue;
                     if(vl.equals(Apps.MOST_USED)) suggested.add(new SuggestedApp(MOST_USED, count + 1));

--- a/app/src/main/java/com/hereliesaz/hg2gui/managers/xml/XMLPrefsManager.java
+++ b/app/src/main/java/com/hereliesaz/hg2gui/managers/xml/XMLPrefsManager.java
@@ -134,13 +134,19 @@ public class XMLPrefsManager {
     static boolean commonsLoaded = false;
     public static void loadCommons(Context context) {
         if(commonsLoaded) return;
-        commonsLoaded = true;
 
         File folder = Tuils.getFolder();
         if(folder == null) {
+            // Do not latch commonsLoaded here: a caller that hits this before the folder is
+            // available (transient — unmounted storage, a permission not yet settled) would
+            // otherwise disable preference loading for the rest of the process's life. Every
+            // subsequent get() falls back to a default silently, and code that reads an entry
+            // without going through get()'s exception-swallowing path crashes on a null one.
             Tuils.sendOutput(Color.RED, context, R.string.tuinotfound_xmlprefs);
             return;
         }
+
+        commonsLoaded = true;
 
         for(XMLPrefsRoot element : XMLPrefsRoot.values()) {
             File file = new File(folder, element.path);

--- a/app/src/main/java/com/hereliesaz/hg2gui/tuils/Tuils.java
+++ b/app/src/main/java/com/hereliesaz/hg2gui/tuils/Tuils.java
@@ -117,6 +117,14 @@ public class Tuils {
 
     public static Pattern patternNewline = Pattern.compile("%n", Pattern.CASE_INSENSITIVE | Pattern.LITERAL);
 
+    // Set once by TerminalActivity.onCreate, before anything reads a preference. Safe to hold
+    // statically: an application context, not an Activity, so it cannot leak one.
+    private static Context applicationContext;
+
+    public static void init(Context context) {
+        applicationContext = context.getApplicationContext();
+    }
+
     private static Typeface globalTypeface = null;
     public static String fontPath = null;
 
@@ -1379,9 +1387,30 @@ public class Tuils {
         return uri;
     }
 
+    /**
+     * Used to be {@code Environment.getExternalStorageDirectory()} + "t-ui" — a *new* top-level
+     * directory in shared storage. Scoped storage (enforced unconditionally from API 30, and
+     * this app targets 37) refuses to create one regardless of any permission grant: {@code
+     * mkdir()} silently fails and MediaProvider logs "Creating or writing to a non-default top
+     * level directory is not allowed!" for every attempt. Every caller of {@link #getFolder()}
+     * then got null, so every preference read fell through to a default (or, where nothing
+     * defends against a null entry, crashed — that's what killed the app during the
+     * suggested-apps list build).
+     *
+     * The app's own external files directory is exempt from that restriction, requires no
+     * permission, and is still reachable with a file manager under Android/data/ — it just
+     * isn't a bare top-level folder. Falls back to internal storage if external is unavailable
+     * (unmounted SD card, for instance), and to the old behavior only if {@link #init} was
+     * never called, which should not happen in practice.
+     */
     private static File getTuiFolder() {
-        File internalDir = Environment.getExternalStorageDirectory();
-        return new File(internalDir, TUI_FOLDER);
+        File base = null;
+        if (applicationContext != null) {
+            base = applicationContext.getExternalFilesDir(null);
+            if (base == null) base = applicationContext.getFilesDir();
+        }
+        if (base == null) base = Environment.getExternalStorageDirectory();
+        return new File(base, TUI_FOLDER);
     }
 
     public static double eval(final String str) {


### PR DESCRIPTION
The app got past the splash-screen hang fixed in #40, then crashed outright. The reporter's device log shows the real sequence:

```
MediaProvider: Creating or writing to a non-default top level directory is not allowed!
...
FATAL EXCEPTION: Thread-4
java.lang.NullPointerException: Attempt to read from field 'java.lang.String ... XMLPrefsEntry.value'
on a null object reference in method '... AppsManager$AppsHolder$SuggestedAppMgr.<init>'
```

## Root cause

`Tuils.getTuiFolder()` resolved the app's config/prefs directory as `Environment.getExternalStorageDirectory() + "t-ui"` — a *new* top-level directory in shared storage. Scoped storage refuses to create one regardless of permission grant, on every API level this app can run on (targetSdk 37): `mkdir()` silently fails, `getFolder()` retries for its bounded 1s and gives up, and every one of the **19 call sites** that depend on it gets null.

Most reads go through `XMLPrefsManager.get()`, which catches that and falls back to a default — that's the flood of caught `NullPointerException`s logged under the `"andre"` tag through `MainManager`'s construction in the log, all harmless on their own. `XMLPrefsManager.loadCommons()` compounded it: it latched `commonsLoaded = true` *before* confirming the folder resolved, so a single failure disabled preference loading for the rest of the process's life instead of retrying.

One read doesn't go through that fallback. `AppsManager`'s suggested-app list reads an `XMLPrefsList` entry directly and dereferences it with no null check, on a background thread with no catch above it — so it wasn't a handled default, it was an **uncaught** NPE, and Android kills the whole process for an uncaught exception on *any* thread, not just main. That's what `FATAL EXCEPTION: Thread-4` plus the immediately following `InputDispatcher: channel ... is unrecoverably broken` is: the process dying while the terminal screen was still visible.

## Fix, in the order it matters

1. **`Tuils.getTuiFolder()`** now resolves to the app's own external files directory (falling back to internal storage, then to the old behavior as a last resort) instead of a bare top-level shared-storage path. No permission required, not subject to the top-level restriction, still reachable with a file manager under `Android/data/`. This is the actual fix; the other two are cheap correctness fixes surfaced by tracing it.
2. **`XMLPrefsManager.loadCommons()`** only latches `commonsLoaded` after the folder resolves, so a transient failure gets retried by the next caller instead of disabling preferences for good.
3. **`AppsManager`'s suggested-app read** now treats a missing entry the way every other preference read already does — falls back to `Apps.NULL` instead of dereferencing null. This is in addition to (1), not instead of it: it's the one unguarded read in an otherwise-defended system, and it's what actually killed the process in the device log, so it felt worth closing given the evidence in hand rather than leaving it as the only crash-capable path.

`Tuils.init(applicationContext)` is called from `TerminalActivity.onCreate`, before `Tuils.getFolder()` is reachable from anything (`loadCommons` or any manager `MainManager` constructs).

## Verification

- Compiles (Kotlin + Java)
- `assembleFdroidDebug` succeeds
- Existing unit tests pass

I can't exercise the actual scoped-storage rejection without an emulator or the reporter's device — please confirm on-device that the app now gets past this point.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdfiMKAr36j4PKVBwA9RX4)_

## Summary by Sourcery

Resolve the app’s configuration storage to an app-scoped directory to prevent scoped-storage crashes and harden preference loading and suggested-app handling against missing data.

Bug Fixes:
- Prevent a fatal crash during suggested-app list construction by handling missing XML preference entries and falling back to a default value.
- Avoid disabling preference loading when the configuration folder is temporarily unavailable by only marking commons as loaded after successful resolution.
- Ensure the t-ui configuration folder is created in the app’s own external/internal storage instead of a prohibited top-level shared-storage path, avoiding scoped-storage rejection and null folder returns.

Enhancements:
- Initialize Tuils with the application context at TerminalActivity startup so storage paths are resolved consistently and without leaking Activity context.