### PR TITLE
Bind background-constructed Handlers to the main Looper

### DIFF
--- a/app/src/main/java/com/hereliesaz/hg2gui/managers/MessagesManager.java
+++ b/app/src/main/java/com/hereliesaz/hg2gui/managers/MessagesManager.java
@@ -3,6 +3,7 @@ package com.hereliesaz.hg2gui.managers;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.os.Handler;
+import android.os.Looper;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -39,7 +40,11 @@ public class MessagesManager {
     boolean tutorialMode;
 
     final int delay = 100;
-    Handler handler = new Handler();
+    // MainManager (which constructs this, when Behavior.show_hints — on by default — is set)
+    // now builds on a background dispatcher with no Looper, so a plain `new Handler()` throws
+    // instead of picking one implicitly. Bind explicitly to main, matching what happened
+    // implicitly when everything used to construct on the main thread.
+    Handler handler = new Handler(Looper.getMainLooper());
     Runnable post = this::tryPrint;
 
     public MessagesManager(Context context) {

--- a/app/src/main/java/com/hereliesaz/hg2gui/managers/RssManager.java
+++ b/app/src/main/java/com/hereliesaz/hg2gui/managers/RssManager.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.graphics.Color;
 import android.net.ConnectivityManager;
 import android.os.Handler;
+import android.os.Looper;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import android.text.TextUtils;
 
@@ -143,7 +144,13 @@ public class RssManager implements XMLPrefsElement {
 
         values = new XMLPrefsList();
 
-        handler = new Handler();
+        // A plain `new Handler()` binds to whatever thread constructs this instance. That used
+        // to always be the main thread; now MainManager (and therefore this) is built on a
+        // background dispatcher with no Looper, and the no-arg constructor throws instead of
+        // silently picking one. Binding explicitly to the main Looper restores the original
+        // behavior — callbacks posted here always land on the main thread — regardless of
+        // which thread does the constructing.
+        handler = new Handler(Looper.getMainLooper());
         refresh();
     }
 

--- a/app/src/main/java/com/hereliesaz/hg2gui/managers/TuiLocationManager.java
+++ b/app/src/main/java/com/hereliesaz/hg2gui/managers/TuiLocationManager.java
@@ -144,7 +144,10 @@ public class TuiLocationManager {
             Tuils.toFile(e);
         }
 
-        handler = new Handler();
+        // Built-in commands (including this one, via the `location` command) run on
+        // Dispatchers.IO — a thread pool with no Looper. A plain `new Handler()` needs one,
+        // same failure as the requestLocationUpdates call three lines up worked around already.
+        handler = new Handler(Looper.getMainLooper());
         handler.postDelayed(new Runnable() {
             @Override
             public void run() {


### PR DESCRIPTION
Regression from the splash-screen fix (#40): moving `MainManager`'s construction off the main thread broke every `new Handler()` inside it, which used to work by accident — the no-arg constructor binds to whatever thread constructs it, and that used to always be the main thread. It isn't anymore. From the reporter's device log:

```
RuntimeException: Can't create handler inside thread
[DefaultDispatcher-worker-2,5,main] that has not called Looper.prepare()
    at android.os.Handler.<init>
    at RssManager.<init>(RssManager.java:146)
    at MainManager.<init>(MainManager.java:227)
    at TerminalActivity$onCreate$...(TerminalActivity.kt:75)
```

Uncaught, on the same background dispatcher — same failure mode as #41, process killed outright.

## Scope

`RssManager` was the one that actually crashed. Two more are constructed from the same chain and would have crashed the same way on the very next launch or the first use of a core command:

- **`MessagesManager`**, built by `MainManager` whenever `Behavior.show_hints` is set — which **defaults to true**, so this was the very next crash after fixing `RssManager`, not a hypothetical.
- **`TuiLocationManager`**, built lazily by the `location` command. Built-in commands run via `TerminalEngine.run()`'s `Dispatchers.IO`, another Looper-less pool — same bug, different trigger. Its constructor already binds a nearby `LocationManager` call to `Looper.getMainLooper()` to sidestep the same problem; the `Handler` three lines below it just wasn't given the same treatment.

## Fix

Same in all three: bind explicitly with `new Handler(Looper.getMainLooper())` instead of the no-arg constructor. That's the codebase's own established idiom for "run on the main thread regardless of caller" — restores the original behavior (callbacks always land on main) rather than just silencing the crash, and doesn't depend on which thread happens to construct the manager.

## What I checked and ruled out

Swept the rest of the construction chain (`MainManager` and everything it builds) for the same pattern — no other `new Handler()` or `AsyncTask` usage reachable from it. `libsuperuser`'s `Shell.Interactive` has the same no-arg `Handler` call but already guards it behind `Looper.myLooper() != null`, so it degrades instead of crashing.

## Verification

- Compiles (Kotlin + Java)
- `assembleFdroidDebug` succeeds
- Existing unit tests pass

Same caveat as #41: I can't reproduce a Looper-less background dispatcher crash on this environment — please confirm on-device.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdfiMKAr36j4PKVBwA9RX4)_

## Summary by Sourcery

Bind manager handlers explicitly to the main looper to restore main-thread callback behavior when managers are constructed off the main thread.

Bug Fixes:
- Prevent crashes when RssManager, MessagesManager, and TuiLocationManager are constructed on background threads without a Looper by binding their Handlers to Looper.getMainLooper().

Enhancements:
- Clarify handler threading behavior with inline comments documenting the main-looper binding and its rationale.