### PR TITLE
Fix Settings screen ignoring safe-area insets

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/SettingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/SettingsScreen.kt
@@ -34,7 +34,12 @@ fun SettingsScreen(
     onFontScalePercentChange: (Int) -> Unit,
     onBack: () -> Unit
 ) {
-    Column(Modifier.fillMaxSize().background(PageYellow)) {
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(PageYellow)
+            .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
+    ) {
         Row(
             Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp),
             verticalAlignment = Alignment.CenterVertically


### PR DESCRIPTION
## Summary

In Safe Area (non-fullscreen) mode, the Settings screen's content — starting with the `‹ BACK` button — sat under the status bar, uncleared of the system bars.

`SettingsScreen` already receives a `fullscreen: Boolean` parameter, but never used it for layout — its root `Column` had no inset padding at all, fullscreen or not. `TerminalScreen` already does this correctly:

```kotlin
Modifier.then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
```

Ported that same conditional to `SettingsScreen`'s root `Column` — when not fullscreen, content is pushed clear of both the status bar (top) and navigation bar (bottom); when fullscreen, no padding, matching the existing behavior everywhere else in the app.

## Test plan
- [x] `:composeApp:compilePlaystoreDebugKotlinAndroid` — compiles clean
- [ ] Manual on-device check that Settings content clears both bars in Safe Area mode (not available in this environment — no emulator/device)


---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Bug Fixes:
- Ensure Settings screen content is offset by system bar insets in non-fullscreen (safe area) mode to avoid overlapping the status bar and navigation bar.