### PR TITLE
Fix StackOverflowError crashing the app on launch

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/RssManager.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/RssManager.kt
@@ -53,6 +53,7 @@ class RssManager(private val context: Context, private val client: OkHttpClient)
     private val feeds: MutableList<Rss> = ArrayList()
     private val formats: MutableList<XMLPrefsManager.IdValue> = ArrayList()
     private val cmdRegexes: MutableList<CmdableRegex> = ArrayList()
+    private val values: XMLPrefsList = XMLPrefsList()
 
     private var hideTagPatterns: Array<Pattern>? = null
     private var urlPattern: Pattern? = null
@@ -808,7 +809,6 @@ class RssManager(private val context: Context, private val client: OkHttpClient)
         private const val LINK_CHILD = "link"
         private const val HREF_ATTRIBUTE = "href"
 
-        val values = XMLPrefsList()
         const val PATH = "rss.xml"
         const val NAME = "RSS"
         @JvmField


### PR DESCRIPTION
## Summary

**This is the fix for the "app immediately force-closed on open" report** — a pre-existing crash, unrelated to today's other PRs (#86/#87/#88). Priority: high, it's a P0 for anyone with the app installed.

Root cause, confirmed from a pasted `logcat` stack trace (thousands of identical recursive frames):

```
E/andre: at com.hereliesaz.hg2gui.managers.RssManager.getValues(RssManager.kt:75)
E/andre: at com.hereliesaz.hg2gui.managers.RssManager.getValues(RssManager.kt:75)
... (repeated to StackOverflowError)
```

`RssManager.kt:76` (`override fun getValues(): XMLPrefsList = values`) never had a `values` field declared on the class. Since `XMLPrefsElement.getValues()` is a Java-style getter, Kotlin resolved the bare `values` identifier to the *synthetic property view of `getValues()` itself* — the usual sugar that lets Kotlin call a Java getter without parens — rather than any real field, because none existed in the class's own scope. So `getValues()` called itself, unconditionally, every time.

`RssManager`'s constructor calls `refresh()` eagerly, which hits `values.add(...)` on a background thread during `MainManager`'s init — i.e. on **every app launch**, before anything is interactive. That's the fatal `StackOverflowError` matching the report exactly.

There was already a companion-object `val values = XMLPrefsList()` sitting in the file — apparently an earlier attempt at this exact fix — but companion members don't take priority over the synthetic getter-derived property in Kotlin's resolution order, so it never actually worked, and nothing referenced it externally (confirmed via search). Replaced it with a real instance field, which does take priority — matching the pattern the other two Kotlin `XMLPrefsElement` implementers (`AppsManager`, `XMLPrefsManager.XMLPrefsRoot`) already use correctly, just under differently-named fields (`prefsList`, `pValues`) that happened to dodge this trap.

## Test plan
- [x] `:composeApp:compilePlaystoreDebugKotlinAndroid` — compiles clean
- [x] `:composeApp:testPlaystoreDebugUnitTest` — no new failures; the 7 pre-existing `ShellSessionTest` failures reproduce identically on unmodified `master` (sandbox `/system/bin/sh` echo behavior, unrelated)
- [x] Grepped every other `XMLPrefsElement` implementer for the same self-recursive `getX(): T = x` pattern — none found; `RssManager` was the only one bitten by it
- [ ] Manual on-device verification that the app now launches without crashing (not available in this environment — no emulator/device). **Recommend testing this before/alongside merging**, given the severity.


---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Bug Fixes:
- Prevent StackOverflowError on app launch by backing RssManager.getValues() with an instance XMLPrefsList instead of an implicit self-recursive property.