### PR TITLE
Add sandboxed virtual filesystem with a graphical Files explorer

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -1,5 +1,6 @@
 package com.hereliesaz.hg2gui
 
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -22,6 +23,8 @@ import androidx.compose.ui.Modifier
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.hereliesaz.hg2gui.commands.BaseCommandGroup
+import com.hereliesaz.hg2gui.commands.tuixt.TuixtActivity
+import com.hereliesaz.hg2gui.managers.VfsManager
 import com.hereliesaz.hg2gui.managers.xml.XMLPrefsManager
 import com.hereliesaz.hg2gui.managers.xml.options.Ui
 import com.hereliesaz.hg2gui.terminal.TerminalEngine
@@ -31,6 +34,8 @@ import com.hereliesaz.hg2gui.ui.HG2GuiTheme
 import com.hereliesaz.hg2gui.ui.SessionUiState
 import com.hereliesaz.hg2gui.ui.SettingsScreen
 import com.hereliesaz.hg2gui.ui.TerminalScreen
+import com.hereliesaz.hg2gui.ui.files.FilesScreen
+import com.hereliesaz.hg2gui.ui.files.VfsEntry
 import com.hereliesaz.hg2gui.ui.guide.CommandGuideScreen
 import com.hereliesaz.hg2gui.ui.menu.CommandTree
 import com.hereliesaz.hg2gui.ui.menu.MenuNode
@@ -47,7 +52,7 @@ class TerminalActivity : ComponentActivity(), Reloadable {
     private var sessions by mutableStateOf(listOf<TerminalSession>())
     private var nextSessionNumber = 2
 
-    private enum class Screen { Terminal, Settings, Guide }
+    private enum class Screen { Terminal, Settings, Guide, Files }
 
     private data class InitResult(
         val main: MainManager,
@@ -69,7 +74,21 @@ class TerminalActivity : ComponentActivity(), Reloadable {
             var screen by remember { mutableStateOf(Screen.Terminal) }
             var fullscreen by remember { mutableStateOf(false) }
             var fontScalePercent by remember { mutableStateOf(100) }
+            var filesPath by remember { mutableStateOf("/") }
+            var filesEntries by remember { mutableStateOf(listOf<VfsEntry>()) }
             val scope = rememberCoroutineScope()
+
+            fun refreshFiles() {
+                scope.launch {
+                    val result = withContext(Dispatchers.IO) {
+                        VfsManager.currentPath() to VfsManager.list(this@TerminalActivity).map { f ->
+                            VfsEntry(f.name, f.isDirectory, if (f.isFile) f.length() else 0L)
+                        }
+                    }
+                    filesPath = result.first
+                    filesEntries = result.second
+                }
+            }
 
             LaunchedEffect(Unit) {
                 val built = withContext(Dispatchers.Default) {
@@ -130,6 +149,49 @@ class TerminalActivity : ComponentActivity(), Reloadable {
                         modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars)
                     )
 
+                    screen == Screen.Files -> FilesScreen(
+                        path = filesPath,
+                        entries = filesEntries,
+                        onNavigate = { target ->
+                            scope.launch {
+                                withContext(Dispatchers.IO) { VfsManager.cd(this@TerminalActivity, target) }
+                                refreshFiles()
+                            }
+                        },
+                        onOpenFile = { name ->
+                            scope.launch {
+                                val file = withContext(Dispatchers.IO) {
+                                    VfsManager.resolve(this@TerminalActivity, name)
+                                }
+                                if (file != null) {
+                                    val intent = Intent(this@TerminalActivity, TuixtActivity::class.java)
+                                    intent.putExtra(TuixtActivity.PATH, file.absolutePath)
+                                    startActivity(intent)
+                                }
+                            }
+                        },
+                        onCreateFolder = { name ->
+                            scope.launch {
+                                withContext(Dispatchers.IO) { VfsManager.mkdir(this@TerminalActivity, name) }
+                                refreshFiles()
+                            }
+                        },
+                        onCreateFile = { name ->
+                            scope.launch {
+                                withContext(Dispatchers.IO) { VfsManager.touch(this@TerminalActivity, name) }
+                                refreshFiles()
+                            }
+                        },
+                        onDelete = { name ->
+                            scope.launch {
+                                withContext(Dispatchers.IO) { VfsManager.delete(this@TerminalActivity, name) }
+                                refreshFiles()
+                            }
+                        },
+                        onBack = { screen = Screen.Terminal },
+                        modifier = Modifier.windowInsetsPadding(WindowInsets.systemBars)
+                    )
+
                     sessions.isNotEmpty() && currentTree != null -> TerminalScreen(
                         tree = currentTree,
                         sessions = sessions.map { it.ui },
@@ -167,6 +229,10 @@ class TerminalActivity : ComponentActivity(), Reloadable {
                         fullscreen = fullscreen,
                         onOpenSettings = { screen = Screen.Settings },
                         onOpenGuide = { screen = Screen.Guide },
+                        onOpenFiles = {
+                            refreshFiles()
+                            screen = Screen.Files
+                        },
                         onRun = { sessionId, line, onOutput ->
                             val session = sessions.first { it.ui.id == sessionId }
                             session.engine.run(line).collect { output -> onOutput(output) }

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/commands/main/raw/vfs.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/commands/main/raw/vfs.kt
@@ -1,0 +1,89 @@
+package com.hereliesaz.hg2gui.commands.main.raw
+
+import com.hereliesaz.hg2gui.commands.CommandAbstraction
+import com.hereliesaz.hg2gui.commands.ExecutePack
+import com.hereliesaz.hg2gui.commands.main.MainPack
+import com.hereliesaz.hg2gui.managers.VfsManager
+import com.hereliesaz.hg2gui.tuils.libsuperuser.Shell
+
+/**
+ * Command-line access to the sandboxed [VfsManager] filesystem. Deliberately namespaced under
+ * `vfs` rather than shadowing `ls`/`cd`/`cat`/etc. directly: those verbs are already offered as
+ * real-shell pills (see CommandTree's SHELL list) and users typing them expect real device
+ * files, not a sandbox. `vfs mount` is the one operation that reaches outside the sandbox, and
+ * only when root is available.
+ */
+class vfs : CommandAbstraction {
+
+    override fun exec(pack: ExecutePack): String? {
+        val info = pack as MainPack
+        val args = pack.args
+        val sub = (args?.getOrNull(0) as? String)?.lowercase() ?: return USAGE
+        val rest = args.drop(1).map { it as? String ?: "" }
+        val context = info.androidContext
+
+        return when (sub) {
+            "ls" -> {
+                val entries = VfsManager.list(context)
+                if (entries.isEmpty()) "(empty)"
+                else entries.joinToString("\n") { if (it.isDirectory) it.name + "/" else it.name }
+            }
+            "pwd" -> VfsManager.currentPath()
+            "cd" -> {
+                val name = rest.getOrNull(0) ?: return "Usage: vfs cd <dir>"
+                if (VfsManager.cd(context, name)) VfsManager.currentPath() else "No such directory: $name"
+            }
+            "mkdir" -> {
+                val name = rest.getOrNull(0) ?: return "Usage: vfs mkdir <name>"
+                if (VfsManager.mkdir(context, name)) "Created $name" else "Could not create $name"
+            }
+            "touch" -> {
+                val name = rest.getOrNull(0) ?: return "Usage: vfs touch <name>"
+                if (VfsManager.touch(context, name)) "Created $name" else "Could not create $name"
+            }
+            "cat" -> {
+                val name = rest.getOrNull(0) ?: return "Usage: vfs cat <name>"
+                VfsManager.readText(context, name) ?: "No such file: $name"
+            }
+            "rm" -> {
+                val name = rest.getOrNull(0) ?: return "Usage: vfs rm <name>"
+                if (VfsManager.delete(context, name)) "Removed $name" else "Could not remove $name"
+            }
+            "mv" -> {
+                if (rest.size < 2) return "Usage: vfs mv <from> <to>"
+                if (VfsManager.move(context, rest[0], rest[1])) "Moved ${rest[0]} -> ${rest[1]}" else "Could not move"
+            }
+            "cp" -> {
+                if (rest.size < 2) return "Usage: vfs cp <from> <to>"
+                if (VfsManager.copy(context, rest[0], rest[1])) "Copied ${rest[0]} -> ${rest[1]}" else "Could not copy"
+            }
+            "mount" -> mount(context, rest.getOrNull(0))
+            else -> USAGE
+        }
+    }
+
+    private fun mount(context: android.content.Context, target: String?): String {
+        if (!Shell.SU.available()) {
+            return "Root not available — vfs mount requires a rooted device (su)."
+        }
+        if (target == null) return "Usage: vfs mount <real-path>"
+        val root = VfsManager.init(context)
+        val result = Shell.SU.run("mkdir -p '$target' && mount --bind '${root.absolutePath}' '$target'")
+        return if (result != null) "Mounted ${root.absolutePath} at $target"
+        else "Mount failed — check that su granted access and the target path is valid."
+    }
+
+    override fun argType(): IntArray = intArrayOf(CommandAbstraction.PLAIN_TEXT)
+
+    override fun priority(): Int = 3
+
+    override fun helpRes(): Int = 0
+
+    override fun onArgNotFound(pack: ExecutePack, indexNotFound: Int): String? = null
+
+    override fun onNotArgEnough(pack: ExecutePack, nArgs: Int): String? = USAGE
+
+    companion object {
+        private const val USAGE = "Usage: vfs <ls|cd|pwd|mkdir|touch|cat|rm|mv|cp|mount> [args]"
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/VfsManager.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/VfsManager.kt
@@ -1,0 +1,113 @@
+package com.hereliesaz.hg2gui.managers
+
+import android.content.Context
+import java.io.File
+
+/**
+ * A sandboxed filesystem rooted at the app's private storage, so `mkdir`/`touch`/editing
+ * never touches real Android storage unless explicitly mounted (see `vfs mount`, which
+ * requires root). Confined by construction: every path resolves through [resolve], which
+ * refuses anything that canonicalizes outside the root.
+ *
+ * Global and shared across the whole app rather than per-session — this is the same "one
+ * Files app" model a phone's real file manager uses, not a per-terminal-tab concept.
+ */
+object VfsManager {
+    private var root: File? = null
+    private var relativePath: String = ""
+
+    fun init(context: Context): File {
+        val existing = root
+        if (existing != null) return existing
+        val created = File(context.filesDir, "vfs").apply { mkdirs() }
+        root = created
+        return created
+    }
+
+    /** The directory currently open in the explorer / used by relative `vfs` commands. */
+    fun currentDir(context: Context): File {
+        val r = init(context)
+        val dir = File(r, relativePath)
+        return if (dir.isDirectory) dir else r
+    }
+
+    fun currentPath(): String = if (relativePath.isEmpty()) "/" else "/$relativePath"
+
+    /** Resolves [path] against the root (absolute) or the current directory (relative). Returns
+     *  null if it would escape the sandbox root. */
+    fun resolve(context: Context, path: String): File? {
+        val r = init(context)
+        val base = if (path.startsWith("/")) r else currentDir(context)
+        val candidate = File(base, path.removePrefix("/")).canonicalFile
+        val rootCanonical = r.canonicalFile
+        return if (candidate == rootCanonical || candidate.path.startsWith(rootCanonical.path + File.separator)) {
+            candidate
+        } else {
+            null
+        }
+    }
+
+    fun list(context: Context): List<File> =
+        currentDir(context).listFiles()
+            ?.sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
+            ?: emptyList()
+
+    fun cd(context: Context, name: String): Boolean {
+        val r = init(context)
+        val target = if (name == "..") currentDir(context).parentFile else resolve(context, name)
+        if (target == null || !target.isDirectory) return false
+        val targetCanonical = target.canonicalFile
+        val rootCanonical = r.canonicalFile
+        if (targetCanonical != rootCanonical && !targetCanonical.path.startsWith(rootCanonical.path + File.separator)) {
+            return false
+        }
+        relativePath = targetCanonical.path.removePrefix(rootCanonical.path).trim(File.separatorChar)
+        return true
+    }
+
+    fun cdInto(context: Context, absoluteDir: File): Boolean {
+        val r = init(context)
+        val rootCanonical = r.canonicalFile
+        val targetCanonical = absoluteDir.canonicalFile
+        if (!targetCanonical.isDirectory) return false
+        if (targetCanonical != rootCanonical && !targetCanonical.path.startsWith(rootCanonical.path + File.separator)) {
+            return false
+        }
+        relativePath = targetCanonical.path.removePrefix(rootCanonical.path).trim(File.separatorChar)
+        return true
+    }
+
+    fun mkdir(context: Context, name: String): Boolean = resolve(context, name)?.mkdirs() ?: false
+
+    fun touch(context: Context, name: String): Boolean {
+        val f = resolve(context, name) ?: return false
+        return f.exists() || f.createNewFile()
+    }
+
+    fun readText(context: Context, name: String): String? =
+        resolve(context, name)?.takeIf { it.isFile }?.readText()
+
+    fun writeText(context: Context, name: String, text: String): Boolean {
+        val f = resolve(context, name) ?: return false
+        f.writeText(text)
+        return true
+    }
+
+    fun delete(context: Context, name: String): Boolean = resolve(context, name)?.deleteRecursively() ?: false
+
+    fun move(context: Context, from: String, to: String): Boolean {
+        val f = resolve(context, from) ?: return false
+        val t = resolve(context, to) ?: return false
+        return f.renameTo(t)
+    }
+
+    fun copy(context: Context, from: String, to: String): Boolean {
+        val f = resolve(context, from) ?: return false
+        val t = resolve(context, to) ?: return false
+        return try {
+            if (f.isDirectory) f.copyRecursively(t, overwrite = true) else { f.copyTo(t, overwrite = true); true }
+        } catch (e: Exception) {
+            false
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
@@ -48,6 +48,7 @@ fun TerminalScreen(
     fullscreen: Boolean,
     onOpenSettings: () -> Unit,
     onOpenGuide: () -> Unit,
+    onOpenFiles: () -> Unit,
     onRun: suspend (sessionId: String, line: String, onOutput: (String) -> Unit) -> Unit
 ) {
     val active = sessions.first { it.id == activeSessionId }
@@ -135,6 +136,7 @@ fun TerminalScreen(
             activeId = activeSessionId,
             onOpenSettings = onOpenSettings,
             onOpenGuide = { showGuide = true },
+            onOpenFiles = onOpenFiles,
             onPick = onSessionPick,
             onNew = onNewSession,
             onClose = onCloseSession
@@ -281,6 +283,7 @@ private fun SessionTabs(
     activeId: String,
     onOpenSettings: () -> Unit,
     onOpenGuide: () -> Unit,
+    onOpenFiles: () -> Unit,
     onPick: (String) -> Unit,
     onNew: () -> Unit,
     onClose: (String) -> Unit
@@ -347,13 +350,26 @@ private fun SessionTabs(
                 .size(22.dp)
                 .clip(RoundedCornerShape(percent = 50))
                 .background(Azphalt.Ink.copy(alpha = .14f))
+                .clickable(onClick = onOpenFiles),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                "F",
+                style = MaterialTheme.typography.titleMedium.copy(color = Azphalt.Ink, fontSize = 11.sp, fontWeight = FontWeight.Black)
+            )
+        }
+        Box(
+            Modifier
+                .size(22.dp)
+                .clip(RoundedCornerShape(percent = 50))
+                .background(Azphalt.Ink.copy(alpha = .14f))
                 .clickable(onClick = onOpenSettings),
             contentAlignment = Alignment.Center
-        ) { 
+        ) {
             Text(
-                "⚙", 
+                "⚙",
                 style = MaterialTheme.typography.titleMedium.copy(color = Azphalt.Ink, fontSize = 12.sp)
-            ) 
+            )
         }
         Box(
             Modifier

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FilesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FilesScreen.kt
@@ -1,0 +1,262 @@
+package com.hereliesaz.hg2gui.ui.files
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.hg2gui.ui.menu.Azphalt
+
+/*
+ * The graphical file explorer over VfsManager's sandbox. Same page, same capsule primitive,
+ * same "no icons, no borders, no shadows" rules as the rest of Azphalt — folders read as
+ * folders because of a trailing "/" and a hue, not a glyph. Drill-down is breadcrumb-based
+ * rather than nested indentation, so depth never grows the screen the way PillMenu's cascade
+ * never does either.
+ */
+
+private val PageYellow = Brush.linearGradient(
+    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
+)
+
+data class VfsEntry(val name: String, val isDirectory: Boolean, val sizeBytes: Long)
+
+@Composable
+fun FilesScreen(
+    path: String,
+    entries: List<VfsEntry>,
+    onNavigate: (String) -> Unit,
+    onOpenFile: (String) -> Unit,
+    onCreateFolder: (String) -> Unit,
+    onCreateFile: (String) -> Unit,
+    onDelete: (String) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var creating by remember(path) { mutableStateOf<CreateMode?>(null) }
+    var nameInput by remember(path) { mutableStateOf("") }
+
+    Column(modifier.fillMaxSize().background(PageYellow)) {
+        Row(
+            Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                "FILES",
+                style = MaterialTheme.typography.titleMedium.copy(color = Azphalt.Ink, fontSize = 14.sp)
+            )
+            Text(
+                "CLOSE",
+                style = MaterialTheme.typography.labelSmall.copy(color = Azphalt.Ink.copy(alpha = .6f), fontSize = 9.sp),
+                modifier = Modifier.clickable(onClick = onBack)
+            )
+        }
+
+        Breadcrumbs(path = path, onNavigate = onNavigate)
+
+        if (creating != null) {
+            CreatePrompt(
+                mode = creating!!,
+                name = nameInput,
+                onNameChange = { nameInput = it },
+                onConfirm = {
+                    if (nameInput.isNotBlank()) {
+                        when (creating) {
+                            CreateMode.FOLDER -> onCreateFolder(nameInput.trim())
+                            CreateMode.FILE -> onCreateFile(nameInput.trim())
+                            null -> {}
+                        }
+                    }
+                    creating = null
+                    nameInput = ""
+                },
+                onCancel = { creating = null; nameInput = "" }
+            )
+        }
+
+        if (entries.isEmpty()) {
+            Text(
+                "EMPTY",
+                style = MaterialTheme.typography.labelSmall.copy(color = Azphalt.Ink.copy(alpha = .4f), fontSize = 10.sp),
+                modifier = Modifier.padding(start = 20.dp, top = 20.dp)
+            )
+        }
+
+        LazyColumn(
+            modifier = Modifier.weight(1f).fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            items(entries) { entry ->
+                EntryRow(
+                    entry = entry,
+                    onClick = { if (entry.isDirectory) onNavigate(entry.name) else onOpenFile(entry.name) },
+                    onDelete = { onDelete(entry.name) }
+                )
+            }
+        }
+
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            ActionPill("+ FOLDER") { creating = CreateMode.FOLDER; nameInput = "" }
+            ActionPill("+ FILE") { creating = CreateMode.FILE; nameInput = "" }
+        }
+    }
+}
+
+private enum class CreateMode { FOLDER, FILE }
+
+@Composable
+private fun Breadcrumbs(path: String, onNavigate: (String) -> Unit) {
+    val segments = path.trim('/').split('/').filter { it.isNotEmpty() }
+    Row(
+        Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(start = 20.dp, top = 10.dp),
+        horizontalArrangement = Arrangement.spacedBy(4.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        BreadcrumbLabel("/", segments.isEmpty()) { onNavigate("/") }
+        var acc = ""
+        segments.forEach { seg ->
+            acc += "/$seg"
+            val target = acc
+            Text(
+                "/",
+                style = MaterialTheme.typography.labelSmall.copy(color = Azphalt.Ink.copy(alpha = .35f), fontSize = 10.sp)
+            )
+            BreadcrumbLabel(seg, target == "/${segments.joinToString("/")}") { onNavigate(target) }
+        }
+    }
+}
+
+@Composable
+private fun BreadcrumbLabel(text: String, current: Boolean, onClick: () -> Unit) {
+    Text(
+        text.uppercase(),
+        style = MaterialTheme.typography.labelSmall.copy(
+            color = if (current) Azphalt.Ink else Azphalt.Ink.copy(alpha = .5f),
+            fontSize = 10.sp,
+            fontWeight = if (current) FontWeight.Black else FontWeight.Normal
+        ),
+        modifier = Modifier.clickable(onClick = onClick)
+    )
+}
+
+@Composable
+private fun EntryRow(entry: VfsEntry, onClick: () -> Unit, onDelete: () -> Unit) {
+    val hue = if (entry.isDirectory) Azphalt.hues[Azphalt.hueOf(entry.name)] else Azphalt.Ink.copy(alpha = .14f)
+    val fg = if (entry.isDirectory) Azphalt.White else Azphalt.Ink
+
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(percent = 50))
+            .background(hue)
+            .clickable(onClick = onClick)
+            .padding(start = 16.dp, end = 10.dp, top = 10.dp, bottom = 10.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            (entry.name + if (entry.isDirectory) "/" else "").uppercase(),
+            style = MaterialTheme.typography.titleMedium.copy(
+                color = fg,
+                fontSize = 11.sp,
+                fontWeight = FontWeight.ExtraBold,
+                letterSpacing = 0.09.em
+            ),
+            maxLines = 1
+        )
+        Text(
+            "×",
+            style = MaterialTheme.typography.titleMedium.copy(color = fg.copy(alpha = .7f), fontSize = 13.sp),
+            modifier = Modifier.clickable(onClick = onDelete).padding(start = 8.dp)
+        )
+    }
+}
+
+@Composable
+private fun ActionPill(label: String, onClick: () -> Unit) {
+    Row(
+        Modifier
+            .clip(RoundedCornerShape(percent = 50))
+            .background(Azphalt.Ink.copy(alpha = .14f))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 14.dp, vertical = 8.dp)
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.titleMedium.copy(
+                color = Azphalt.Ink,
+                fontSize = 9.sp,
+                letterSpacing = 0.06.em
+            )
+        )
+    }
+}
+
+@Composable
+private fun CreatePrompt(
+    mode: CreateMode,
+    name: String,
+    onNameChange: (String) -> Unit,
+    onConfirm: () -> Unit,
+    onCancel: () -> Unit
+) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 20.dp, vertical = 8.dp)
+            .heightIn(min = 32.dp)
+            .clip(RoundedCornerShape(percent = 50))
+            .background(Azphalt.Ink)
+            .padding(start = 14.dp, end = 6.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(6.dp)
+    ) {
+        Text(
+            if (mode == CreateMode.FOLDER) "NEW FOLDER" else "NEW FILE",
+            style = MaterialTheme.typography.labelSmall.copy(color = Azphalt.Yellow.copy(alpha = .7f), fontSize = 8.sp)
+        )
+        BasicTextField(
+            value = name,
+            onValueChange = onNameChange,
+            modifier = Modifier.weight(1f),
+            textStyle = MaterialTheme.typography.bodyMedium.copy(color = Azphalt.Yellow, fontSize = 12.sp),
+            cursorBrush = SolidColor(Azphalt.Yellow),
+            singleLine = true
+        )
+        Text(
+            "OK",
+            style = MaterialTheme.typography.titleMedium.copy(color = Azphalt.Yellow, fontSize = 10.sp),
+            modifier = Modifier.clickable(onClick = onConfirm).padding(horizontal = 8.dp, vertical = 6.dp)
+        )
+        Text(
+            "X",
+            style = MaterialTheme.typography.titleMedium.copy(color = Azphalt.Yellow.copy(alpha = .6f), fontSize = 10.sp),
+            modifier = Modifier.clickable(onClick = onCancel).padding(horizontal = 8.dp, vertical = 6.dp)
+        )
+    }
+}

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -57,16 +57,19 @@ Compose. There is no `UIManager`; a screen is a function of state.
 *   **root**: `TerminalActivity` (Kotlin), plus `GuideActivity`, `PanicActivity` — feature
     screens reached by command, never by icon.
 *   **`ui/`**: Compose UI and the pill menu.
+    *   `ui/files/FilesScreen.kt`: the graphical explorer over `VfsManager`'s sandbox.
 *   **`managers/`**: Logic for specific domains.
     *   `AppsManager`: launching installed apps (as a command, not a drawer).
-    *   `FileManager`: file system operations.
+    *   `FileManager`: file system operations against real Android storage.
+    *   `VfsManager`: a second, sandboxed file layer rooted at `filesDir/vfs` — real files, but
+        confined to the app's private storage and never touched by the real shell.
     *   `TerminalManager`: core terminal state — scrollback, history, sessions.
     *   `SystemContext`: OS/environment emulation.
 *   **`commands/`**: The command pattern.
     *   `CommandAbstraction`: interface for all commands.
     *   `CommandRepository`: index of available commands — also the source of the menu tree.
-    *   `main/`: core system commands.
-    *   `tuixt/`: the built-in text editor.
+    *   `main/`: core system commands, including `vfs` (the command-line face of `VfsManager`).
+    *   `tuixt/`: the built-in text editor — also how `FilesScreen` opens a file.
 *   **`tuils/`**: Utilities.
 
 ## Data Flow

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -26,9 +26,25 @@ the menu *is* the interface. Every command, subcommand and argument is a pill yo
         entry per session: that would reintroduce the multi-task/launcher-lifecycle
         complexity Phase 1 deliberately dropped, for a benefit real terminal apps (Termux
         included) don't bother with either.
--   [ ] **Virtual Filesystem:** A persistent virtual filesystem so users can `mkdir`, `touch`
-        and edit files without cluttering real Android storage, unless they explicitly mount
-        it.
+-   [x] **Virtual Filesystem:** A sandbox rooted at the app's private storage (`VfsManager`,
+        `filesDir/vfs`) — real files, but invisible to every other app and cleared on
+        uninstall. Reached two ways: the **Files** screen (graphical, tree-style, Azphalt
+        capsules — no icons, folders read by a trailing `/` and a hue) for browsing/creating/
+        deleting, and the `vfs` command (`vfs mkdir`, `vfs ls`, `vfs cat`, …) for the same
+        operations from the command line.
+
+        This does **not** virtualize the real shell. `ls`, `cat`, `rm` and friends still run
+        for real against real storage — `TerminalEngine` only intercepts a command whose verb
+        exactly matches an app builtin, and there is no pty/FUSE layer to intercept anything
+        else. A literal transparent VFS underneath arbitrary shell input isn't buildable on a
+        non-rooted phone, which is why the sandbox is namespaced under `vfs` rather than
+        shadowing `ls`/`cd`/`cat` — those verbs are already offered as real-shell pills, and
+        shadowing them would have silently broken that.
+
+        "Mount" is real, not simulated, but conditional: `vfs mount <path>` bind-mounts the
+        sandbox onto a real path with `su`, and only runs when root is available
+        (`Shell.SU.available()`, from the vendored `libsuperuser`). Without root it says so
+        plainly rather than pretending to work.
 -   [ ] **Scripting:** A custom scripting language or deeper Python integration for
         automating tasks within the terminal.
 


### PR DESCRIPTION
## Summary

Implements VISION.md Phase 2's "Virtual Filesystem" item: a persistent sandbox so `mkdir`/`touch`/editing don't clutter real Android storage unless explicitly mounted.

**`VfsManager`** (new) roots a real filesystem at the app's private storage (`filesDir/vfs`) — real `java.io.File`s, but invisible to every other app and cleared on uninstall. Every path resolves through a confinement check that refuses to canonicalize outside the root.

**Two ways in, sharing the same sandbox and current directory:**
- **Files screen** (new, commonMain, Azphalt-styled): breadcrumb-based drill-down (no unbounded nesting — same "height never grows with depth" rule as PillMenu), capsule pills per entry, no icons — folders read by a trailing `/` and a hue. Reached via a new "F" control next to Settings/Guide. Opening a file launches the existing `tuixt` editor on it.
- **`vfs` command-line builtin**: `vfs ls|cd|pwd|mkdir|touch|cat|rm|mv|cp|mount`.

**Why `vfs` is namespaced instead of shadowing `ls`/`cd`/`cat`/etc. directly:** those verbs are already offered as real-shell pills in `CommandTree`'s `SHELL` list, and `TerminalEngine` dispatches purely by exact builtin-name match — shadowing them would silently redirect users typing `ls`/`cat` away from real files with no indication anything changed. More fundamentally: a *literal* transparent VFS underneath arbitrary shell input isn't buildable here at all — there's no pty/FUSE layer, commands not matching a builtin stream straight into a real `/system/bin/sh` process with zero interception point, and Android's non-rooted sandbox rules out building one. `vfs` as a distinct namespace is the honest boundary: what's virtualized vs. what still hits real storage is explicit, not implied.

**`vfs mount <path>`** is real, not simulated, but conditional: it bind-mounts the sandbox onto a real path using the already-vendored `libsuperuser`'s `Shell.SU`, and only runs when `Shell.SU.available()` is true. Without root it says so plainly rather than pretending to work.

## Test plan
- [x] `:composeApp:compilePlaystoreDebugKotlinAndroid` / `compilePlaystoreDebugJavaWithJavac` — compile clean
- [x] `:composeApp:lintVitalPlaystoreRelease` — passes clean
- [x] `:composeApp:testPlaystoreDebugUnitTest` — no new failures; the 7 pre-existing `ShellSessionTest` failures reproduce identically on unmodified `master` (sandbox `/system/bin/sh` echo behavior, unrelated to this change)
- [ ] Manual verification in a running app, including `vfs mount` on an actual rooted device (not available in this environment — no emulator/device, no root)


---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Add a sandboxed virtual filesystem with both a graphical Files explorer and a `vfs` CLI command, integrating it into the terminal UI and documenting its behavior and constraints.

New Features:
- Introduce a sandboxed virtual filesystem rooted in app-private storage via VfsManager, shared across sessions.
- Add a graphical Files screen for browsing, creating, opening, and deleting entries in the virtual filesystem, integrated with the existing Tuixt editor.
- Expose a namespaced `vfs` command-line builtin for managing the virtual filesystem and optionally bind-mounting it onto real paths on rooted devices.

Enhancements:
- Extend the terminal UI with a new Files control and screen state to switch between terminal, settings, guide, and the new file explorer.
- Document the virtual filesystem design and integration points in VISION and ARCHITECTURE, including how it interacts with the shell and commands.