### PR TITLE
Fix missing PendingIntent mutability flags

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/music/MusicService.java
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/music/MusicService.java
@@ -160,7 +160,7 @@ public class MusicService extends Service implements
 
     public static Notification buildNotification(Context context, String songTitle) {
         Intent notIntent = new Intent(context, TerminalActivity.class);
-        PendingIntent pendInt = PendingIntent.getActivity(context, 0, notIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        PendingIntent pendInt = PendingIntent.getActivity(context, 0, notIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
         Notification not;
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context);
@@ -181,7 +181,7 @@ public class MusicService extends Service implements
             i.putExtra(MainManager.MUSIC_SERVICE, true);
 
             NotificationCompat.Action action = new NotificationCompat.Action.Builder(R.mipmap.ic_launcher, label,
-                    PendingIntent.getBroadcast(context.getApplicationContext(), 10, i, PendingIntent.FLAG_UPDATE_CURRENT))
+                    PendingIntent.getBroadcast(context.getApplicationContext(), 10, i, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE))
                     .addRemoteInput(remoteInput)
                     .build();
 

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/notifications/KeeperService.java
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/notifications/KeeperService.java
@@ -156,7 +156,7 @@ public class KeeperService extends Service {
                     c,
                     0,
                     startMain,
-                    PendingIntent.FLAG_CANCEL_CURRENT
+                    PendingIntent.FLAG_CANCEL_CURRENT | PendingIntent.FLAG_IMMUTABLE
             );
         } else if(clickCmd != null && clickCmd.length() > 0) {
             Intent cmdIntent = new Intent(PublicIOReceiver.ACTION_CMD);
@@ -166,7 +166,7 @@ public class KeeperService extends Service {
                     c,
                     0,
                     cmdIntent,
-                    0
+                    PendingIntent.FLAG_IMMUTABLE
             );
         } else {
             pendingIntent = null;
@@ -223,7 +223,7 @@ public class KeeperService extends Service {
             NotificationCompat.Action.Builder actionBuilder = new NotificationCompat.Action.Builder(
                     R.mipmap.ic_launcher,
                     cmdLabel,
-                    PendingIntent.getBroadcast(c.getApplicationContext(), 40, i, PendingIntent.FLAG_UPDATE_CURRENT))
+                    PendingIntent.getBroadcast(c.getApplicationContext(), 40, i, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE))
                         .addRemoteInput(remoteInput);
 
             builder.addAction(actionBuilder.build());


### PR DESCRIPTION
## Summary

`lintVitalPlaystoreRelease` was failing the release build:

```
KeeperService.java:159: Error: Missing PendingIntent mutability flag [UnspecifiedImmutableFlag]
KeeperService.java:169: Error: Missing PendingIntent mutability flag [UnspecifiedImmutableFlag]
```

Apps targeting Android 12+ must specify `FLAG_IMMUTABLE` or `FLAG_MUTABLE` on every `PendingIntent`, or construction throws `IllegalArgumentException` at runtime — this isn't just a lint nag, it's a real crash on API 31+. minSdk is 24, well above the API-23 floor for `FLAG_IMMUTABLE`, so no version guard is needed.

While fixing the two lint-flagged sites in `KeeperService.java`, I found three more call sites with the identical gap that lint hadn't flagged yet (`MusicService.java` ×2, and one more in `KeeperService.java`'s `RemoteInput` reply action). Fixed all five for consistency and to avoid the same failure resurfacing lint-run-by-lint-run. None of these need the receiver to fill in or alter the `Intent`, so `FLAG_IMMUTABLE` is correct throughout — including the two `RemoteInput` ones, since Android delivers the typed reply as extras on the received `Intent` without requiring a mutable `PendingIntent`.

## Test plan
- [x] `:composeApp:lintVitalPlaystoreRelease` — passes clean (previously failed with 2 fatal errors)
- [x] `:composeApp:compilePlaystoreDebugKotlinAndroid` / `compilePlaystoreDebugJavaWithJavac` — compile clean
- [ ] Manual verification in a running app (not available in this environment — no emulator/device)


---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Bug Fixes:
- Specify FLAG_IMMUTABLE on PendingIntents in KeeperService and MusicService notifications to avoid IllegalArgumentException on Android 12+ when constructing PendingIntents without mutability flags.