### PR TITLE
Move command line below the pill tree; speed up pill animations 3x with linear easing

### DIFF
--- a/app/src/main/java/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
+++ b/app/src/main/java/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
@@ -56,6 +56,16 @@ fun TerminalScreen(
             modifier = Modifier.padding(start = 20.dp, top = 10.dp)
         )
 
+        Eyebrow("01 — Command tree")
+
+        // The pill tree is the input method, so it gets the middle of the screen; the command
+        // line and quick keys anchor to the bottom, under it, where a thumb actually reaches.
+        PillMenu(
+            roots = tree,
+            modifier = Modifier.weight(1f).padding(horizontal = 20.dp, vertical = 12.dp),
+            onRun = { tokens = it }
+        )
+
         CommandLine(
             tokens = tokens,
             hint = when {
@@ -88,14 +98,6 @@ fun TerminalScreen(
         output?.let { OutputTile(it) { output = null } }
 
         ModifierKeys()
-
-        Eyebrow("01 — Command tree")
-
-        PillMenu(
-            roots = tree,
-            modifier = Modifier.weight(1f).padding(horizontal = 20.dp, vertical = 12.dp),
-            onRun = { tokens = it }
-        )
     }
 }
 

--- a/app/src/main/java/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/app/src/main/java/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -1,7 +1,6 @@
 package com.hereliesaz.hg2gui.ui.menu
 
 import androidx.compose.animation.core.Animatable
-import androidx.compose.animation.core.CubicBezierEasing
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.keyframes
 import androidx.compose.animation.core.tween
@@ -64,12 +63,10 @@ object Azphalt {
     /** Hue is assigned by hashing the identifier — it carries no meaning. */
     fun hueOf(id: String) = (id.hashCode().let { if (it < 0) -it else it }) % hues.size
 
-    val Unfold = CubicBezierEasing(0f, 0.9f, 0.1f, 1f)   // slide + drop
-    val Swing = CubicBezierEasing(0.3f, 0.05f, 0.2f, 1f) // the turn
-
-    const val SLIDE_MS = 420
-    const val DROP_MS = 420
-    const val SWING_MS = 520
+    // Three times as fast, linear throughout — no eased curves.
+    const val SLIDE_MS = 420 / 3
+    const val DROP_MS = 420 / 3
+    const val SWING_MS = 520 / 3
     const val LIFT_FRACTION = 0.90f   // the lift happens in the last 10%
 }
 
@@ -186,8 +183,8 @@ private fun StackPill(
     LaunchedEffect(leaving, entering) {
         if (entering) offset.animateTo(
             0f,
-            tween(Azphalt.SLIDE_MS, delayMillis = index * 70, easing = Azphalt.Swing)
-        ) else offset.animateTo(target, tween(Azphalt.SLIDE_MS, easing = Azphalt.Swing))
+            tween(Azphalt.SLIDE_MS, delayMillis = index * 70, easing = LinearEasing)
+        ) else offset.animateTo(target, tween(Azphalt.SLIDE_MS, easing = LinearEasing))
     }
 
     Pill(
@@ -210,7 +207,7 @@ private fun StackPill(
 private fun HostPill(node: MenuNode, rowsBelow: Int, onClick: () -> Unit) {
     val drop = remember { Animatable(-(ROW_PITCH.value * rowsBelow)) }
     LaunchedEffect(node.id) {
-        drop.animateTo(0f, tween(Azphalt.DROP_MS, easing = Azphalt.Unfold))
+        drop.animateTo(0f, tween(Azphalt.DROP_MS, easing = LinearEasing))
     }
     Box(Modifier.fillMaxSize()) {
         Pill(
@@ -252,7 +249,7 @@ private fun ChildChain(
                 launch {
                     turn.animateTo(0f, keyframes {
                         durationMillis = Azphalt.SWING_MS
-                        (if (i % 2 == 0) -360f else 360f) at 0 using Azphalt.Swing
+                        (if (i % 2 == 0) -360f else 360f) at 0 using LinearEasing
                         (if (i % 2 == 0) -36f else 36f) at (Azphalt.SWING_MS * 0.9f).toInt() using LinearEasing
                         0f at Azphalt.SWING_MS
                     })
@@ -261,7 +258,7 @@ private fun ChildChain(
                     // holds its predecessor's row, then rises exactly one row at the tail
                     lift.animateTo(-pitchPx * i, keyframes {
                         durationMillis = Azphalt.SWING_MS
-                        (-pitchPx * (i - 1).coerceAtLeast(0)) at (Azphalt.SWING_MS * 0.9f).toInt()
+                        (-pitchPx * (i - 1).coerceAtLeast(0)) at (Azphalt.SWING_MS * 0.9f).toInt() using LinearEasing
                     })
                 }
             }


### PR DESCRIPTION
First installment of a larger set of requested changes (full-screen/font-size settings, a settings screen, verifying commands work end-to-end, and switching the default shell are still in progress in this session — this PR is just the layout/motion piece, since it's a complete, independently-verifiable unit).

## Layout: command line + quick keys move below the pill tree

`CommandLine` (the input pill + RUN) and `ModifierKeys` (CTRL/ALT/ESC/TAB/↑/↓) now render after `PillMenu` in the `Column`, not before it.

`PillMenu` still takes the weighted remaining space and bottom-aligns its own rows within that space — so the visible effect is: the animated pill tree owns the middle of the screen, and the command line + quick keys anchor at the very bottom, directly under it, where they're reachable one-handed. Previously the pill tree was squeezed into whatever space was left after three top-anchored control rows, which is what pinned it against the bottom of the screen (and the nav bar, per the reporter's screenshot) to begin with.

## Animation: 3x faster, linear throughout

- `SLIDE_MS`/`DROP_MS`: 420ms → 140ms
- `SWING_MS`: 520ms → ~173ms

`Azphalt.Unfold` and `Azphalt.Swing` (the two `CubicBezierEasing` curves driving the slide/drop and the turn) are removed outright rather than left unused. Every `tween` and keyframe segment that referenced them now uses `LinearEasing` explicitly — including the keyframe segments that had no `using` clause at all (Compose already defaults those to linear, but removing the custom easings made it worth stating rather than relying on the implicit default).

## Verification

- Compiles
- Existing unit tests pass

This is a visual/motion change with no test coverage of its own — it needs to be seen on a device to confirm the feel, not just the arithmetic.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RdfiMKAr36j4PKVBwA9RX4)_

## Summary by Sourcery

Rework the terminal screen layout to position the command line and quick keys below the pill tree, and speed up pill animations with simplified linear timing.

Enhancements:
- Move CommandLine and ModifierKeys below the pill tree so the animated menu occupies the middle of the screen and controls anchor at the bottom for better reachability.
- Increase pill slide, drop, and swing animation speed by roughly 3x and standardize all related animations to linear easing for a snappier, more consistent feel.