### PR TITLE
GPLv3 license, plus the redesigned File Manager and Guide reader

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
 
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    HG2Gui, a touch-driven Termux terminal for Android
+    Copyright (C) 2026  HereLiesAz
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    HG2Gui  Copyright (C) 2026  HereLiesAz
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,12 @@ Inspired by the *Hitchhiker's Guide to the Galaxy* (2005) aesthetic and built on
 *   **Sessions.** Named terminal sessions, each with its own scrollback and working directory.
 *   **Aliases.** Native shell aliases plus `ShellAliases.kt`'s own suggestion pills — no
     duplicate alias system layered on top of the real shell's.
+*   **A real file manager.** Search, sort, multi-select batch actions, in-place rename, an
+    automatic media grid, and a storage-by-type breakdown over the `vfs` sandbox — folders are
+    capsules that expand in place, siblings squishing into thin coloured rods beside them.
+*   **The Guide.** A chaptered glossary of real commands paired with invented, Hitchhiker's-
+    Guide-style definitions, reachable from the command picker — reading material, not another
+    way to run something.
 
 ## Interface
 
@@ -60,7 +66,10 @@ reflection-discovered plugin system.
     *   `util/CalculationEngine.kt` — the expression parser behind `calc`.
     *   `ui/` — Compose UI. `TerminalScreen.kt` (the terminal), `SessionUiState.kt` (per-session
         state, including the pending-prompt hand-off for interactive commands), `ui/editor/` (the
-        `edit` command's text editor screen), `ui/files/` (the `vfs` sandbox's file browser).
+        `edit` command's text editor screen), `ui/files/` (the `vfs` sandbox's file manager —
+        `FilesScreen.kt`'s nested-accordion browser, `FolderPicker.kt`'s tile/rod/panel Move/Copy
+        destination picker, `StorageScreen.kt`), `ui/guide/` (`CommandGuideScreen.kt`'s command
+        picker, nesting `GuideReaderScreen.kt` and its content in `GuideContent.kt`).
     *   `ui/menu/PillMenu.kt` — the suggestion tree and its choreography. `MenuNode` supports
         lazily-resolved children (`resolveChildren`) for live data, like a directory listing.
 *   `composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/`

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.core.content.FileProvider
 import androidx.core.content.edit
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
@@ -31,13 +32,17 @@ import com.hereliesaz.hg2gui.managers.VfsManager
 import com.hereliesaz.hg2gui.terminal.Builtins
 import com.hereliesaz.hg2gui.terminal.DistroManager
 import com.hereliesaz.hg2gui.terminal.TerminalEngine
+import com.hereliesaz.hg2gui.util.GenericFileProvider
 import com.hereliesaz.hg2gui.util.Utils
 import com.hereliesaz.hg2gui.ui.HG2GuiTheme
 import com.hereliesaz.hg2gui.ui.SessionUiState
 import com.hereliesaz.hg2gui.ui.SettingsScreen
 import com.hereliesaz.hg2gui.ui.TerminalScreen
 import com.hereliesaz.hg2gui.ui.files.FilesScreen
+import com.hereliesaz.hg2gui.ui.files.StorageCategoryStat
+import com.hereliesaz.hg2gui.ui.files.StorageStats
 import com.hereliesaz.hg2gui.ui.files.VfsEntry
+import com.hereliesaz.hg2gui.ui.files.VfsSearchResult
 import com.hereliesaz.hg2gui.ui.guide.CommandGuideScreen
 import com.hereliesaz.hg2gui.ui.menu.CommandTree
 import com.hereliesaz.hg2gui.ui.menu.MenuNode
@@ -80,20 +85,56 @@ class TerminalActivity : ComponentActivity() {
             var screen by remember { mutableStateOf(Screen.Terminal) }
             var fullscreen by remember { mutableStateOf(false) }
             var fontScalePercent by remember { mutableStateOf(100) }
-            var filesPath by remember { mutableStateOf("/") }
-            var filesEntries by remember { mutableStateOf(listOf<VfsEntry>()) }
             val scope = rememberCoroutineScope()
 
-            fun refreshFiles() {
-                scope.launch {
-                    val result = withContext(Dispatchers.IO) {
-                        VfsManager.currentPath() to VfsManager.list(this@TerminalActivity).map { f ->
-                            VfsEntry(f.name, f.isDirectory, if (f.isFile) f.length() else 0L)
-                        }
+            suspend fun vfsListDir(path: String): List<VfsEntry> = withContext(Dispatchers.IO) {
+                val dir = VfsManager.resolve(this@TerminalActivity, path) ?: return@withContext emptyList()
+                (dir.listFiles() ?: emptyArray())
+                    .sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
+                    .map { f ->
+                        VfsEntry(
+                            name = f.name,
+                            path = VfsManager.pathOf(this@TerminalActivity, f),
+                            isDirectory = f.isDirectory,
+                            sizeBytes = if (f.isFile) f.length() else 0L,
+                            modifiedAt = f.lastModified(),
+                            isImage = f.isFile && VfsManager.isImage(f)
+                        )
                     }
-                    filesPath = result.first
-                    filesEntries = result.second
+            }
+
+            suspend fun vfsSearch(query: String): List<VfsSearchResult> = withContext(Dispatchers.IO) {
+                VfsManager.search(this@TerminalActivity, query).map { f ->
+                    VfsSearchResult(
+                        entry = VfsEntry(
+                            name = f.name,
+                            path = VfsManager.pathOf(this@TerminalActivity, f),
+                            isDirectory = f.isDirectory,
+                            sizeBytes = if (f.isFile) f.length() else 0L,
+                            modifiedAt = f.lastModified(),
+                            isImage = f.isFile && VfsManager.isImage(f)
+                        ),
+                        parentPath = VfsManager.pathOf(this@TerminalActivity, f.parentFile ?: f)
+                    )
                 }
+            }
+
+            suspend fun vfsStorageStats(): StorageStats = withContext(Dispatchers.IO) {
+                val breakdown = VfsManager.storageByType(this@TerminalActivity)
+                StorageStats(
+                    totalBytes = breakdown.totalBytes,
+                    byCategory = breakdown.byCategory.map { (category, bytes) -> StorageCategoryStat(category.label, bytes) },
+                    largest = breakdown.largestFiles.map { f ->
+                        VfsEntry(
+                            name = f.name,
+                            path = VfsManager.pathOf(this@TerminalActivity, f),
+                            isDirectory = f.isDirectory,
+                            sizeBytes = f.length(),
+                            modifiedAt = f.lastModified(),
+                            isImage = VfsManager.isImage(f)
+                        )
+                    }
+                )
             }
 
             LaunchedEffect(Unit) {
@@ -169,18 +210,14 @@ class TerminalActivity : ComponentActivity() {
                     )
 
                     screen == Screen.Files -> FilesScreen(
-                        path = filesPath,
-                        entries = filesEntries,
-                        onNavigate = { target ->
-                            scope.launch {
-                                withContext(Dispatchers.IO) { VfsManager.cd(this@TerminalActivity, target) }
-                                refreshFiles()
-                            }
-                        },
-                        onOpenFile = { name ->
+                        fullscreen = fullscreen,
+                        listDir = { path -> vfsListDir(path) },
+                        search = { query -> vfsSearch(query) },
+                        storageStats = { vfsStorageStats() },
+                        onOpenFile = { path ->
                             scope.launch {
                                 val file = withContext(Dispatchers.IO) {
-                                    VfsManager.resolve(this@TerminalActivity, name)
+                                    VfsManager.resolve(this@TerminalActivity, path)
                                 }
                                 if (file != null) {
                                     val intent = Intent(this@TerminalActivity, EditorActivity::class.java)
@@ -189,22 +226,54 @@ class TerminalActivity : ComponentActivity() {
                                 }
                             }
                         },
-                        onCreateFolder = { name ->
-                            scope.launch {
-                                withContext(Dispatchers.IO) { VfsManager.mkdir(this@TerminalActivity, name) }
-                                refreshFiles()
+                        onCreateFolder = { parentPath, name ->
+                            withContext(Dispatchers.IO) {
+                                VfsManager.resolve(this@TerminalActivity, parentPath)?.let { VfsManager.mkdir(it, name) }
                             }
                         },
-                        onCreateFile = { name ->
-                            scope.launch {
-                                withContext(Dispatchers.IO) { VfsManager.touch(this@TerminalActivity, name) }
-                                refreshFiles()
+                        onCreateFile = { parentPath, name ->
+                            withContext(Dispatchers.IO) {
+                                VfsManager.resolve(this@TerminalActivity, parentPath)?.let { VfsManager.touch(it, name) }
                             }
                         },
-                        onDelete = { name ->
+                        onDelete = { path ->
+                            withContext(Dispatchers.IO) {
+                                VfsManager.resolve(this@TerminalActivity, path)?.let { VfsManager.delete(it) }
+                            }
+                        },
+                        onRename = { path, newName ->
+                            withContext(Dispatchers.IO) {
+                                VfsManager.resolve(this@TerminalActivity, path)?.let { VfsManager.rename(it, newName) }
+                            }
+                        },
+                        onMove = { path, targetDirPath ->
+                            withContext(Dispatchers.IO) {
+                                val file = VfsManager.resolve(this@TerminalActivity, path)
+                                val target = VfsManager.resolve(this@TerminalActivity, targetDirPath)
+                                if (file != null && target != null) VfsManager.moveInto(file, target)
+                            }
+                        },
+                        onCopy = { path, targetDirPath ->
+                            withContext(Dispatchers.IO) {
+                                val file = VfsManager.resolve(this@TerminalActivity, path)
+                                val target = VfsManager.resolve(this@TerminalActivity, targetDirPath)
+                                if (file != null && target != null) VfsManager.copyInto(file, target)
+                            }
+                        },
+                        onShare = { path ->
                             scope.launch {
-                                withContext(Dispatchers.IO) { VfsManager.delete(this@TerminalActivity, name) }
-                                refreshFiles()
+                                val file = withContext(Dispatchers.IO) {
+                                    VfsManager.resolve(this@TerminalActivity, path)
+                                }
+                                if (file != null && file.isFile) {
+                                    val uri = FileProvider.getUriForFile(this@TerminalActivity, GenericFileProvider.PROVIDER_NAME, file)
+                                    val intent = Intent(Intent.ACTION_SEND).apply {
+                                        type = "*/*"
+                                        putExtra(Intent.EXTRA_STREAM, uri)
+                                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                    }
+                                    startActivity(Intent.createChooser(intent, "Share ${file.name}"))
+                                }
                             }
                         },
                         onBack = { screen = Screen.Terminal },
@@ -247,10 +316,7 @@ class TerminalActivity : ComponentActivity() {
                         fullscreen = fullscreen,
                         onOpenSettings = { screen = Screen.Settings },
                         onOpenGuide = { screen = Screen.Guide },
-                        onOpenFiles = {
-                            refreshFiles()
-                            screen = Screen.Files
-                        },
+                        onOpenFiles = { screen = Screen.Files },
                         onRun = { sessionId, line, onOutput, onNeedInput ->
                             val session = sessions.first { it.ui.id == sessionId }
                             session.engine.run(line, onNeedInput).collect { output -> onOutput(output) }

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/VfsManager.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/VfsManager.kt
@@ -33,6 +33,15 @@ object VfsManager {
 
     fun currentPath(): String = if (relativePath.isEmpty()) "/" else "/$relativePath"
 
+    /** [file]'s own path expressed relative to the sandbox root, e.g. "/Downloads/photo.png" -
+     *  the stable, platform-agnostic identifier the file-manager UI (commonMain, no `File`
+     *  access) keys everything off. */
+    fun pathOf(context: Context, file: File): String {
+        val r = init(context)
+        val relative = file.canonicalPath.removePrefix(r.canonicalPath).trim(File.separatorChar)
+        return if (relative.isEmpty()) "/" else "/$relative"
+    }
+
     /** Resolves [path] against the root (absolute) or the current directory (relative). Returns
      *  null if it would escape the sandbox root. */
     fun resolve(context: Context, path: String): File? {
@@ -109,5 +118,113 @@ object VfsManager {
         } catch (e: Exception) {
             false
         }
+    }
+
+    /** True if [file] is a real path inside the sandbox root - the safety check every File-based
+     *  operation below needs, since these bypass [resolve]'s own name-based containment check. */
+    private fun contains(file: File): Boolean {
+        val r = root ?: return false
+        val rootCanonical = r.canonicalFile
+        val fileCanonical = file.canonicalFile
+        return fileCanonical == rootCanonical || fileCanonical.path.startsWith(rootCanonical.path + File.separator)
+    }
+
+    // --- File-based operations -------------------------------------------------------------
+    // The nested-accordion browser holds real File references for whatever is expanded at each
+    // level, independent of any single "current directory" - so these work directly against a
+    // File rather than resolving a name relative to it.
+
+    fun mkdir(dir: File, name: String): Boolean = contains(dir) && File(dir, name).mkdirs()
+
+    fun touch(dir: File, name: String): Boolean {
+        if (!contains(dir)) return false
+        val f = File(dir, name)
+        return f.exists() || f.createNewFile()
+    }
+
+    fun delete(file: File): Boolean = contains(file) && file.deleteRecursively()
+
+    fun rename(file: File, newName: String): Boolean {
+        if (!contains(file)) return false
+        val parent = file.parentFile ?: return false
+        return file.renameTo(File(parent, newName))
+    }
+
+    fun moveInto(file: File, targetDir: File): Boolean {
+        if (!contains(file) || !contains(targetDir)) return false
+        return file.renameTo(File(targetDir, file.name))
+    }
+
+    fun copyInto(file: File, targetDir: File): Boolean {
+        if (!contains(file) || !contains(targetDir)) return false
+        val target = File(targetDir, file.name)
+        return try {
+            if (file.isDirectory) file.copyRecursively(target, overwrite = true) else { file.copyTo(target, overwrite = true); true }
+        } catch (e: Exception) {
+            false
+        }
+    }
+
+    /** Every file and directory under [dir] (or the whole sandbox, by default), depth-first,
+     *  directories before their own contents - the walk every recursive feature below shares. */
+    private fun walk(dir: File, into: MutableList<File>) {
+        val children = dir.listFiles()
+            ?.sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
+            ?: return
+        for (child in children) {
+            into.add(child)
+            if (child.isDirectory) walk(child, into)
+        }
+    }
+
+    /** Every name under [dir] (defaulting to the sandbox root) containing [query], case
+     *  insensitive - real recursive search, not just the one open directory. Capped at [limit]
+     *  since a query that matches broadly (a single common letter) shouldn't hang the UI walking
+     *  an unbounded tree. */
+    fun search(context: Context, query: String, dir: File = init(context), limit: Int = 200): List<File> {
+        if (query.isBlank()) return emptyList()
+        val q = query.lowercase()
+        val all = mutableListOf<File>()
+        walk(dir, all)
+        return all.filter { it.name.lowercase().contains(q) }.take(limit)
+    }
+
+    enum class StorageCategory(val label: String) {
+        IMAGES("Images"), DOCUMENTS("Documents"), CODE("Code"), ARCHIVES("Archives"), OTHER("Other")
+    }
+
+    private val IMAGE_EXT = setOf("png", "jpg", "jpeg", "gif", "webp", "bmp", "svg", "heic")
+    private val DOCUMENT_EXT = setOf("pdf", "doc", "docx", "txt", "md", "odt", "xls", "xlsx", "ppt", "pptx", "csv")
+    private val CODE_EXT = setOf("kt", "java", "py", "js", "ts", "kts", "json", "xml", "html", "css", "c", "cpp", "h", "go", "rs", "sh")
+    private val ARCHIVE_EXT = setOf("zip", "tar", "gz", "7z", "rar", "bz2", "xz")
+
+    fun isImage(file: File): Boolean = file.extension.lowercase() in IMAGE_EXT
+
+    private fun categoryOf(file: File): StorageCategory = when (file.extension.lowercase()) {
+        in IMAGE_EXT -> StorageCategory.IMAGES
+        in DOCUMENT_EXT -> StorageCategory.DOCUMENTS
+        in CODE_EXT -> StorageCategory.CODE
+        in ARCHIVE_EXT -> StorageCategory.ARCHIVES
+        else -> StorageCategory.OTHER
+    }
+
+    data class StorageBreakdown(
+        val totalBytes: Long,
+        val byCategory: Map<StorageCategory, Long>,
+        val largestFiles: List<File>
+    )
+
+    /** Recursively sizes the whole sandbox by [StorageCategory] - this is storage used inside
+     *  HG2Gui's own private sandbox, not the device's, since that's the only filesystem [vfs]
+     *  actually models; a device-wide figure would be claiming knowledge this sandbox doesn't
+     *  have. */
+    fun storageByType(context: Context): StorageBreakdown {
+        val all = mutableListOf<File>()
+        walk(init(context), all)
+        val files = all.filter { it.isFile }
+        val byCategory = files.groupingBy { categoryOf(it) }.fold(0L) { acc, f -> acc + f.length() }
+        val total = files.sumOf { it.length() }
+        val largest = files.sortedByDescending { it.length() }.take(10)
+        return StorageBreakdown(total, byCategory, largest)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FilesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FilesScreen.kt
@@ -1,20 +1,28 @@
+@file:OptIn(androidx.compose.foundation.ExperimentalFoundationApi::class)
+
 package com.hereliesaz.hg2gui.ui.files
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -27,218 +35,619 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import kotlinx.coroutines.launch
 
 /*
- * The graphical file explorer over VfsManager's sandbox. Same page, same capsule primitive,
- * same "no icons, no borders, no shadows" rules as the rest of Azphalt — folders read as
- * folders because of a trailing "/" and a hue, not a glyph. Drill-down is breadcrumb-based
- * rather than nested indentation, so depth never grows the screen the way PillMenu's cascade
- * never does either.
+ * The file manager: search, sort, multi-select batch actions, in-place rename, an automatic
+ * media grid, and a real storage-by-type breakdown, all built on Azphalt's capsule primitive.
+ * No icons: a folder is a whole rounded rectangle in its own hue; tapping one expands it while
+ * its siblings squish into thin coloured rods beside it, its children living inside it as
+ * smaller rectangles - two accordion levels deep, then a plain record of what's inside.
  */
 
 private val PageYellow = Brush.linearGradient(
     0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
 )
 
-data class VfsEntry(val name: String, val isDirectory: Boolean, val sizeBytes: Long)
+private enum class SortMode(val label: String) { NAME("Name"), NEWEST("Newest") }
+private enum class FMScreen { Browse, Search, Storage, PickMove, PickCopy }
+private enum class CreateMode { FOLDER, FILE }
 
-private fun formatFileSize(bytes: Long): String = when {
-    bytes < 1024 -> "$bytes B"
-    bytes < 1024 * 1024 -> "${bytes / 1024} KB"
-    else -> "${bytes / (1024 * 1024)} MB"
+private fun sortEntries(list: List<VfsEntry>, mode: SortMode): List<VfsEntry> = when (mode) {
+    SortMode.NAME -> list.sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
+    SortMode.NEWEST -> list.sortedWith(compareBy({ !it.isDirectory }, { -it.modifiedAt }))
 }
 
 @Composable
 fun FilesScreen(
-    path: String,
-    entries: List<VfsEntry>,
-    onNavigate: (String) -> Unit,
-    onOpenFile: (String) -> Unit,
-    onCreateFolder: (String) -> Unit,
-    onCreateFile: (String) -> Unit,
-    onDelete: (String) -> Unit,
+    fullscreen: Boolean,
+    listDir: suspend (path: String) -> List<VfsEntry>,
+    search: suspend (query: String) -> List<VfsSearchResult>,
+    storageStats: suspend () -> StorageStats,
+    onOpenFile: (path: String) -> Unit,
+    onCreateFolder: suspend (parentPath: String, name: String) -> Unit,
+    onCreateFile: suspend (parentPath: String, name: String) -> Unit,
+    onDelete: suspend (path: String) -> Unit,
+    onRename: suspend (path: String, newName: String) -> Unit,
+    onMove: suspend (path: String, targetDirPath: String) -> Unit,
+    onCopy: suspend (path: String, targetDirPath: String) -> Unit,
+    onShare: (path: String) -> Unit,
     onBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    var creating by remember(path) { mutableStateOf<CreateMode?>(null) }
-    var nameInput by remember(path) { mutableStateOf("") }
+    var screen by remember { mutableStateOf(FMScreen.Browse) }
+    var openChain by remember { mutableStateOf<List<VfsEntry>>(emptyList()) }
+    var rootEntries by remember { mutableStateOf<List<VfsEntry>>(emptyList()) }
+    var l0Entries by remember { mutableStateOf<List<VfsEntry>>(emptyList()) }
+    var recordEntries by remember { mutableStateOf<List<VfsEntry>>(emptyList()) }
+    var sortMode by remember { mutableStateOf(SortMode.NAME) }
+    var refreshTick by remember { mutableStateOf(0) }
 
-    Column(modifier.fillMaxSize().background(PageYellow)) {
+    var searchActive by remember { mutableStateOf(false) }
+    var searchQuery by remember { mutableStateOf("") }
+    var searchResults by remember { mutableStateOf<List<VfsSearchResult>>(emptyList()) }
+
+    var selectMode by remember { mutableStateOf(false) }
+    var selected by remember { mutableStateOf<Set<String>>(emptySet()) }
+
+    var renameTarget by remember { mutableStateOf<VfsEntry?>(null) }
+    var renameInput by remember { mutableStateOf("") }
+    var creating by remember { mutableStateOf<CreateMode?>(null) }
+    var createInput by remember { mutableStateOf("") }
+
+    var storage by remember { mutableStateOf<StorageStats?>(null) }
+
+    val scope = rememberCoroutineScope()
+    fun refresh() { refreshTick++ }
+
+    val currentTargetDir = openChain.lastOrNull()?.path ?: "/"
+
+    LaunchedEffect(refreshTick) { rootEntries = sortEntries(listDir("/"), sortMode) }
+    LaunchedEffect(openChain.getOrNull(0)?.path, sortMode, refreshTick) {
+        l0Entries = openChain.getOrNull(0)?.let { sortEntries(listDir(it.path), sortMode) } ?: emptyList()
+    }
+    LaunchedEffect(openChain.getOrNull(1)?.path, sortMode, refreshTick) {
+        recordEntries = openChain.getOrNull(1)?.let { sortEntries(listDir(it.path), sortMode) } ?: emptyList()
+    }
+    LaunchedEffect(searchQuery, refreshTick) {
+        searchResults = if (searchQuery.isNotBlank()) search(searchQuery) else emptyList()
+    }
+
+    fun openEntry(depth: Int, entry: VfsEntry) {
+        openChain = when (depth) {
+            0 -> if (openChain.getOrNull(0)?.path == entry.path) emptyList() else listOf(entry)
+            1 -> if (openChain.getOrNull(1)?.path == entry.path) openChain.take(1) else openChain.take(1) + entry
+            else -> listOf(openChain[1], entry) // descending past the 2-level window
+        }
+    }
+
+    fun tapEntry(depth: Int, entry: VfsEntry) {
+        if (selectMode) {
+            selected = if (entry.path in selected) selected - entry.path else selected + entry.path
+        } else if (entry.isDirectory) {
+            openEntry(depth, entry)
+        } else {
+            onOpenFile(entry.path)
+        }
+    }
+
+    if (screen == FMScreen.PickMove || screen == FMScreen.PickCopy) {
+        FolderPicker(
+            title = if (screen == FMScreen.PickMove) "Move to…" else "Copy to…",
+            listDir = listDir,
+            onCancel = { screen = FMScreen.Browse },
+            onConfirm = { target ->
+                scope.launch {
+                    val isMove = screen == FMScreen.PickMove
+                    for (path in selected) {
+                        if (isMove) onMove(path, target) else onCopy(path, target)
+                    }
+                    selected = emptySet()
+                    selectMode = false
+                    screen = FMScreen.Browse
+                    refresh()
+                }
+            },
+            modifier = modifier
+        )
+        return
+    }
+
+    if (screen == FMScreen.Storage) {
+        LaunchedEffect(Unit) { storage = storageStats() }
+        StorageScreen(
+            stats = storage,
+            onDelete = { path -> scope.launch { onDelete(path); storage = storageStats(); refresh() } },
+            onBack = { screen = FMScreen.Browse },
+            fullscreen = fullscreen,
+            modifier = modifier
+        )
+        return
+    }
+
+    Column(
+        modifier
+            .fillMaxSize()
+            .background(PageYellow)
+            .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
+    ) {
+        // --- Header ---------------------------------------------------------------------
         Row(
             Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
-            Text(
-                "FILES",
-                style = MaterialTheme.typography.titleMedium.copy(color = Azphalt.Ink, fontSize = 14.sp)
-            )
-            Text(
-                "CLOSE",
-                style = MaterialTheme.typography.labelSmall.copy(color = Azphalt.Ink.copy(alpha = .6f), fontSize = 9.sp),
-                modifier = Modifier.clickable(onClick = onBack)
-            )
+            if (selectMode) {
+                Chip("‹ ${selected.size} SELECTED", onClick = { selectMode = false; selected = emptySet() })
+            } else {
+                Chip("‹ CLOSE", onClick = onBack)
+                val count = rootEntries.size + l0Entries.size + recordEntries.size
+                Chip("$count THINGS HERE", filled = false, clickable = false)
+            }
         }
 
-        Breadcrumbs(path = path, onNavigate = onNavigate)
+        // --- Search / sort row ------------------------------------------------------------
+        if (!selectMode) {
+            Row(
+                Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 12.dp),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Row(
+                    Modifier
+                        .weight(if (searchActive) 1f else 0.001f, fill = searchActive)
+                        .clip(RoundedCornerShape(percent = 50))
+                        .background(Azphalt.Ink.copy(alpha = .10f))
+                        .clickable(enabled = !searchActive) { searchActive = true }
+                        .padding(start = 14.dp, end = 10.dp, top = 8.dp, bottom = 8.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    if (searchActive) {
+                        BasicTextField(
+                            value = searchQuery,
+                            onValueChange = { searchQuery = it; screen = FMScreen.Search },
+                            modifier = Modifier.weight(1f),
+                            textStyle = androidx.compose.ui.text.TextStyle(
+                                color = Azphalt.Ink, fontSize = 13.sp, fontWeight = FontWeight.SemiBold
+                            ),
+                            cursorBrush = SolidColor(Azphalt.Ink),
+                            singleLine = true
+                        )
+                        Text(
+                            "✕", color = Azphalt.Ink.copy(alpha = .6f), fontSize = 13.sp,
+                            modifier = Modifier.clickable {
+                                searchActive = false; searchQuery = ""; screen = FMScreen.Browse
+                            }
+                        )
+                    } else {
+                        Text(
+                            "SEARCH", color = Azphalt.Ink.copy(alpha = .55f),
+                            fontSize = 10.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.1.em
+                        )
+                    }
+                }
+                if (!searchActive) {
+                    Row(
+                        Modifier
+                            .clip(RoundedCornerShape(percent = 50))
+                            .background(Azphalt.Ink.copy(alpha = .10f))
+                            .clickable { sortMode = if (sortMode == SortMode.NAME) SortMode.NEWEST else SortMode.NAME }
+                            .padding(horizontal = 14.dp, vertical = 8.dp)
+                    ) {
+                        Text(
+                            "${sortMode.label.uppercase()} ▾", color = Azphalt.Ink.copy(alpha = .55f),
+                            fontSize = 10.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.1.em
+                        )
+                    }
+                    Row(
+                        Modifier
+                            .clip(RoundedCornerShape(percent = 50))
+                            .background(Azphalt.Ink.copy(alpha = .10f))
+                            .clickable { screen = FMScreen.Storage }
+                            .padding(horizontal = 14.dp, vertical = 8.dp)
+                    ) {
+                        Text(
+                            "STORAGE ›", color = Azphalt.Ink.copy(alpha = .55f),
+                            fontSize = 10.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.1.em
+                        )
+                    }
+                }
+            }
+        }
 
-        if (creating != null) {
-            CreatePrompt(
-                mode = creating!!,
-                name = nameInput,
-                onNameChange = { nameInput = it },
-                onConfirm = {
-                    if (nameInput.isNotBlank()) {
-                        when (creating) {
-                            CreateMode.FOLDER -> onCreateFolder(nameInput.trim())
-                            CreateMode.FILE -> onCreateFile(nameInput.trim())
-                            null -> {}
+        // --- Content ------------------------------------------------------------------------
+        if (screen == FMScreen.Search) {
+            SearchResults(
+                results = searchResults,
+                onOpen = { result ->
+                    if (result.entry.isDirectory) {
+                        // A folder from search just becomes the new deepest-open level.
+                        openChain = listOf(result.entry)
+                        searchActive = false; searchQuery = ""; screen = FMScreen.Browse
+                    } else {
+                        onOpenFile(result.entry.path)
+                    }
+                }
+            )
+        } else {
+            LazyColumn(
+                Modifier.weight(1f).fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp),
+                verticalArrangement = Arrangement.spacedBy(10.dp)
+            ) {
+                item(key = "level0") {
+                    ExpandableLevel(
+                        entries = rootEntries,
+                        openEntry = openChain.getOrNull(0),
+                        onToggle = { openEntry(0, it) },
+                        selectMode = selectMode,
+                        selected = selected,
+                        onTap = { tapEntry(0, it) },
+                        onLongPress = { selectMode = true; selected = setOf(it.path) },
+                        onRename = { renameTarget = it; renameInput = it.name },
+                        onDelete = { scope.launch { onDelete(it.path); refresh() } },
+                        onShare = { onShare(it.path) }
+                    ) {
+                        if (openChain.isNotEmpty()) {
+                            ExpandableLevel(
+                                entries = l0Entries,
+                                openEntry = openChain.getOrNull(1),
+                                onToggle = { openEntry(1, it) },
+                                selectMode = selectMode,
+                                selected = selected,
+                                onTap = { tapEntry(1, it) },
+                                onLongPress = { selectMode = true; selected = setOf(it.path) },
+                                onRename = { renameTarget = it; renameInput = it.name },
+                                onDelete = { scope.launch { onDelete(it.path); refresh() } },
+                                onShare = { onShare(it.path) }
+                            ) {
+                                if (openChain.size == 2) {
+                                    RecordList(
+                                        entries = recordEntries,
+                                        selectMode = selectMode,
+                                        selected = selected,
+                                        onTap = { tapEntry(2, it) },
+                                        onLongPress = { selectMode = true; selected = setOf(it.path) },
+                                        onRename = { renameTarget = it; renameInput = it.name },
+                                        onDelete = { scope.launch { onDelete(it.path); refresh() } },
+                                        onShare = { onShare(it.path) }
+                                    )
+                                }
+                            }
                         }
                     }
-                    creating = null
-                    nameInput = ""
+                }
+            }
+        }
+
+        if (creating != null) {
+            NamePrompt(
+                label = if (creating == CreateMode.FOLDER) "NEW FOLDER" else "NEW FILE",
+                name = createInput,
+                onNameChange = { createInput = it },
+                onConfirm = {
+                    val name = createInput.trim()
+                    if (name.isNotEmpty()) {
+                        scope.launch {
+                            when (creating) {
+                                CreateMode.FOLDER -> onCreateFolder(currentTargetDir, name)
+                                CreateMode.FILE -> onCreateFile(currentTargetDir, name)
+                                null -> {}
+                            }
+                            refresh()
+                        }
+                    }
+                    creating = null; createInput = ""
                 },
-                onCancel = { creating = null; nameInput = "" }
+                onCancel = { creating = null; createInput = "" }
             )
         }
 
-        if (entries.isEmpty()) {
-            Text(
-                "EMPTY",
-                style = MaterialTheme.typography.labelSmall.copy(color = Azphalt.Ink.copy(alpha = .4f), fontSize = 10.sp),
-                modifier = Modifier.padding(start = 20.dp, top = 20.dp)
-            )
-        }
-
-        LazyColumn(
-            modifier = Modifier.weight(1f).fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp),
-            verticalArrangement = Arrangement.spacedBy(8.dp)
-        ) {
-            items(entries) { entry ->
-                EntryRow(
-                    entry = entry,
-                    onClick = { if (entry.isDirectory) onNavigate(entry.name) else onOpenFile(entry.name) },
-                    onDelete = { onDelete(entry.name) }
+        renameTarget?.let { target ->
+            Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 8.dp)) {
+                Text(
+                    "Same capsule as creating something — renaming isn't a different tool, just a filled-in one.",
+                    color = Azphalt.Ink.copy(alpha = .5f), fontSize = 9.sp, lineHeight = 13.sp,
+                    modifier = Modifier.padding(bottom = 6.dp)
+                )
+                NamePrompt(
+                    label = "RENAME",
+                    name = renameInput,
+                    onNameChange = { renameInput = it },
+                    onConfirm = {
+                        val name = renameInput.trim()
+                        if (name.isNotEmpty()) {
+                            scope.launch { onRename(target.path, name); refresh() }
+                        }
+                        renameTarget = null
+                    },
+                    onCancel = { renameTarget = null }
                 )
             }
         }
 
+        // --- Bottom bar ---------------------------------------------------------------------
         Row(
-            Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp),
+            Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 14.dp),
             horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
-            ActionPill("+ FOLDER") { creating = CreateMode.FOLDER; nameInput = "" }
-            ActionPill("+ FILE") { creating = CreateMode.FILE; nameInput = "" }
+            if (selectMode) {
+                Chip("MOVE", onClick = { screen = FMScreen.PickMove })
+                Chip("COPY", onClick = { screen = FMScreen.PickCopy })
+                Chip("SHARE", onClick = { selected.forEach(onShare) })
+                Spacer(Modifier.weight(1f))
+                Chip("DELETE", background = Azphalt.hues[6], foreground = Azphalt.White, onClick = {
+                    scope.launch {
+                        selected.forEach { onDelete(it) }
+                        selected = emptySet(); selectMode = false; refresh()
+                    }
+                })
+            } else {
+                Chip("+ NEW FOLDER", filled = false, onClick = { creating = CreateMode.FOLDER; createInput = "" })
+                Chip("+ NEW FILE", filled = false, onClick = { creating = CreateMode.FILE; createInput = "" })
+                Spacer(Modifier.weight(1f))
+                Chip("SELECT", onClick = { selectMode = true })
+            }
         }
     }
 }
 
-private enum class CreateMode { FOLDER, FILE }
-
 @Composable
-private fun Breadcrumbs(path: String, onNavigate: (String) -> Unit) {
-    val segments = path.trim('/').split('/').filter { it.isNotEmpty() }
-    Row(
-        Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()).padding(start = 20.dp, top = 10.dp),
-        horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically
-    ) {
-        BreadcrumbLabel("/", segments.isEmpty()) { onNavigate("/") }
-        var acc = ""
-        segments.forEach { seg ->
-            acc += "/$seg"
-            val target = acc
+private fun ExpandableLevel(
+    entries: List<VfsEntry>,
+    openEntry: VfsEntry?,
+    onToggle: (VfsEntry) -> Unit,
+    selectMode: Boolean,
+    selected: Set<String>,
+    onTap: (VfsEntry) -> Unit,
+    onLongPress: (VfsEntry) -> Unit,
+    onRename: (VfsEntry) -> Unit,
+    onDelete: (VfsEntry) -> Unit,
+    onShare: (VfsEntry) -> Unit,
+    nestedContent: @Composable () -> Unit
+) {
+    val folders = entries.filter { it.isDirectory }
+    val files = entries.filter { !it.isDirectory }
+
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        if (openEntry != null) {
+            val others = folders.filter { it.path != openEntry.path }
+            if (others.isNotEmpty()) {
+                Row(
+                    Modifier.fillMaxWidth().horizontalScroll(rememberScrollState()),
+                    horizontalArrangement = Arrangement.spacedBy(4.dp)
+                ) {
+                    others.forEach { f ->
+                        key(f.path) {
+                            Box(
+                                Modifier
+                                    .width(10.dp)
+                                    .height(40.dp)
+                                    .clip(RoundedCornerShape(percent = 50))
+                                    .background(Azphalt.hues[Azphalt.hueOf(f.path)])
+                                    .clickable { onToggle(f) }
+                            )
+                        }
+                    }
+                }
+            }
+            Box(
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(18.dp))
+                    .background(if (selectMode && openEntry.path in selected) Azphalt.Ink else Azphalt.hues[Azphalt.hueOf(openEntry.path)])
+                    .clickable { onTap(openEntry) }
+                    .padding(14.dp)
+            ) {
+                Column {
+                    Row(horizontalArrangement = Arrangement.SpaceBetween, modifier = Modifier.fillMaxWidth()) {
+                        Text(
+                            openEntry.name.uppercase(), color = Azphalt.White,
+                            fontSize = 13.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.06.em
+                        )
+                        EntryMenu(openEntry, onRename, onDelete, onShare, tint = Azphalt.White)
+                    }
+                    Box(Modifier.padding(start = 14.dp, top = 10.dp)) { nestedContent() }
+                }
+            }
+        } else if (folders.isNotEmpty()) {
             Text(
-                "/",
-                style = MaterialTheme.typography.labelSmall.copy(color = Azphalt.Ink.copy(alpha = .35f), fontSize = 10.sp)
+                "FOLDERS · ${folders.size}", color = Azphalt.Ink.copy(alpha = .45f),
+                fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.18.em
             )
-            BreadcrumbLabel(seg, target == "/${segments.joinToString("/")}") { onNavigate(target) }
+            folders.forEach { f -> key(f.path) { FolderRow(f, selectMode, f.path in selected, onTap, onLongPress, onRename, onDelete, onShare) } }
+        }
+
+        if (files.isNotEmpty()) {
+            if (folders.isNotEmpty() || openEntry != null) {
+                Text(
+                    "FILES · ${files.size}", color = Azphalt.Ink.copy(alpha = .45f),
+                    fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.18.em,
+                    modifier = Modifier.padding(top = 4.dp)
+                )
+            }
+            FileRows(files, selectMode, selected, onTap, onLongPress, onRename, onDelete, onShare)
         }
     }
 }
 
 @Composable
-private fun BreadcrumbLabel(text: String, current: Boolean, onClick: () -> Unit) {
-    Text(
-        text.uppercase(),
-        style = MaterialTheme.typography.labelSmall.copy(
-            color = if (current) Azphalt.Ink else Azphalt.Ink.copy(alpha = .5f),
-            fontSize = 10.sp,
-            fontWeight = if (current) FontWeight.Black else FontWeight.Normal
-        ),
-        modifier = Modifier.clickable(onClick = onClick)
-    )
+private fun RecordList(
+    entries: List<VfsEntry>,
+    selectMode: Boolean,
+    selected: Set<String>,
+    onTap: (VfsEntry) -> Unit,
+    onLongPress: (VfsEntry) -> Unit,
+    onRename: (VfsEntry) -> Unit,
+    onDelete: (VfsEntry) -> Unit,
+    onShare: (VfsEntry) -> Unit
+) {
+    val folders = entries.filter { it.isDirectory }
+    val files = entries.filter { !it.isDirectory }
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        folders.forEach { f -> key(f.path) { FolderRow(f, selectMode, f.path in selected, onTap, onLongPress, onRename, onDelete, onShare) } }
+        if (files.isNotEmpty()) FileRows(files, selectMode, selected, onTap, onLongPress, onRename, onDelete, onShare)
+    }
 }
 
 @Composable
-private fun EntryRow(entry: VfsEntry, onClick: () -> Unit, onDelete: () -> Unit) {
-    val hue = if (entry.isDirectory) Azphalt.hues[Azphalt.hueOf(entry.name)] else Azphalt.Ink.copy(alpha = .14f)
-    val fg = if (entry.isDirectory) Azphalt.White else Azphalt.Ink
-
+private fun FolderRow(
+    entry: VfsEntry,
+    selectMode: Boolean,
+    isSelected: Boolean,
+    onTap: (VfsEntry) -> Unit,
+    onLongPress: (VfsEntry) -> Unit,
+    onRename: (VfsEntry) -> Unit,
+    onDelete: (VfsEntry) -> Unit,
+    onShare: (VfsEntry) -> Unit
+) {
     Row(
         Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(percent = 50))
-            .background(hue)
-            .clickable(onClick = onClick)
-            .padding(start = 16.dp, end = 10.dp, top = 10.dp, bottom = 10.dp),
+            .background(if (isSelected) Azphalt.Ink else Azphalt.hues[Azphalt.hueOf(entry.path)])
+            .combinedClickable(onClick = { onTap(entry) }, onLongClick = { onLongPress(entry) })
+            .padding(start = 16.dp, end = 8.dp, top = 10.dp, bottom = 10.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            if (selectMode) SelectMark(isSelected, dark = true)
             Text(
-                (entry.name + if (entry.isDirectory) "/" else "").uppercase(),
-                style = MaterialTheme.typography.titleMedium.copy(
-                    color = fg,
-                    fontSize = 11.sp,
-                    fontWeight = FontWeight.ExtraBold,
-                    letterSpacing = 0.09.em
-                ),
-                maxLines = 1
+                (entry.name + "/").uppercase(),
+                color = Azphalt.White, fontSize = 11.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em, maxLines = 1
             )
-            if (!entry.isDirectory) {
-                Text(
-                    formatFileSize(entry.sizeBytes),
-                    style = MaterialTheme.typography.labelSmall.copy(color = fg.copy(alpha = .55f), fontSize = 9.sp)
-                )
+        }
+        if (!selectMode) EntryMenu(entry, onRename, onDelete, onShare, tint = Azphalt.White)
+    }
+}
+
+@Composable
+private fun FileRows(
+    files: List<VfsEntry>,
+    selectMode: Boolean,
+    selected: Set<String>,
+    onTap: (VfsEntry) -> Unit,
+    onLongPress: (VfsEntry) -> Unit,
+    onRename: (VfsEntry) -> Unit,
+    onDelete: (VfsEntry) -> Unit,
+    onShare: (VfsEntry) -> Unit
+) {
+    val images = files.filter { it.isImage }
+    val others = files.filterNot { it.isImage }
+
+    Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+        // A folder made mostly of images renders itself as a thumbnail grid, in place,
+        // automatically - never a manual list/grid toggle.
+        if (images.size >= 3) {
+            Text(
+                "${images.size} PHOTOS", color = Azphalt.Ink.copy(alpha = .5f),
+                fontSize = 8.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.1.em
+            )
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(3),
+                modifier = Modifier.fillMaxWidth().height(((images.size / 3 + 1) * 90).dp),
+                horizontalArrangement = Arrangement.spacedBy(5.dp),
+                verticalArrangement = Arrangement.spacedBy(5.dp)
+            ) {
+                items(images, key = { it.path }) { img ->
+                    Box(
+                        Modifier
+                            .aspectRatio(1f)
+                            .clip(RoundedCornerShape(9.dp))
+                            .background(if (img.path in selected) Azphalt.Ink else Azphalt.hues[Azphalt.hueOf(img.path)])
+                            .clickable { onTap(img) },
+                        contentAlignment = Alignment.BottomStart
+                    ) {
+                        Text(
+                            img.name, color = Azphalt.White.copy(alpha = .8f), fontSize = 7.sp,
+                            fontWeight = FontWeight.Bold, maxLines = 1,
+                            modifier = Modifier.padding(6.dp)
+                        )
+                    }
+                }
             }
         }
-        Text(
-            "×",
-            style = MaterialTheme.typography.titleMedium.copy(color = fg.copy(alpha = .7f), fontSize = 13.sp),
-            modifier = Modifier.clickable(onClick = onDelete).padding(start = 8.dp)
-        )
+        others.forEach { f ->
+            key(f.path) {
+                Row(
+                    Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(percent = 50))
+                        .background(if (f.path in selected) Azphalt.Ink else Azphalt.Ink.copy(alpha = .09f))
+                        .combinedClickable(onClick = { onTap(f) }, onLongClick = { onLongPress(f) })
+                        .padding(start = 16.dp, end = 8.dp, top = 10.dp, bottom = 10.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                        if (selectMode) SelectMark(f.path in selected, dark = f.path !in selected)
+                        val fg = if (f.path in selected) Azphalt.Yellow else Azphalt.Ink
+                        Text(f.name.uppercase(), color = fg, fontSize = 11.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em, maxLines = 1)
+                        Text(formatFileSize(f.sizeBytes), color = fg.copy(alpha = .55f), fontSize = 9.sp)
+                    }
+                    if (!selectMode) EntryMenu(f, onRename, onDelete, onShare, tint = Azphalt.Ink)
+                }
+            }
+        }
     }
 }
 
 @Composable
-private fun ActionPill(label: String, onClick: () -> Unit) {
-    Row(
+private fun SelectMark(selected: Boolean, dark: Boolean) {
+    Box(
         Modifier
+            .size(16.dp)
             .clip(RoundedCornerShape(percent = 50))
-            .background(Azphalt.Ink.copy(alpha = .14f))
-            .clickable(onClick = onClick)
-            .padding(horizontal = 14.dp, vertical = 8.dp)
+            .background(if (selected) Azphalt.Yellow else (if (dark) Azphalt.White.copy(alpha = .25f) else Azphalt.Ink.copy(alpha = .2f))),
+        contentAlignment = Alignment.Center
     ) {
-        Text(
-            label,
-            style = MaterialTheme.typography.titleMedium.copy(
-                color = Azphalt.Ink,
-                fontSize = 9.sp,
-                letterSpacing = 0.06.em
-            )
-        )
+        if (selected) Text("✓", color = Azphalt.Ink, fontSize = 9.sp, fontWeight = FontWeight.Black)
     }
 }
 
 @Composable
-private fun CreatePrompt(
-    mode: CreateMode,
-    name: String,
-    onNameChange: (String) -> Unit,
-    onConfirm: () -> Unit,
-    onCancel: () -> Unit
-) {
+private fun EntryMenu(entry: VfsEntry, onRename: (VfsEntry) -> Unit, onDelete: (VfsEntry) -> Unit, onShare: (VfsEntry) -> Unit, tint: Color) {
+    Row(horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+        Text("RENAME", color = tint.copy(alpha = .7f), fontSize = 8.sp, fontWeight = FontWeight.Bold, modifier = Modifier.clickable { onRename(entry) })
+        if (!entry.isDirectory) {
+            Text("SHARE", color = tint.copy(alpha = .7f), fontSize = 8.sp, fontWeight = FontWeight.Bold, modifier = Modifier.clickable { onShare(entry) })
+        }
+        Text("×", color = tint.copy(alpha = .85f), fontSize = 13.sp, modifier = Modifier.clickable { onDelete(entry) })
+    }
+}
+
+@Composable
+private fun ColumnScope.SearchResults(results: List<VfsSearchResult>, onOpen: (VfsSearchResult) -> Unit) {
+    if (results.isEmpty()) {
+        Text(
+            "NOTHING", color = Azphalt.Ink.copy(alpha = .4f),
+            fontSize = 12.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.1.em,
+            modifier = Modifier.padding(start = 20.dp, top = 20.dp)
+        )
+        return
+    }
+    LazyColumn(
+        Modifier.fillMaxWidth().weight(1f).padding(horizontal = 20.dp, vertical = 12.dp),
+        verticalArrangement = Arrangement.spacedBy(2.dp)
+    ) {
+        items(results, key = { it.entry.path }) { r ->
+            Column(
+                Modifier.fillMaxWidth().clickable { onOpen(r) }.padding(vertical = 10.dp)
+            ) {
+                Text(
+                    (r.entry.name + if (r.entry.isDirectory) "/" else "").uppercase(),
+                    color = Azphalt.Ink, fontSize = 13.sp, fontWeight = FontWeight.ExtraBold
+                )
+                Text(r.parentPath, color = Azphalt.Ink.copy(alpha = .5f), fontSize = 10.sp)
+            }
+            Box(Modifier.fillMaxWidth().height(1.dp).background(Azphalt.Ink.copy(alpha = .12f)))
+        }
+    }
+}
+
+@Composable
+private fun NamePrompt(label: String, name: String, onNameChange: (String) -> Unit, onConfirm: () -> Unit, onCancel: () -> Unit) {
     Row(
         Modifier
             .fillMaxWidth()
@@ -250,27 +659,39 @@ private fun CreatePrompt(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(6.dp)
     ) {
-        Text(
-            if (mode == CreateMode.FOLDER) "NEW FOLDER" else "NEW FILE",
-            style = MaterialTheme.typography.labelSmall.copy(color = Azphalt.Yellow.copy(alpha = .7f), fontSize = 8.sp)
-        )
+        Text(label, color = Azphalt.Yellow.copy(alpha = .7f), fontSize = 8.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.1.em)
         BasicTextField(
             value = name,
             onValueChange = onNameChange,
             modifier = Modifier.weight(1f),
-            textStyle = MaterialTheme.typography.bodyMedium.copy(color = Azphalt.Yellow, fontSize = 12.sp),
+            textStyle = androidx.compose.ui.text.TextStyle(color = Azphalt.Yellow, fontSize = 12.sp),
             cursorBrush = SolidColor(Azphalt.Yellow),
             singleLine = true
         )
-        Text(
-            "OK",
-            style = MaterialTheme.typography.titleMedium.copy(color = Azphalt.Yellow, fontSize = 10.sp),
-            modifier = Modifier.clickable(onClick = onConfirm).padding(horizontal = 8.dp, vertical = 6.dp)
-        )
-        Text(
-            "X",
-            style = MaterialTheme.typography.titleMedium.copy(color = Azphalt.Yellow.copy(alpha = .6f), fontSize = 10.sp),
-            modifier = Modifier.clickable(onClick = onCancel).padding(horizontal = 8.dp, vertical = 6.dp)
-        )
+        Text("OK", color = Azphalt.Yellow, fontSize = 10.sp, fontWeight = FontWeight.ExtraBold, modifier = Modifier.clickable(onClick = onConfirm).padding(horizontal = 8.dp, vertical = 6.dp))
+        Text("X", color = Azphalt.Yellow.copy(alpha = .6f), fontSize = 10.sp, fontWeight = FontWeight.ExtraBold, modifier = Modifier.clickable(onClick = onCancel).padding(horizontal = 8.dp, vertical = 6.dp))
+    }
+}
+
+@Composable
+private fun Chip(
+    label: String,
+    modifier: Modifier = Modifier,
+    background: Color = Azphalt.Ink,
+    foreground: Color = Azphalt.Yellow,
+    filled: Boolean = true,
+    clickable: Boolean = true,
+    onClick: () -> Unit = {}
+) {
+    val bg = if (filled) background else Azphalt.Ink.copy(alpha = .14f)
+    val fg = if (filled) foreground else Azphalt.Ink.copy(alpha = .55f)
+    Box(
+        modifier
+            .clip(RoundedCornerShape(percent = 50))
+            .background(bg)
+            .then(if (clickable) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(horizontal = 14.dp, vertical = 8.dp)
+    ) {
+        Text(label, color = fg, fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FolderPicker.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FolderPicker.kt
@@ -1,0 +1,265 @@
+package com.hereliesaz.hg2gui.ui.files
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.layout.onGloballyPositioned
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.Density
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+
+/*
+ * The Move/Copy destination picker: a grid of folder tiles where tapping one morphs it into an
+ * open panel while its siblings shrink into thin coloured rods beside it - not a fade between
+ * two screens, a single continuous move. Tapping a rod swaps which tile is open; tapping the
+ * open panel's own header descends into it, its former siblings' rods becoming the new grid.
+ *
+ * Geometry is tracked per item as a target Rect (position + size in px), animated with one
+ * Animatable<Rect> each rather than the design source's multi-stage keyframes - fewer stops
+ * along the way, but the same shape of motion: a tile becoming a rod, a rod becoming a panel.
+ */
+
+private const val COLUMNS = 3
+private val GRID_GAP = 6.dp
+private val ROD_WIDTH = 14.dp
+private val ROD_GAP = 4.dp
+private const val MORPH_MS = 480
+
+private data class Rect(val x: Float, val y: Float, val w: Float, val h: Float)
+
+@Composable
+fun FolderPicker(
+    title: String,
+    listDir: suspend (path: String) -> List<VfsEntry>,
+    onConfirm: (targetPath: String) -> Unit,
+    onCancel: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var currentPath by remember { mutableStateOf("/") }
+    var folders by remember { mutableStateOf<List<VfsEntry>>(emptyList()) }
+    var openIndex by remember { mutableStateOf<Int?>(null) }
+
+    LaunchedEffect(currentPath) {
+        folders = listDir(currentPath).filter { it.isDirectory }.sortedBy { it.name.lowercase() }
+        openIndex = null
+    }
+
+    val density = LocalDensity.current
+
+    Column(modifier.fillMaxSize().background(PageYellowBrush)) {
+        Row(
+            Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            PickerChip("‹ CANCEL", onClick = onCancel)
+            PickerChip(title.uppercase(), filled = false, clickable = false)
+        }
+
+        Row(
+            Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 10.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            val crumbs = currentPath.trim('/').split('/').filter { it.isNotEmpty() }
+            Text(
+                "/" + crumbs.joinToString("/"),
+                color = Azphalt.Ink.copy(alpha = .55f),
+                fontSize = 11.sp,
+                fontWeight = FontWeight.Bold,
+                maxLines = 1
+            )
+        }
+
+        Box(Modifier.weight(1f).fillMaxWidth().padding(20.dp)) {
+            if (folders.isEmpty()) {
+                Text(
+                    "NO SUBFOLDERS HERE",
+                    color = Azphalt.Ink.copy(alpha = .4f),
+                    fontSize = 10.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    letterSpacing = 0.18.em
+                )
+            } else {
+                var canvasWidthPx by remember { mutableStateOf(0f) }
+                Box(
+                    Modifier.fillMaxSize().onGloballyPositioned { canvasWidthPx = it.size.width.toFloat() }
+                ) {
+                    if (canvasWidthPx > 0f) {
+                        folders.forEachIndexed { i, folder ->
+                            key(folder.path) {
+                                MorphTile(
+                                    label = folder.name,
+                                    hue = Azphalt.hues[Azphalt.hueOf(folder.path)],
+                                    rect = targetRect(i, folders.size, openIndex, canvasWidthPx, density),
+                                    isOpen = openIndex == i,
+                                    onClick = {
+                                        openIndex = if (openIndex == i) null else i
+                                    },
+                                    onOpenDescend = { currentPath = folder.path }
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            PickerChip("USE THIS FOLDER", background = Azphalt.hues[6], foreground = Azphalt.White, fillWidth = true) {
+                onConfirm(currentPath)
+            }
+        }
+    }
+}
+
+/** The grid rect (nothing open), the panel rect (this tile is open), or a rod rect (some other
+ *  tile is open) for item [i] of [count], in px against a canvas [canvasWidthPx] wide. */
+private fun targetRect(i: Int, count: Int, openIndex: Int?, canvasWidthPx: Float, density: Density): Rect = with(density) {
+    val gapPx = GRID_GAP.toPx()
+    val tileSize = (canvasWidthPx - gapPx * (COLUMNS - 1)) / COLUMNS
+
+    when {
+        openIndex == null -> {
+            val row = i / COLUMNS
+            val col = i % COLUMNS
+            Rect(col * (tileSize + gapPx), row * (tileSize + gapPx), tileSize, tileSize)
+        }
+        openIndex == i -> {
+            Rect(0f, 0f, canvasWidthPx, tileSize * 1.6f)
+        }
+        else -> {
+            val rodWidthPx = ROD_WIDTH.toPx()
+            val rodGapPx = ROD_GAP.toPx()
+            val others = (0 until count).filter { it != openIndex }
+            val slot = others.indexOf(i)
+            val panelHeight = tileSize * 1.6f
+            Rect(slot * (rodWidthPx + rodGapPx), panelHeight + GRID_GAP.toPx(), rodWidthPx, tileSize * 0.7f)
+        }
+    }
+}
+
+@Composable
+private fun MorphTile(
+    label: String,
+    hue: Color,
+    rect: Rect,
+    isOpen: Boolean,
+    onClick: () -> Unit,
+    onOpenDescend: () -> Unit
+) {
+    val density = LocalDensity.current
+    val x = remember { Animatable(rect.x) }
+    val y = remember { Animatable(rect.y) }
+    val w = remember { Animatable(rect.w) }
+    val h = remember { Animatable(rect.h) }
+    val easing = CubicBezierEasing(0f, .9f, .1f, 1f)
+
+    LaunchedEffect(rect) {
+        launchAll(
+            { x.animateTo(rect.x, tween(MORPH_MS, easing = easing)) },
+            { y.animateTo(rect.y, tween(MORPH_MS, easing = easing)) },
+            { w.animateTo(rect.w, tween(MORPH_MS, easing = easing)) },
+            { h.animateTo(rect.h, tween(MORPH_MS, easing = easing)) }
+        )
+    }
+
+    with(density) {
+        Box(
+            Modifier
+                .offset { IntOffset(x.value.toInt(), y.value.toInt()) }
+                .width(w.value.toDp())
+                .height(h.value.toDp())
+                .clip(RoundedCornerShape(if (isOpen) 18.dp else if (w.value.toDp() < 20.dp) 999.dp else 13.dp))
+                .background(hue)
+                .clickable { if (isOpen) onOpenDescend() else onClick() }
+                .padding(if (isOpen) 14.dp else 6.dp),
+            contentAlignment = if (isOpen) Alignment.TopStart else Alignment.BottomStart
+        ) {
+            if (w.value.toDp() > 24.dp) {
+                Column {
+                    Text(
+                        label.uppercase(),
+                        color = Azphalt.White,
+                        fontSize = if (isOpen) 15.sp else 8.sp,
+                        fontWeight = FontWeight.ExtraBold,
+                        letterSpacing = 0.06.em,
+                        maxLines = if (isOpen) 1 else 2
+                    )
+                    if (isOpen) {
+                        Text(
+                            "TAP TO GO INSIDE",
+                            color = Azphalt.White.copy(alpha = .7f),
+                            fontSize = 9.sp,
+                            fontWeight = FontWeight.Bold,
+                            modifier = Modifier.padding(top = 4.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private suspend fun launchAll(vararg blocks: suspend () -> Unit) {
+    coroutineScope {
+        blocks.forEach { block -> launch { block() } }
+    }
+}
+
+private val PageYellowBrush = Brush.linearGradient(
+    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
+)
+
+@Composable
+private fun PickerChip(
+    label: String,
+    modifier: Modifier = Modifier,
+    background: Color = Azphalt.Ink,
+    foreground: Color = Azphalt.Yellow,
+    filled: Boolean = true,
+    clickable: Boolean = true,
+    fillWidth: Boolean = false,
+    onClick: () -> Unit = {}
+) {
+    val bg = if (filled) background else Azphalt.Ink.copy(alpha = .14f)
+    val fg = if (filled) foreground else Azphalt.Ink.copy(alpha = .55f)
+    Box(
+        modifier
+            .then(if (fillWidth) Modifier.fillMaxWidth() else Modifier)
+            .clip(RoundedCornerShape(percent = 50))
+            .background(bg)
+            .then(if (clickable) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(horizontal = 14.dp, vertical = 9.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(label, color = fg, fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/StorageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/StorageScreen.kt
@@ -1,0 +1,186 @@
+package com.hereliesaz.hg2gui.ui.files
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.hg2gui.ui.menu.Azphalt
+
+/*
+ * Storage broken down by content type - real numbers from a recursive walk of the sandbox, not
+ * a device-wide figure the app has no way to actually know. Two tabs: the breakdown, and the
+ * worst offenders named.
+ */
+
+private val PageYellow = Brush.linearGradient(
+    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
+)
+
+private val CATEGORY_HUES = mapOf(
+    "Images" to 0, "Documents" to 2, "Code" to 9, "Archives" to 5, "Other" to 4
+)
+
+private enum class StorageTab { BY_TYPE, LARGEST }
+
+@Composable
+fun StorageScreen(
+    stats: StorageStats?,
+    onDelete: (path: String) -> Unit,
+    onBack: () -> Unit,
+    fullscreen: Boolean,
+    modifier: Modifier = Modifier
+) {
+    var tab by remember { mutableStateOf(StorageTab.BY_TYPE) }
+
+    Column(
+        modifier
+            .fillMaxSize()
+            .background(PageYellow)
+            .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
+    ) {
+        Row(
+            Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Chip("‹ BACK", onClick = onBack)
+            Chip("${stats?.byCategory?.size ?: 0} PLACES", filled = false, clickable = false)
+        }
+
+        if (stats == null) {
+            Text(
+                "COUNTING…", color = Azphalt.Ink.copy(alpha = .4f),
+                fontSize = 12.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.1.em,
+                modifier = Modifier.padding(start = 20.dp, top = 24.dp)
+            )
+            return
+        }
+
+        Column(Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 20.dp)) {
+            Text(
+                "USED IN THIS SANDBOX", color = Azphalt.Ink.copy(alpha = .55f),
+                fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.18.em
+            )
+            Text(
+                formatFileSize(stats.totalBytes), color = Azphalt.Ink,
+                fontSize = 44.sp, lineHeight = 40.sp, fontWeight = FontWeight.Black
+            )
+            Spacer(Modifier.height(14.dp))
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .height(12.dp)
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.Ink.copy(alpha = .14f))
+            ) {
+                val total = stats.totalBytes.coerceAtLeast(1)
+                stats.byCategory.filter { it.bytes > 0 }.forEach { cat ->
+                    val fraction = (cat.bytes.toFloat() / total.toFloat()).coerceIn(0f, 1f)
+                    Box(
+                        Modifier
+                            .fillMaxHeight()
+                            .weight(fraction.coerceAtLeast(0.001f))
+                            .background(Azphalt.hues[CATEGORY_HUES[cat.label] ?: 3])
+                    )
+                }
+            }
+        }
+
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 16.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            Chip("BY TYPE", filled = tab == StorageTab.BY_TYPE, onClick = { tab = StorageTab.BY_TYPE })
+            Chip("LARGEST", filled = tab == StorageTab.LARGEST, onClick = { tab = StorageTab.LARGEST })
+        }
+
+        when (tab) {
+            StorageTab.BY_TYPE -> LazyColumn(
+                Modifier.weight(1f).fillMaxWidth().padding(horizontal = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(2.dp)
+            ) {
+                items(stats.byCategory.filter { it.bytes > 0 }.sortedByDescending { it.bytes }, key = { it.label }) { cat ->
+                    Row(
+                        Modifier.fillMaxWidth().padding(vertical = 11.dp),
+                        horizontalArrangement = Arrangement.SpaceBetween,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                            Box(
+                                Modifier.size(8.dp).clip(RoundedCornerShape(percent = 50))
+                                    .background(Azphalt.hues[CATEGORY_HUES[cat.label] ?: 3])
+                            )
+                            Text(cat.label.uppercase(), color = Azphalt.Ink, fontSize = 12.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.06.em)
+                        }
+                        Text(formatFileSize(cat.bytes), color = Azphalt.Ink.copy(alpha = .6f), fontSize = 11.sp, fontWeight = FontWeight.Bold)
+                    }
+                    Box(Modifier.fillMaxWidth().height(1.dp).background(Azphalt.Ink.copy(alpha = .12f)))
+                }
+            }
+
+            StorageTab.LARGEST -> LazyColumn(
+                Modifier.weight(1f).fillMaxWidth().padding(horizontal = 20.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                items(stats.largest, key = { it.path }) { f ->
+                    Row(
+                        Modifier
+                            .fillMaxWidth()
+                            .clip(RoundedCornerShape(percent = 50))
+                            .background(Azphalt.Ink.copy(alpha = .10f))
+                            .padding(start = 16.dp, end = 8.dp, top = 10.dp, bottom = 10.dp),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.SpaceBetween
+                    ) {
+                        Column {
+                            Text(f.name, color = Azphalt.Ink, fontSize = 12.sp, fontWeight = FontWeight.Bold, maxLines = 1)
+                            Text(formatFileSize(f.sizeBytes), color = Azphalt.Ink.copy(alpha = .55f), fontSize = 9.sp)
+                        }
+                        Text(
+                            "×", color = Azphalt.Ink.copy(alpha = .7f), fontSize = 15.sp,
+                            modifier = Modifier.clickable { onDelete(f.path) }.padding(start = 8.dp)
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun Chip(
+    label: String,
+    modifier: Modifier = Modifier,
+    filled: Boolean = true,
+    clickable: Boolean = true,
+    onClick: () -> Unit = {}
+) {
+    val bg = if (filled) Azphalt.Ink else Azphalt.Ink.copy(alpha = .14f)
+    val fg = if (filled) Azphalt.Yellow else Azphalt.Ink.copy(alpha = .55f)
+    Box(
+        modifier
+            .clip(RoundedCornerShape(percent = 50))
+            .background(bg)
+            .then(if (clickable) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(horizontal = 14.dp, vertical = 8.dp)
+    ) {
+        Text(label, color = fg, fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/VfsEntry.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/VfsEntry.kt
@@ -1,0 +1,50 @@
+package com.hereliesaz.hg2gui.ui.files
+
+/**
+ * One node in the sandboxed filesystem, identified by an absolute path from the vfs root
+ * (e.g. "/Downloads/photo.png") - not a `java.io.File`, so this stays platform-agnostic and the
+ * actual I/O lives entirely on the Android side, reached only through the callbacks
+ * [FilesScreen] is handed.
+ */
+data class VfsEntry(
+    val name: String,
+    val path: String,
+    val isDirectory: Boolean,
+    val sizeBytes: Long,
+    val modifiedAt: Long = 0L,
+    val isImage: Boolean = false
+)
+
+/** [entry]'s own containing directory, so a search result can show where it lives. */
+data class VfsSearchResult(val entry: VfsEntry, val parentPath: String)
+
+data class StorageCategoryStat(val label: String, val bytes: Long)
+
+data class StorageStats(
+    val totalBytes: Long,
+    val byCategory: List<StorageCategoryStat>,
+    val largest: List<VfsEntry>
+)
+
+/** The parent path of [path] ("/a/b/c" -> "/a/b"; "/a" -> "/"). */
+fun vfsParentPath(path: String): String {
+    val trimmed = path.trimEnd('/')
+    val slash = trimmed.lastIndexOf('/')
+    return if (slash <= 0) "/" else trimmed.substring(0, slash)
+}
+
+/** Joins a directory path and a child name into a normalized absolute path. */
+fun vfsChildPath(parent: String, name: String): String {
+    val base = parent.trimEnd('/')
+    return if (base.isEmpty()) "/$name" else "$base/$name"
+}
+
+fun formatFileSize(bytes: Long): String = when {
+    bytes < 1024 -> "$bytes B"
+    bytes < 1024 * 1024 -> "${bytes / 1024} KB"
+    bytes < 1024 * 1024 * 1024 -> "${bytes / (1024 * 1024)} MB"
+    else -> {
+        val tenths = bytes / (1024L * 1024L * 1024L / 10L)
+        "${tenths / 10}.${tenths % 10} GB"
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/CommandGuideScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/CommandGuideScreen.kt
@@ -6,6 +6,10 @@ import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,6 +43,20 @@ fun CommandGuideScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
+    // The real Hitchhiker's Guide - a chapter index of parody command entries, not a picker -
+    // is nested inside this screen rather than replacing it: this remains "pick a command",
+    // that remains "read about one", one pill apart.
+    var readingGuide by remember { mutableStateOf(false) }
+
+    if (readingGuide) {
+        GuideReaderScreen(
+            fullscreen = fullscreen,
+            onBack = { readingGuide = false },
+            modifier = modifier
+        )
+        return
+    }
+
     Column(
         modifier
             .fillMaxSize()
@@ -47,6 +65,7 @@ fun CommandGuideScreen(
     ) {
         Row(
             Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically
         ) {
             Box(
@@ -58,6 +77,18 @@ fun CommandGuideScreen(
             ) {
                 Text(
                     "‹ BACK", color = Azphalt.Yellow,
+                    fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+                )
+            }
+            Box(
+                Modifier
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.hues[6])
+                    .clickable { readingGuide = true }
+                    .padding(horizontal = 14.dp, vertical = 7.dp)
+            ) {
+                Text(
+                    "THE GUIDE", color = Azphalt.White,
                     fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
                 )
             }

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideContent.kt
@@ -1,0 +1,160 @@
+package com.hereliesaz.hg2gui.ui.guide
+
+/**
+ * One glossary entry: a real command paired with an invented, tone-not-fiction definition -
+ * the Guide adds flavor, never a false claim about what the command actually does.
+ */
+data class GuideEntry(
+    val cmd: String,
+    val full: String,
+    val blurb: String,
+    val chapterLabel: String,
+    val chapterTitle: String,
+    val chapterIntro: String
+) {
+    /** The index row's teaser - only the blurb's first sentence, the rest is saved for the entry
+     *  itself so the index reads as a table of contents, not the whole book. */
+    val teaser: String get() = blurb.substringBefore('.').trim() + "."
+}
+
+private data class Chapter(val label: String, val title: String, val intro: String, val entries: List<Triple<String, String, String>>)
+
+private val CHAPTERS = listOf(
+    Chapter(
+        "Chapter 1", "Standard Input",
+        "The Hitchhiker's Guide to the Galaxy defines Terminal as \"fatal,\" and encourages anyone using one to emulate that.",
+        listOf(
+            Triple("ls", "list", "Lists every file in the directory, but completely glosses over every file without a name."),
+            Triple("echo", "echo", "Because it wasn't all Narcissus' fault."),
+            Triple("cd", "change directory", "Changes your directory, but sadly, not your destiny, duties, death, damnation, or deal.")
+        )
+    ),
+    Chapter(
+        "Chapter 2", "File Permissions",
+        "To prevent the entire universe from collapsing under the weight of its own poorly written shell scripts, the Unix permissions model was invented to ensure nobody could actually touch anything of value.",
+        listOf(
+            Triple("chmod", "change mode", "Charades played with the operating system, pretending you have power over the inevitable decay of your data."),
+            Triple("chown", "change owner", "Transfers the crushing, inescapable existential burden of ownership from one doomed user to another.")
+        )
+    ),
+    Chapter(
+        "Chapter 3", "Navigation",
+        "Space is big. You just won't believe how vastly, hugely, mind-bogglingly big it is. But it is nothing compared to the labyrinthine absurdity of the root file system.",
+        listOf(
+            Triple("pwd", "print working directory", "Proves without a shadow of a doubt that you are exactly where you didn't want to be."),
+            Triple("mkdir", "make directory", "Manufactures a meticulously sterile void, perfectly prepared to house your digital disappointments.")
+        )
+    ),
+    Chapter(
+        "Chapter 4", "Package Management",
+        "The Guide notes that all major galactic civilizations go through three distinct and recognizable phases of package management: Survival (How do I install this?), Inquiry (Why is this dependency broken?), and Sophistication (Where did my free space go?).",
+        listOf(
+            Triple("pkg install", "package install", "Procures perfectly packaged problems you previously didn't possess."),
+            Triple("apt-get update", "advanced package tool get", "Asks the universe if entropy has escalated since you last inquired. Spoiler: It has.")
+        )
+    ),
+    Chapter(
+        "Chapter 6", "Text Editors",
+        "(Note: Chapter 5 was eaten by a small, heavily armed logic flaw.) There is a long and storied history of holy wars across the galaxy, mostly fought over the proper way to exit a text editor.",
+        listOf(
+            Triple("nano", "nano's another editor", "Nurtures your neuroses by explicitly explaining how to escape the very cage you just built."),
+            Triple("vi", "visual", "Vindicates the Vogon view that true art requires unyielding, inescapable agony.")
+        )
+    ),
+    Chapter(
+        "Chapter 7", "Processes",
+        "A process is simply a program that has managed to briefly trick the CPU into believing it has a purpose.",
+        listOf(
+            Triple("top", "table of processes", "Tally of the parasitic processes currently consuming the cold, calculating core of your computer."),
+            Triple("kill", "kill", "Kicks the metaphorical chair out from beneath a process that has outlived its microscopic usefulness.")
+        )
+    ),
+    Chapter(
+        "Chapter 8", "Storage",
+        "The Encyclopedia Galactica defines a file system as a logical method for storing data. The Guide defines it as a digital sock drawer where you will inevitably lose the one script you actually need.",
+        listOf(
+            Triple("df", "disk free", "Documents the depressing depletion of your disk space, offering absolutely zero psychological support."),
+            Triple("rm", "remove", "Renders reality slightly emptier, rapidly resolving the temporary existence of your trivial files.")
+        )
+    ),
+    Chapter(
+        "Chapter 9", "Shell Scripting",
+        "If you are going to do something utterly pointless, the Guide advises that you should at least automate it so you can be somewhere else when the error logs start flooding in.",
+        listOf(
+            Triple("bash", "bourne-again shell", "Bashes your fragile, flawed human logic repeatedly against the unforgiving anvil of machine syntax."),
+            Triple("source", "source", "Sucks the soul out of a separate script, violently assimilating its variables like a digital vampire.")
+        )
+    ),
+    Chapter(
+        "Chapter 10", "Networking",
+        "Connecting to the internet from a terminal emulator is much like shouting into a black hole, except occasionally the black hole shouts back to offer you a suspiciously cheap pharmaceutical product.",
+        listOf(
+            Triple("ping", "packet internet groper", "Pokes the pitch-black abyss of the internet, praying something out there pokes back."),
+            Triple("ssh", "secure shell", "Sends your consciousness hurtling through hyperspace, solely so you can shatter systems from the safety of your sofa.")
+        )
+    ),
+    Chapter(
+        "chapter_01", "The Absurdity of Redundancy",
+        "It is a well-documented phenomenon that any sufficiently advanced filesystem will spontaneously generate duplicate files with slightly altered casing, just to see if the user is paying attention.",
+        listOf(Triple("ls -a", "list, all", "Lifts the veil on the lurking, hidden files, highlighting the horrific reality that your system has secrets."))
+    ),
+    Chapter(
+        "chapter_02", "Doppelgänger Permissions",
+        "You may attempt to read this file, but it will only tell you that the permissions you thought you understood were merely another language game designed to keep you from realizing the terminal is actually empty.",
+        listOf(Triple("sudo", "superuser do", "Summons a superficial sense of supremacy, temporarily tricking the terminal into trusting your terrible ideas."))
+    ),
+    Chapter(
+        "chapter_03", "The Infinite Directory",
+        "A wise philosopher once noted that having two maps of the exact same territory does not help you find your keys any faster.",
+        listOf(Triple("rmdir", "remove directory", "Removes the remnants of a room that was already agonizingly absent of anything."))
+    ),
+    Chapter(
+        "chapter_04", "Ghost Dependencies",
+        "You have successfully downloaded a duplicate chapter about package management. The dependencies for understanding this chapter include a complete abandonment of logical coherence.",
+        listOf(Triple("dpkg", "debian package", "Delivers the dependent data with the depressing demeanor of a doomed, depressed dictionary."))
+    ),
+    Chapter(
+        "chapter_05", "The Anomaly",
+        "Curiously, while the uppercase Chapter 5 was destroyed by a logic flaw, this file survived. It contains nothing but the creeping dread of realization.",
+        listOf(Triple("find", "find", "Frantically flails through the filesystem, finally confirming the absolute absence of whatever you were foolish enough to look for."))
+    ),
+    Chapter(
+        "chapter_06", "The Mirror Editor",
+        "An editor editing a file about an editor editing a duplicate file.",
+        listOf(Triple("cat", "concatenate", "Carelessly coughs the complete contents of a file directly onto your screen, utterly unconcerned with context or comprehension."))
+    ),
+    Chapter(
+        "chapter_07", "Zombie Processes",
+        "This file is the textual equivalent of a zombie process. It has no parent, it serves no function, and it simply refuses to die.",
+        listOf(Triple("ps", "process status", "Parades the pathetic, purgatorial processes perpetually trapped in the processor's penal colony."))
+    ),
+    Chapter(
+        "chapter_08", "Backing up the Void",
+        "To ensure the utmost safety of your completely irrelevant data, it is highly recommended to keep a lower-case copy of every upper-case file.",
+        listOf(Triple("tar", "tape archive", "Traps your trivial texts in a tight, terrible tomb, ensuring they degrade together in the dark."))
+    ),
+    Chapter(
+        "chapter_09", "Looping the Loop",
+        "Automating the creation of the very file you are reading. Time is an illusion. Terminal history doubly so.",
+        listOf(Triple("grep", "global regular expression print", "Grabs greedily at the galactic garbage heap, guaranteeing you only gather other, slightly sharper garbage."))
+    ),
+    Chapter(
+        "chapter_10", "The Ultimate Handshake",
+        "The final duplicate file. By this point, the Guide assumes you have either mastered the command line or have thrown your device into the nearest body of water.",
+        listOf(Triple("ifconfig", "interface configuration", "Inappropriately forces your interface to strip and show its subnet mask to complete, calculating strangers."))
+    )
+)
+
+/** Chapter label + title + entries, for the index. */
+data class GuideChapter(val label: String, val title: String, val entries: List<GuideEntry>)
+
+object GuideBook {
+    val chapters: List<GuideChapter> = CHAPTERS.map { ch ->
+        GuideChapter(ch.label, ch.title, ch.entries.map { (cmd, full, blurb) ->
+            GuideEntry(cmd, full, blurb, ch.label, ch.title, ch.intro)
+        })
+    }
+
+    /** Every entry, flattened in reading order - the order Next/Prev and the entry index walk. */
+    val entries: List<GuideEntry> = chapters.flatMap { it.entries }
+}

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideReaderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideReaderScreen.kt
@@ -1,0 +1,364 @@
+package com.hereliesaz.hg2gui.ui.guide
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import kotlinx.coroutines.delay
+
+/*
+ * The Guide: a chapter index of real commands paired with invented, Hitchhiker's-Guide-style
+ * definitions - reading material, not a command picker. Nested inside the existing command
+ * picker (also historically called "the Guide") rather than replacing it, reachable through a
+ * pill at that screen's top.
+ *
+ * Every screen change wipes on: one axis, reading order, no fade, never loops. Text and rules
+ * reveal via a left-to-right clip; pills grow their actual width instead, so a rounded end grows
+ * into being rather than getting guillotined by a hard clip partway through its curve.
+ */
+
+private val PageYellow = Brush.linearGradient(
+    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
+)
+
+private val GUIDE_HUES = intArrayOf(6, 5, 4, 2, 9, 0, 7) // red, orange, amber, teal, blue, violet, magenta
+
+private enum class GuideView { Index, Entry }
+
+@Composable
+fun GuideReaderScreen(
+    fullscreen: Boolean,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    var view by remember { mutableStateOf(GuideView.Index) }
+    var entryIndex by remember { mutableStateOf(0) }
+    var wipeKey by remember { mutableStateOf(0) }
+
+    Column(
+        modifier
+            .fillMaxSize()
+            .background(PageYellow)
+            .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
+    ) {
+        when (view) {
+            GuideView.Index -> GuideIndex(
+                onBack = onBack,
+                onOpenEntry = { i -> entryIndex = i; wipeKey++; view = GuideView.Entry }
+            )
+            GuideView.Entry -> GuideEntryReader(
+                entry = GuideBook.entries[entryIndex],
+                number = entryIndex + 1,
+                total = GuideBook.entries.size,
+                wipeKey = wipeKey,
+                onBackToIndex = { view = GuideView.Index },
+                onPrev = {
+                    entryIndex = (entryIndex - 1 + GuideBook.entries.size) % GuideBook.entries.size
+                    wipeKey++
+                },
+                onNext = {
+                    entryIndex = (entryIndex + 1) % GuideBook.entries.size
+                    wipeKey++
+                },
+                onReplay = { wipeKey++ }
+            )
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.GuideIndex(onBack: () -> Unit, onOpenEntry: (Int) -> Unit) {
+    Row(
+        Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Chip("‹ BACK", onClick = onBack)
+        Chip("${GuideBook.entries.size} ENTRIES", filled = false, clickable = false)
+    }
+
+    Column(Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp)) {
+        Text(
+            "THE GUIDE",
+            color = Azphalt.Ink,
+            fontSize = 34.sp,
+            lineHeight = 30.sp,
+            fontWeight = FontWeight.Black,
+            letterSpacing = (-0.02).em
+        )
+        Text(
+            "The galaxy's largest repository of half-truths and pseudo-knowledge required to " +
+                "pocket a wild Linux environment. Proceed with a care-free sort of caution.",
+            color = Azphalt.Ink.copy(alpha = .78f),
+            fontSize = 13.sp,
+            lineHeight = 18.sp,
+            modifier = Modifier.padding(top = 8.dp)
+        )
+    }
+
+    LazyColumn(
+        Modifier.weight(1f).fillMaxWidth().padding(horizontal = 20.dp),
+        contentPadding = androidx.compose.foundation.layout.PaddingValues(top = 18.dp, bottom = 40.dp),
+        verticalArrangement = Arrangement.spacedBy(20.dp)
+    ) {
+        GuideBook.chapters.forEach { chapter ->
+            item(key = chapter.label) {
+                Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
+                    Text(
+                        chapter.label.uppercase(),
+                        color = Azphalt.Ink.copy(alpha = .45f),
+                        fontSize = 9.sp,
+                        fontWeight = FontWeight.ExtraBold,
+                        letterSpacing = 0.18.em
+                    )
+                    Text(
+                        chapter.title.uppercase(),
+                        color = Azphalt.Ink,
+                        fontSize = 16.sp,
+                        fontWeight = FontWeight.Black,
+                        letterSpacing = (-0.01).em
+                    )
+                    Spacer(Modifier.height(2.dp))
+                    Box(Modifier.fillMaxWidth().height(1.dp).background(Azphalt.Ink.copy(alpha = .16f)))
+                    chapter.entries.forEach { entry ->
+                        val globalIndex = GuideBook.entries.indexOf(entry)
+                        Row(
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable { onOpenEntry(globalIndex) }
+                                .padding(vertical = 11.dp),
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Text(
+                                entry.cmd,
+                                color = Azphalt.Ink,
+                                fontSize = 13.sp,
+                                fontWeight = FontWeight.ExtraBold,
+                                letterSpacing = 0.01.em,
+                                modifier = Modifier.weight(0.4f)
+                            )
+                            Text(
+                                entry.teaser,
+                                color = Azphalt.Ink.copy(alpha = .55f),
+                                fontSize = 12.sp,
+                                lineHeight = 16.sp,
+                                modifier = Modifier.weight(0.6f)
+                            )
+                        }
+                        Box(Modifier.fillMaxWidth().height(1.dp).background(Azphalt.Ink.copy(alpha = .16f)))
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun ColumnScope.GuideEntryReader(
+    entry: GuideEntry,
+    number: Int,
+    total: Int,
+    wipeKey: Int,
+    onBackToIndex: () -> Unit,
+    onPrev: () -> Unit,
+    onNext: () -> Unit,
+    onReplay: () -> Unit
+) {
+    val hue = GUIDE_HUES[GuideBook.entries.indexOf(entry) % GUIDE_HUES.size]
+
+    Column(Modifier.fillMaxSize().padding(horizontal = 20.dp)) {
+        Row(
+            Modifier.fillMaxWidth().padding(top = 18.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            WipeItem(0, wipeKey, wide = false) { Chip("GUIDE", onClick = onBackToIndex) }
+            Chip("REPLAY", onClick = onReplay)
+        }
+
+        WipeItem(1, wipeKey, wide = false, modifier = Modifier.padding(top = 14.dp)) {
+            Chip("ENTRY $number OF $total", filled = false, clickable = false)
+        }
+
+        WipeItem(2, wipeKey, wide = true, modifier = Modifier.padding(top = 16.dp)) {
+            Text(
+                entry.cmd.uppercase(),
+                color = Azphalt.Ink,
+                fontSize = 34.sp,
+                lineHeight = 30.sp,
+                fontWeight = FontWeight.Black,
+                letterSpacing = (-0.02).em
+            )
+        }
+
+        WipeItem(3, wipeKey, wide = true, modifier = Modifier.padding(top = 12.dp)) {
+            Box(
+                Modifier
+                    .width(220.dp)
+                    .height(4.dp)
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.hues[hue])
+            )
+        }
+
+        WipeItem(4, wipeKey, wide = true, modifier = Modifier.padding(top = 16.dp)) {
+            Text(
+                entry.blurb,
+                color = Azphalt.Ink.copy(alpha = .78f),
+                fontSize = 15.sp,
+                lineHeight = 21.sp
+            )
+        }
+
+        WipeItem(5, wipeKey, wide = true, modifier = Modifier.padding(top = 10.dp)) {
+            Text(
+                "STANDS FOR “${entry.full.uppercase()}”",
+                color = Azphalt.Ink.copy(alpha = .45f),
+                fontSize = 10.sp,
+                fontWeight = FontWeight.ExtraBold,
+                letterSpacing = 0.14.em
+            )
+        }
+
+        WipeItem(6, wipeKey, wide = true, modifier = Modifier.padding(top = 20.dp)) {
+            Column {
+                FactRow("Chapter", entry.chapterTitle)
+                FactRow("Actually does something", "Yes")
+            }
+        }
+
+        WipeItem(7, wipeKey, wide = true, modifier = Modifier.padding(top = 20.dp)) {
+            Column {
+                Text(
+                    "FROM THE CHAPTER",
+                    color = Azphalt.Ink.copy(alpha = .45f),
+                    fontSize = 9.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    letterSpacing = 0.18.em
+                )
+                Text(
+                    entry.chapterIntro,
+                    color = Azphalt.Ink.copy(alpha = .78f),
+                    fontSize = 12.sp,
+                    lineHeight = 17.sp,
+                    modifier = Modifier.padding(top = 6.dp)
+                )
+            }
+        }
+
+        Spacer(Modifier.weight(1f))
+
+        Row(
+            Modifier.fillMaxWidth().padding(bottom = 22.dp),
+            horizontalArrangement = Arrangement.spacedBy(8.dp)
+        ) {
+            WipeItem(8, wipeKey, wide = false) { Chip("PREV", onClick = onPrev) }
+            WipeItem(
+                9, wipeKey, wide = false,
+                modifier = Modifier.weight(1f)
+            ) {
+                Chip("NEXT ENTRY", background = Azphalt.hues[6], foreground = Azphalt.White, onClick = onNext, fillWidth = true)
+            }
+        }
+    }
+}
+
+@Composable
+private fun FactRow(label: String, value: String) {
+    Row(
+        Modifier.fillMaxWidth().padding(vertical = 9.dp),
+        horizontalArrangement = Arrangement.SpaceBetween
+    ) {
+        Text(
+            label.uppercase(), color = Azphalt.Ink.copy(alpha = .55f),
+            fontSize = 10.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+        )
+        Text(value, color = Azphalt.Ink, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+    }
+    Box(Modifier.fillMaxWidth().height(1.dp).background(Azphalt.Ink.copy(alpha = .16f)))
+}
+
+@Composable
+private fun Chip(
+    label: String,
+    modifier: Modifier = Modifier,
+    background: Color = Azphalt.Ink,
+    foreground: Color = Azphalt.Yellow,
+    filled: Boolean = true,
+    clickable: Boolean = true,
+    fillWidth: Boolean = false,
+    onClick: () -> Unit = {}
+) {
+    val bg = if (filled) background else Azphalt.Ink.copy(alpha = .14f)
+    val fg = if (filled) foreground else Azphalt.Ink.copy(alpha = .55f)
+    Box(
+        modifier
+            .then(if (fillWidth) Modifier.fillMaxWidth() else Modifier)
+            .clip(RoundedCornerShape(percent = 50))
+            .background(bg)
+            .then(if (clickable) Modifier.clickable(onClick = onClick) else Modifier)
+            .padding(horizontal = 14.dp, vertical = 8.dp),
+        contentAlignment = Alignment.Center
+    ) {
+        Text(label, color = fg, fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em)
+    }
+}
+
+/**
+ * One element of the wipe-on sequence: `wide` elements (text/rules) reveal via a left-to-right
+ * clip with a slight slide, since the content is already full width - only visibility grows.
+ * Non-wide elements are pills/chips, whose actual layout width is animated instead: clip-masking
+ * an already-round shape would guillotine its leading curve, where growing the real width lets
+ * the rounded end come into being along with everything else.
+ */
+@Composable
+private fun WipeItem(seq: Int, wipeKey: Int, wide: Boolean, modifier: Modifier = Modifier, content: @Composable () -> Unit) {
+    val duration = if (wide) 420 else 300
+    val progress = remember(wipeKey) { Animatable(0f) }
+    LaunchedEffect(wipeKey) {
+        progress.snapTo(0f)
+        delay((120 + seq * 110).toLong())
+        progress.animateTo(1f, tween(duration, easing = CubicBezierEasing(0f, .9f, .1f, 1f)))
+    }
+    Box(modifier.then(if (wide) Modifier.wipeClip(progress.value) else Modifier.wipeGrow(progress.value))) {
+        content()
+    }
+}
+
+private fun Modifier.wipeClip(progress: Float): Modifier = this
+    .drawWithContent {
+        clipRect(right = size.width * progress) { this@drawWithContent.drawContent() }
+    }
+    .graphicsLayer { translationX = -14.dp.toPx() * (1f - progress) }
+
+private fun Modifier.wipeGrow(progress: Float): Modifier = this.layout { measurable, constraints ->
+    val placeable = measurable.measure(constraints)
+    val w = (placeable.width * progress).toInt().coerceIn(0, placeable.width)
+    layout(w, placeable.height) { placeable.placeRelative(0, 0) }
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -44,19 +44,36 @@ the same motion the root stack uses to re-enter.
 
 The children are their own scroll region; the host does not move.
 
+## 4a. The trail
+
+A picked child doesn't just cascade its own children in — it also drops out of the band and
+settles beside the host as a **trail crumb**, the record of what's been picked so far. The
+trail starts at 24% of the frame, just clear of the host's right end, and runs left to right in
+pick order. Unlike every other pill (sized as a fraction of the screen), a crumb is sized by its
+own content, with a 56dp floor so a short label like `ls` doesn't shrink-wrap smaller than
+everything around it. Tapping a crumb pops the trail back to just before it and re-opens that
+pill's own band — each level is its own fresh cascade, never more pills piled onto the one
+before it.
+
 ## 5. Motion
 
 | | |
 | --- | --- |
-| Slide the stack away | 420ms, `cubic-bezier(.3, .05, .2, 1)` |
-| Host drop | 420ms, `cubic-bezier(0, .9, .1, 1)` |
-| Child turn | 520ms |
+| Slide the stack away | 140ms, linear |
+| Host drop | 140ms, linear |
+| Child turn (swing) | 173ms, linear |
 | Lift | final 10% of the turn |
-| Cascade | strictly sequential — 520ms per step |
+| Cascade | strictly sequential — 173ms per step |
 | Host rests at | 34% of the frame |
 | Child pill | 34% wide, 30% in |
+| Trail starts at | 24% of the frame |
+| Trail crumb | content-sized, 56dp floor |
 | Overhang | 62dp past the left edge |
 | Row pitch | 20dp |
+| Pick grows to | 1.15× before settling back to 1× |
+
+Every motion in the menu is **linear** — there is no easing curve anywhere; an eased pill reads
+as a bug at this speed.
 
 A child begins **exactly behind the pill before it** — the first behind the host, on the host's
 row — so it is invisible at rest. It turns a full **360°** hinged on one end:
@@ -68,11 +85,15 @@ Strictly sequential: a pill does not begin until the one before it has landed. W
 are parked on the host's row underneath it — they do not exist on screen until their turn.
 
 **Every change of stack is animated.** A pill never appears or vanishes on the spot; dismissing
-a host slides the stack back in from off the left edge, 70ms apart.
+a host plays the exact same arrival as opening the app — one column, one clock, no per-pill
+stagger, because returning to a stack and arriving at it are the same event.
 
 Nothing fades. A pill is always fully opaque, even mid-turn. There are no hover or press states
 — state is structural: a pill is a hue, or ink (open), or a 14% wash (idle). On an ink ground
 that inverts: the open pill is yellow with an ink end-cap, so it never disappears into the page.
+
+Animation state is remembered against a node's **id**, never its index — a contextual root can
+appear or vanish between frames, and a keyed-by-position pill would inherit a stranger's motion.
 
 ## 6. Scale
 

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -61,4 +61,14 @@ binary now, run in the Termux environment below, not a reimplementation of one.
     file handler, so other apps can open files in it.
 -   **Files:** the Files screen browses a sandboxed filesystem rooted at the app's private
     storage (the `vfs` command's backing store) — separate from the real Termux filesystem the
-    shell operates on.
+    shell operates on. A folder is a capsule: tap one to expand it while its siblings squish
+    into thin coloured rods beside it, two levels deep before you're looking at a plain list of
+    what's inside. From there: search across the whole sandbox, sort by name or newest, tap
+    **Select** to multi-select for a batch Move, Copy, Share or Delete, rename anything in place,
+    and a folder that's mostly photos renders itself as a thumbnail grid automatically — no
+    manual list/grid toggle. **Storage** breaks down what's using space by type, and names the
+    largest files.
+-   **The Guide:** the command picker (reached the same way as the Files screen) has its own
+    **THE GUIDE** pill in the top corner, opening a chaptered glossary of real commands paired
+    with invented, Hitchhiker's-Guide-style definitions — reading material, not another way to
+    run something.


### PR DESCRIPTION
## Summary

**License**
- Replaces the blank `LICENSE` file with the verbatim GNU GPLv3 text (copyright line filled in for `HereLiesAz`).
- An empty license file didn't actually clear up the project's licensing situation: the app still bundles GPL-licensed code (`managers/flashlight/`, by Merbin J Anselm) and Apache-2.0 code (`util/libsuperuser/`, by Jorrit "Chainfire" Jongma), and depends on Termux's own `terminal-emulator`/`termux-shared` modules — leaving the project's own terms undefined while distributing GPL code is a worse position than picking real ones. GPLv3 was chosen as the least-surprising match for what's already embedded.

**File manager** (`ui/files/`)
- Replaces the flat breadcrumb-list `FilesScreen` with the redesign's nested-accordion capsule browser: tap a folder to expand it while its siblings squish into thin coloured rods beside it, two accordion levels deep before a plain record of what's inside.
- Adds an inline expandable search capsule (real recursive search via `VfsManager`), Name/Newest sort, a multi-select mode with real Move/Copy/Share/Delete batch actions, in-place rename, an automatic media grid for image-heavy folders, and a Storage screen breaking down the sandbox by content type.
- Move/Copy get a real destination picker (`FolderPicker.kt`) with the redesign's tile-expands/siblings-shrink-to-rod/balloon-return morph animation.
- `VfsManager` gains recursive search, a `storageByType()` aggregator, and File-based operation overloads to support the accordion's multi-depth navigation.

**Guide** (`ui/guide/`)
- Adds a chaptered glossary of real commands paired with invented, Hitchhiker's-Guide-style definitions (`GuideContent.kt`) and a reader (`GuideReaderScreen.kt`) with the redesign's wipe-on transition.
- Nested inside the existing command-picker Guide screen via a pill, rather than replacing it or competing for the same name.

**Docs**
- Resyncs `docs/DESIGN.md`'s motion table to the menu's actual shipped values (140ms slide/drop, 173ms swing, linear easing) and documents the trail-crumb mechanic — both already true of `PillMenu.kt` but previously undocumented.
- Updates `README.md`/`USER_GUIDE.md` for the new features.

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlinAndroid` — succeeds, no new warnings
- [x] `./gradlew :composeApp:testPlaystoreDebugUnitTest` — succeeds
- [ ] Manual on-device verification of the file manager, folder picker, and Guide reader (no device available in this environment)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z
