### PR TITLE
Fix PillMenu: the stacking animation wasn't what stacked the pills

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -90,14 +90,12 @@ fun PillMenu(
         when (val p = phase) {
             is Phase.Browsing, is Phase.Leaving -> {
                 val leavingHost = (p as? Phase.Leaving)?.hostId
-                Column(
-                    Modifier.fillMaxSize().padding(bottom = 12.dp),
-                    verticalArrangement = Arrangement.spacedBy(3.dp, Alignment.Bottom)
-                ) {
+                Box(Modifier.fillMaxSize().padding(bottom = 12.dp)) {
                     roots.forEachIndexed { i, node ->
                         StackPill(
                             node = node,
                             index = i,
+                            row = roots.size - 1 - i,
                             leaving = leavingHost != null,
                             isHost = node.id == leavingHost,
                             entering = leavingHost == null,
@@ -148,6 +146,7 @@ fun PillMenu(
 private fun StackPill(
     node: MenuNode,
     index: Int,
+    row: Int,
     leaving: Boolean,
     isHost: Boolean,
     entering: Boolean,
@@ -167,18 +166,35 @@ private fun StackPill(
         ) else offset.animateTo(target, tween(Azphalt.SLIDE_MS, easing = LinearEasing))
     }
 
-    Pill(
-        label = node.label,
-        cap = node.cap,
-        hue = Azphalt.hueOf(node.id),
-        selected = leaving && isHost,
-        modifier = Modifier
-            .fillMaxWidth(0.66f)
-            .offsetByFractionOfParent(offset.value)
-            .padding(start = 0.dp)
-            .absoluteBleed(OVERHANG)
-            .clickable(enabled = !leaving, onClick = onClick)
-    )
+    // The row this pill rests on is reached the same way HostPill reaches its own row: a single
+    // Animatable driving translationY, nothing else places it there. It starts one pitch below
+    // its resting row so entering the stack is what puts it on that row, not a side effect of it
+    // already being there.
+    val density = LocalDensity.current
+    val pitchPx = with(density) { ROW_PITCH.toPx() }
+    val lift = remember { Animatable(-pitchPx * (row - 1)) }
+    LaunchedEffect(entering) {
+        if (entering) lift.animateTo(
+            -pitchPx * row,
+            tween(Azphalt.SLIDE_MS, delayMillis = index * 70, easing = LinearEasing)
+        )
+    }
+
+    Box(Modifier.fillMaxSize()) {
+        Pill(
+            label = node.label,
+            cap = node.cap,
+            hue = Azphalt.hueOf(node.id),
+            selected = leaving && isHost,
+            modifier = Modifier
+                .align(Alignment.BottomStart)
+                .fillMaxWidth(0.66f)
+                .offsetByFractionOfParent(offset.value)
+                .absoluteBleed(OVERHANG)
+                .graphicsLayer { translationY = lift.value }
+                .clickable(enabled = !leaving, onClick = onClick)
+        )
+    }
 }
 
 @Composable
@@ -291,10 +307,7 @@ private fun ChildPill(
             })
         }
         launch {
-            lift.animateTo(-pitchPx * absoluteRow, keyframes {
-                durationMillis = Azphalt.SWING_MS
-                (-pitchPx * predecessorRow) at (Azphalt.SWING_MS * 0.9f).toInt() using LinearEasing
-            })
+            lift.animateTo(-pitchPx * absoluteRow, tween(Azphalt.SWING_MS, easing = LinearEasing))
         }
     }
 


### PR DESCRIPTION
## Summary

Fixes the pill-menu entrance animation looking broken/glitchy — pills appearing to already be in their final stacked positions with occasional visible tearing, instead of a visible build-up.

**Root cause 1 — `StackPill` (root MAIN/category list):** placed by a real Compose `Column` with `Arrangement.spacedBy(3.dp, Alignment.Bottom)`. That Column places every pill in its final row the instant it composes — the stack already exists, fully formed, before any animation runs. The only thing `StackPill` itself animated was a horizontal `offsetByFractionOfParent` slide, unrelated to row placement. So the "stacking" animation was decorative, riding on top of a layout the Column had already finished.

**Root cause 2 — `ChildPill` (the command-tree cascade, e.g. `SHELL` → `PING`/`GETPROP`/`UNAME`/…):** here there's no Column — position comes solely from a `lift` Animatable via `graphicsLayer.translationY`, which is structurally correct. But its `keyframes` block set the 90%-mark to the *same value* as its start, so `lift` sat motionless for 90% of `SWING_MS` (~155ms) and then covered the entire vertical distance in the last 10% (~17ms) — reading as "already there, then a glitch/tear" rather than a rise into place. `turn` (the rotation) doesn't have this bug — its 90%-mark differs from its start — which is why only the vertical motion looked broken.

## Fix

`HostPill` already has the correct shape for this: a single `Animatable` driving `translationY`, animated with a plain `tween`, and nothing else determines its position.

- Ported that pattern to `StackPill`: dropped the `Column` for a `Box`, and each pill's row now comes from its own `lift` Animatable (starting one row short of its resting spot, tweening up to it) — the same way `HostPill` already works.
- `ChildPill`'s `lift` now uses the same plain `tween` instead of the broken `keyframes` block.

No behavior change to the horizontal slide/leave transitions, tap targets, or `turn`'s rotation flourish — only how each pill's row position is reached.

## Test plan
- [x] `:composeApp:compilePlaystoreDebugKotlinAndroid` — compiles clean
- [ ] Manual on-device check that the root stack and command-tree cascade now visibly build up pill-by-pill instead of popping in (not available in this environment — no emulator/device)


---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Fix the root and child pill entrance animations so pills visibly stack into place instead of appearing in their final positions.

Bug Fixes:
- Correct StackPill layout so its vertical row position is driven by an Animatable lift animation rather than a static Column layout.
- Fix ChildPill vertical lift animation by replacing the broken keyframe sequence with a smooth tween for translationY.

Enhancements:
- Align StackPill’s vertical entrance animation with the existing HostPill pattern using a single Animatable and Box-based layout.