### PR TITLE
Restore the shared-origin cascade the pill stack used before recursion

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -167,12 +167,12 @@ private fun StackPill(
     }
 
     // The row this pill rests on is reached the same way HostPill reaches its own row: a single
-    // Animatable driving translationY, nothing else places it there. It starts one pitch below
-    // its resting row so entering the stack is what puts it on that row, not a side effect of it
-    // already being there.
+    // Animatable driving translationY, nothing else places it there. Every pill starts from the
+    // same shared origin - row 0, the bottom of the stack - and rises to its own row, so it reads
+    // as pills flying up into a stack rather than each one nudging up off the pill below it.
     val density = LocalDensity.current
     val pitchPx = with(density) { ROW_PITCH.toPx() }
-    val lift = remember { Animatable(-pitchPx * (row - 1)) }
+    val lift = remember { Animatable(0f) }
     LaunchedEffect(entering) {
         if (entering) lift.animateTo(
             -pitchPx * row,
@@ -288,12 +288,13 @@ private fun ChildPill(
     val pitchPx = with(density) { ROW_PITCH.toPx() }
 
     val absoluteRow = baseRow + localIndex
-    // The row this pill sits behind until its own turn: the anchor's row for the first child
-    // of a band, otherwise the row the pill immediately before it lands on.
-    val predecessorRow = baseRow + (localIndex - 1).coerceAtLeast(0)
 
     val turn = remember(node.id) { Animatable(if (localIndex % 2 == 0) -360f else 360f) }
-    val lift = remember(node.id) { Animatable(-pitchPx * predecessorRow) }
+    // Every pill in a band rises from the same place: the anchor's own row, exactly where
+    // HostPill (or the parent pill that opened this band) already rests. That shared origin is
+    // what makes it read as pills flying up out of the anchor into a stack, rather than each one
+    // nudging up off the pill before it.
+    val lift = remember(node.id) { Animatable(-pitchPx * baseRow) }
     val leaveOffset = remember(node.id) { Animatable(0f) }
 
     LaunchedEffect(node.id) {
@@ -307,7 +308,10 @@ private fun ChildPill(
             })
         }
         launch {
-            lift.animateTo(-pitchPx * absoluteRow, tween(Azphalt.SWING_MS, easing = LinearEasing))
+            lift.animateTo(-pitchPx * absoluteRow, keyframes {
+                durationMillis = Azphalt.SWING_MS
+                (-pitchPx * (absoluteRow - 1).coerceAtLeast(baseRow)) at (Azphalt.SWING_MS * 0.9f).toInt() using LinearEasing
+            })
         }
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #91, which didn't actually fix the pill-stack animation — it corrected *how* `lift` interpolates but left *where it starts from* unchanged, and that turned out to be the real problem.

Comparing against `af02081` (the version before `d78a97d`, "Make the child cascade recurse at every depth"): every pill in a band used to start from a **shared origin** — the host's own row (`Animatable(0f)`, row 0) — and rise up to its own row from there, so farther pills travelled farther and it genuinely read as pills flying up out of the host into a stack.

The recursion refactor changed that start to the immediate *predecessor's* row instead, which shrinks every pill's actual travel to a single row-pitch (~20dp) regardless of its position in the stack. That's such a small motion that no amount of easing/timing fixes makes it read as a cascade — it's closer to a barely-visible relay than a stack building up. #91's tween fix was correct as far as it went (the old keyframes block genuinely was broken, sitting still for 90% of its window), but it didn't touch this, so the visible result was practically unchanged.

## Fix
- `ChildPill`: restored the shared-origin start (`-pitchPx * baseRow`, the anchor pill's own row), generalized with `baseRow` so it still works at every recursion depth (`baseRow` was implicitly `0` in the old flat version). Restored the keyframes shape that pairing depends on — most of the multi-row journey in the first 90% of the window, the final increment in the last 10% — since that motion profile only makes sense relative to a shared, farther-away start.
- `StackPill`: applied the same shared-origin principle to its entrance (row 0), which #91 had given a predecessor-relative start by the same mistake.

## Test plan
- [x] `:composeApp:compilePlaystoreDebugKotlinAndroid` — compiles clean
- [ ] Manual on-device check that the stack now visibly cascades up from the host/bottom row instead of each pill barely nudging into place (not available in this environment — no emulator/device)


---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Restore shared-origin vertical animation for stack and child pills so the menu stack visually cascades from the host/bottom row.

Enhancements:
- Update StackPill to animate from a shared bottom-row origin to its target row for clearer stack entrance motion.
- Update ChildPill to animate from the anchor/base row using a restored keyframe profile that emphasizes the multi-row travel before settling.