### PR TITLE
Fix release-play workflow looking for the bundle under the wrong module

### DIFF
--- a/.github/workflows/release-play.yml
+++ b/.github/workflows/release-play.yml
@@ -240,7 +240,7 @@ jobs:
       - name: Verify the bundle is signed by the expected key
         run: |
           set -euo pipefail
-          aab=$(find app/build/outputs/bundle/release -name "*.aab" | head -n1)
+          aab=$(find composeApp/build/outputs/bundle/release -name "*.aab" | head -n1)
           [ -n "$aab" ] || { echo "::error::No .aab was produced."; exit 1; }
           echo "AAB_PATH=$aab" >> "$GITHUB_ENV"
 
@@ -287,7 +287,7 @@ jobs:
         with:
           name: quicloc-release-aab-${{ env.VERSION_NAME }}
           path: |
-            app/build/outputs/bundle/release/*.aab
+            composeApp/build/outputs/bundle/release/*.aab
             version.properties
           if-no-files-found: error
 


### PR DESCRIPTION
## Summary

Fixes the CI failure:

```
find: ‘app/build/outputs/bundle/release’: No such file or directory
Error: Process completed with exit code 1.
```

`.github/workflows/release-play.yml` runs `./gradlew bundleRelease`, which correctly builds `composeApp`'s bundle — it's the only Android application module. But the very next step searched `app/build/outputs/bundle/release` for the produced `.aab`. There is no `:app` module — `settings.gradle.kts` only declares `:composeApp`, `:terminal-emulator`, and `:termux-shared` — so the build succeeds but the `find` always comes up empty, failing the "Verify the bundle is signed by the expected key" step right after a successful, signed build.

Unrelated to #85 (missing `KEYSTORE_RAW` secret) — this bug is downstream of signing succeeding, a stale `app/` path left over from a rename to `composeApp` that was never updated in this workflow. Grepped the rest of `.github/` for the same pattern; both occurrences were in this one file.

## Changes
- `find app/build/outputs/bundle/release` → `find composeApp/build/outputs/bundle/release`
- Upload-artifact `path:` glob updated to match

## Test plan
- [x] YAML re-parses cleanly (`yaml.safe_load`)
- [x] Confirmed via `settings.gradle.kts` that `composeApp` is the correct (and only) application module
- [x] Grepped `.github/` for any other stray `app/build`/`app/outputs`/`:app:` references — none found
- [ ] Full workflow run through Play upload (needs the `KEYSTORE_RAW` secret from #85 restored first, plus real repo secrets — not runnable from this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Bug Fixes:
- Fix Play release workflow failing to locate the generated .aab bundle by pointing find and artifact upload paths to the composeApp module output.