### PR TITLE
Open the Files screen with the "pill becomes the page" transition

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Rect
 import androidx.core.content.FileProvider
 import androidx.core.content.edit
 import androidx.core.view.WindowInsetsCompat
@@ -44,8 +45,11 @@ import com.hereliesaz.hg2gui.ui.files.StorageStats
 import com.hereliesaz.hg2gui.ui.files.VfsEntry
 import com.hereliesaz.hg2gui.ui.files.VfsSearchResult
 import com.hereliesaz.hg2gui.ui.guide.CommandGuideScreen
+import com.hereliesaz.hg2gui.ui.menu.Azphalt
 import com.hereliesaz.hg2gui.ui.menu.CommandTree
 import com.hereliesaz.hg2gui.ui.menu.MenuNode
+import com.hereliesaz.hg2gui.ui.menu.PillWrapReveal
+import com.hereliesaz.hg2gui.ui.menu.PillWrapRevealState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -86,6 +90,24 @@ class TerminalActivity : ComponentActivity() {
             var fullscreen by remember { mutableStateOf(false) }
             var fontScalePercent by remember { mutableStateOf(100) }
             val scope = rememberCoroutineScope()
+
+            // "The pill becomes the page": the Files pill grows out around the screen edge,
+            // then the loop it closes floods with a vertical wipe that reveals the file
+            // explorer already open on its root - see PillWrapReveal.
+            val filesWrap = remember { PillWrapRevealState() }
+            var filesOrigin by remember { mutableStateOf(Rect.Zero) }
+            val filesHue = remember { Azphalt.hues[Azphalt.hueOf("/")] }
+            fun openFiles() {
+                filesWrap.origin = filesOrigin
+                screen = Screen.Files
+                scope.launch { filesWrap.open() }
+            }
+            fun closeFiles() {
+                scope.launch {
+                    filesWrap.close()
+                    screen = Screen.Terminal
+                }
+            }
 
             suspend fun vfsListDir(path: String): List<VfsEntry> = withContext(Dispatchers.IO) {
                 val dir = VfsManager.resolve(this@TerminalActivity, path) ?: return@withContext emptyList()
@@ -182,6 +204,7 @@ class TerminalActivity : ComponentActivity() {
 
             HG2GuiTheme(scale = fontScalePercent / 100f) {
                 val currentTree = tree
+                Box(Modifier.fillMaxSize()) {
                 when {
                     screen == Screen.Settings -> SettingsScreen(
                         fullscreen = fullscreen,
@@ -207,79 +230,6 @@ class TerminalActivity : ComponentActivity() {
                             }
                         },
                         onBack = { screen = Screen.Terminal }
-                    )
-
-                    screen == Screen.Files -> FilesScreen(
-                        fullscreen = fullscreen,
-                        listDir = { path -> vfsListDir(path) },
-                        search = { query -> vfsSearch(query) },
-                        storageStats = { vfsStorageStats() },
-                        onOpenFile = { path ->
-                            scope.launch {
-                                val file = withContext(Dispatchers.IO) {
-                                    VfsManager.resolve(this@TerminalActivity, path)
-                                }
-                                if (file != null) {
-                                    val intent = Intent(this@TerminalActivity, EditorActivity::class.java)
-                                    intent.putExtra(EditorActivity.PATH, file.absolutePath)
-                                    startActivity(intent)
-                                }
-                            }
-                        },
-                        onCreateFolder = { parentPath, name ->
-                            withContext(Dispatchers.IO) {
-                                VfsManager.resolve(this@TerminalActivity, parentPath)?.let { VfsManager.mkdir(it, name) }
-                            }
-                        },
-                        onCreateFile = { parentPath, name ->
-                            withContext(Dispatchers.IO) {
-                                VfsManager.resolve(this@TerminalActivity, parentPath)?.let { VfsManager.touch(it, name) }
-                            }
-                        },
-                        onDelete = { path ->
-                            withContext(Dispatchers.IO) {
-                                VfsManager.resolve(this@TerminalActivity, path)?.let { VfsManager.delete(it) }
-                            }
-                        },
-                        onRename = { path, newName ->
-                            withContext(Dispatchers.IO) {
-                                VfsManager.resolve(this@TerminalActivity, path)?.let { VfsManager.rename(it, newName) }
-                            }
-                        },
-                        onMove = { path, targetDirPath ->
-                            withContext(Dispatchers.IO) {
-                                val file = VfsManager.resolve(this@TerminalActivity, path)
-                                val target = VfsManager.resolve(this@TerminalActivity, targetDirPath)
-                                if (file != null && target != null) VfsManager.moveInto(file, target)
-                            }
-                        },
-                        onCopy = { path, targetDirPath ->
-                            withContext(Dispatchers.IO) {
-                                val file = VfsManager.resolve(this@TerminalActivity, path)
-                                val target = VfsManager.resolve(this@TerminalActivity, targetDirPath)
-                                if (file != null && target != null) VfsManager.copyInto(file, target)
-                            }
-                        },
-                        onShare = { path ->
-                            scope.launch {
-                                val file = withContext(Dispatchers.IO) {
-                                    VfsManager.resolve(this@TerminalActivity, path)
-                                }
-                                if (file != null && file.isFile) {
-                                    val uri = FileProvider.getUriForFile(this@TerminalActivity, GenericFileProvider.PROVIDER_NAME, file)
-                                    val intent = Intent(Intent.ACTION_SEND).apply {
-                                        type = "*/*"
-                                        putExtra(Intent.EXTRA_STREAM, uri)
-                                        addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                                    }
-                                    startActivity(Intent.createChooser(intent, "Share ${file.name}"))
-                                }
-                            }
-                        },
-                        onBack = { screen = Screen.Terminal },
-                        modifier = Modifier.then(
-                            if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars)
-                        )
                     )
 
                     sessions.isNotEmpty() && currentTree != null -> TerminalScreen(
@@ -316,7 +266,8 @@ class TerminalActivity : ComponentActivity() {
                         fullscreen = fullscreen,
                         onOpenSettings = { screen = Screen.Settings },
                         onOpenGuide = { screen = Screen.Guide },
-                        onOpenFiles = { screen = Screen.Files },
+                        onOpenFiles = { openFiles() },
+                        onFilesButtonPositioned = { filesOrigin = it },
                         onRun = { sessionId, line, onOutput, onNeedInput ->
                             val session = sessions.first { it.ui.id == sessionId }
                             session.engine.run(line, onNeedInput).collect { output -> onOutput(output) }
@@ -332,8 +283,86 @@ class TerminalActivity : ComponentActivity() {
                         Text("Loading…")
                     }
                 }
+
+                if (screen == Screen.Files || filesWrap.active) {
+                    PillWrapReveal(state = filesWrap, hue = filesHue) {
+                        FilesScreen(
+                            fullscreen = fullscreen,
+                            listDir = { path -> vfsListDir(path) },
+                            search = { query -> vfsSearch(query) },
+                            storageStats = { vfsStorageStats() },
+                            onOpenFile = { path ->
+                                scope.launch {
+                                    val file = withContext(Dispatchers.IO) {
+                                        VfsManager.resolve(this@TerminalActivity, path)
+                                    }
+                                    if (file != null) {
+                                        val intent = Intent(this@TerminalActivity, EditorActivity::class.java)
+                                        intent.putExtra(EditorActivity.PATH, file.absolutePath)
+                                        startActivity(intent)
+                                    }
+                                }
+                            },
+                            onCreateFolder = { parentPath, name ->
+                                withContext(Dispatchers.IO) {
+                                    VfsManager.resolve(this@TerminalActivity, parentPath)?.let { VfsManager.mkdir(it, name) }
+                                }
+                            },
+                            onCreateFile = { parentPath, name ->
+                                withContext(Dispatchers.IO) {
+                                    VfsManager.resolve(this@TerminalActivity, parentPath)?.let { VfsManager.touch(it, name) }
+                                }
+                            },
+                            onDelete = { path ->
+                                withContext(Dispatchers.IO) {
+                                    VfsManager.resolve(this@TerminalActivity, path)?.let { VfsManager.delete(it) }
+                                }
+                            },
+                            onRename = { path, newName ->
+                                withContext(Dispatchers.IO) {
+                                    VfsManager.resolve(this@TerminalActivity, path)?.let { VfsManager.rename(it, newName) }
+                                }
+                            },
+                            onMove = { path, targetDirPath ->
+                                withContext(Dispatchers.IO) {
+                                    val file = VfsManager.resolve(this@TerminalActivity, path)
+                                    val target = VfsManager.resolve(this@TerminalActivity, targetDirPath)
+                                    if (file != null && target != null) VfsManager.moveInto(file, target)
+                                }
+                            },
+                            onCopy = { path, targetDirPath ->
+                                withContext(Dispatchers.IO) {
+                                    val file = VfsManager.resolve(this@TerminalActivity, path)
+                                    val target = VfsManager.resolve(this@TerminalActivity, targetDirPath)
+                                    if (file != null && target != null) VfsManager.copyInto(file, target)
+                                }
+                            },
+                            onShare = { path ->
+                                scope.launch {
+                                    val file = withContext(Dispatchers.IO) {
+                                        VfsManager.resolve(this@TerminalActivity, path)
+                                    }
+                                    if (file != null && file.isFile) {
+                                        val uri = FileProvider.getUriForFile(this@TerminalActivity, GenericFileProvider.PROVIDER_NAME, file)
+                                        val intent = Intent(Intent.ACTION_SEND).apply {
+                                            type = "*/*"
+                                            putExtra(Intent.EXTRA_STREAM, uri)
+                                            addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                                        }
+                                        startActivity(Intent.createChooser(intent, "Share ${file.name}"))
+                                    }
+                                }
+                            },
+                            onBack = { closeFiles() },
+                            modifier = Modifier.then(
+                                if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars)
+                            )
+                        )
+                    }
+                }
             }
         }
+    }
     }
 
     private fun applyFullscreen(fullscreen: Boolean) {

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
@@ -18,9 +18,12 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.layout.boundsInRoot
+import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
@@ -50,6 +53,7 @@ fun TerminalScreen(
     onOpenSettings: () -> Unit,
     onOpenGuide: () -> Unit,
     onOpenFiles: () -> Unit,
+    onFilesButtonPositioned: (Rect) -> Unit = {},
     onRun: suspend (
         sessionId: String,
         line: String,
@@ -158,6 +162,7 @@ fun TerminalScreen(
             onOpenSettings = onOpenSettings,
             onOpenGuide = onOpenGuide,
             onOpenFiles = onOpenFiles,
+            onFilesButtonPositioned = onFilesButtonPositioned,
             onPick = onSessionPick,
             onNew = onNewSession,
             onClose = onCloseSession
@@ -334,6 +339,7 @@ private fun SessionTabs(
     onOpenSettings: () -> Unit,
     onOpenGuide: () -> Unit,
     onOpenFiles: () -> Unit,
+    onFilesButtonPositioned: (Rect) -> Unit,
     onPick: (String) -> Unit,
     onNew: () -> Unit,
     onClose: (String) -> Unit
@@ -397,15 +403,15 @@ private fun SessionTabs(
         }
         Box(
             Modifier
-                .size(22.dp)
                 .clip(RoundedCornerShape(percent = 50))
-                .background(Azphalt.Ink.copy(alpha = .14f))
-                .clickable(onClick = onOpenFiles),
-            contentAlignment = Alignment.Center
+                .background(Azphalt.hues[Azphalt.hueOf("/")])
+                .onGloballyPositioned { onFilesButtonPositioned(it.boundsInRoot()) }
+                .clickable(onClick = onOpenFiles)
+                .padding(horizontal = 10.dp, vertical = 5.dp)
         ) {
             Text(
-                "F",
-                style = MaterialTheme.typography.titleMedium.copy(color = Azphalt.Ink, fontSize = 11.sp, fontWeight = FontWeight.Black)
+                "FILES",
+                style = MaterialTheme.typography.titleMedium.copy(color = Azphalt.White, fontSize = 8.sp, fontWeight = FontWeight.Black)
             )
         }
         Box(

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FilesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FilesScreen.kt
@@ -2,6 +2,9 @@
 
 package com.hereliesaz.hg2gui.ui.files
 
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.combinedClickable
@@ -97,6 +100,12 @@ fun FilesScreen(
 
     var storage by remember { mutableStateOf<StorageStats?>(null) }
 
+    // The frame around the wrap-reveal that opened this screen already carries the "screen
+    // arriving" beat - this is the header/footer chrome's own arrival on top of that: the top
+    // bar drops in from above the top edge, the bottom bar pops up from below the bottom edge.
+    val chromeIn = remember { Animatable(0f) }
+    LaunchedEffect(Unit) { chromeIn.animateTo(1f, tween(360, easing = CubicBezierEasing(0f, .9f, .1f, 1f))) }
+
     val scope = rememberCoroutineScope()
     fun refresh() { refreshTick++ }
 
@@ -171,7 +180,9 @@ fun FilesScreen(
             .background(PageYellow)
             .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
     ) {
-        // --- Header ---------------------------------------------------------------------
+        // --- Header --------------------------------------------------------------------
+        // Dropped in from above the top edge as one unit, rather than appearing in place.
+        Column(Modifier.offset(y = (-90).dp * (1f - chromeIn.value))) {
         Row(
             Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -180,7 +191,14 @@ fun FilesScreen(
             if (selectMode) {
                 Chip("‹ ${selected.size} SELECTED", onClick = { selectMode = false; selected = emptySet() })
             } else {
-                Chip("‹ CLOSE", onClick = onBack)
+                Row(horizontalArrangement = Arrangement.spacedBy(8.dp), verticalAlignment = Alignment.CenterVertically) {
+                    Chip("‹ CLOSE", onClick = onBack)
+                    // Drops in alongside the rest of the header, but only once there is
+                    // somewhere to go up to - the root level has no parent of its own.
+                    if (openChain.isNotEmpty()) {
+                        Chip("…", background = Azphalt.Yellow, foreground = Azphalt.Ink, onClick = { openChain = openChain.dropLast(1) })
+                    }
+                }
                 val count = rootEntries.size + l0Entries.size + recordEntries.size
                 Chip("$count THINGS HERE", filled = false, clickable = false)
             }
@@ -254,6 +272,7 @@ fun FilesScreen(
                     }
                 }
             }
+        }
         }
 
         // --- Content ------------------------------------------------------------------------
@@ -367,8 +386,12 @@ fun FilesScreen(
         }
 
         // --- Bottom bar ---------------------------------------------------------------------
+        // Popped up from below the bottom edge, mirroring the header's drop from above.
         Row(
-            Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 14.dp),
+            Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 20.dp, vertical = 14.dp)
+                .offset(y = 90.dp * (1f - chromeIn.value)),
             horizontalArrangement = Arrangement.spacedBy(6.dp)
         ) {
             if (selectMode) {

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillWrapReveal.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillWrapReveal.kt
@@ -1,0 +1,105 @@
+package com.hereliesaz.hg2gui.ui.menu
+
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.drawWithContent
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+
+/*
+ * "The pill becomes the page": a pill runs out around the edge of the screen, closing the loop,
+ * then the space it enclosed floods with a vertical wipe that reveals whatever it opened - the
+ * design source's own name for this two-beat move is "run the perimeter" + "flood". Simplified
+ * here (as elsewhere in this app) from the source's multi-stage keyframe sequence into one
+ * continuous rect interpolation plus a clip-based wipe, rather than four separate animated edges.
+ */
+
+private val WRAP_EASE = CubicBezierEasing(0f, .9f, .1f, 1f)
+private const val WRAP_MS = 640
+private const val FLOOD_MS = 420
+private val BORDER_WIDTH = 3.dp
+
+class PillWrapRevealState {
+    var origin: Rect by mutableStateOf(Rect.Zero)
+    var active: Boolean by mutableStateOf(false)
+    val wrap = Animatable(0f)
+    val flood = Animatable(0f)
+
+    suspend fun open() {
+        active = true
+        wrap.snapTo(0f)
+        flood.snapTo(0f)
+        wrap.animateTo(1f, tween(WRAP_MS, easing = WRAP_EASE))
+        flood.animateTo(1f, tween(FLOOD_MS, easing = WRAP_EASE))
+    }
+
+    suspend fun close() {
+        flood.animateTo(0f, tween(FLOOD_MS, easing = WRAP_EASE))
+        wrap.animateTo(0f, tween(WRAP_MS, easing = WRAP_EASE))
+        active = false
+    }
+}
+
+private fun lerp(a: Float, b: Float, t: Float) = a + (b - a) * t
+
+/**
+ * Renders [content] inside a rect that grows from [PillWrapRevealState.origin] (the pill that
+ * opened it) out to the full available space, framed by a [hue]-coloured border, revealed by a
+ * bottom-to-top wipe once the loop has closed. Renders nothing while [state] is inactive.
+ */
+@Composable
+fun PillWrapReveal(state: PillWrapRevealState, hue: Color, content: @Composable () -> Unit) {
+    if (!state.active) return
+    val density = LocalDensity.current
+    BoxWithConstraints(Modifier.fillMaxSize()) {
+        val fullW = with(density) { maxWidth.toPx() }
+        val fullH = with(density) { maxHeight.toPx() }
+        val o = state.origin
+        val w = state.wrap.value
+        val left = lerp(o.left, 0f, w)
+        val top = lerp(o.top, 0f, w)
+        val right = lerp(o.right, fullW, w)
+        val bottom = lerp(o.bottom, fullH, w)
+        val curW = right - left
+        val curH = bottom - top
+        val corner = lerp(minOf(o.width, o.height) / 2f, 0f, w)
+
+        with(density) {
+            Box(
+                Modifier
+                    .offset { IntOffset(left.toInt(), top.toInt()) }
+                    .size(curW.toDp(), curH.toDp())
+                    .clip(RoundedCornerShape(corner.toDp()))
+            ) {
+                Box(
+                    Modifier
+                        .fillMaxSize()
+                        .drawWithContent {
+                            clipRect(top = size.height * (1f - state.flood.value)) {
+                                this@drawWithContent.drawContent()
+                            }
+                        }
+                ) { content() }
+                Box(Modifier.fillMaxSize().border(BORDER_WIDTH, hue, RoundedCornerShape(corner.toDp())))
+            }
+        }
+    }
+}

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -95,6 +95,24 @@ that inverts: the open pill is yellow with an ink end-cap, so it never disappear
 Animation state is remembered against a node's **id**, never its index — a contextual root can
 appear or vanish between frames, and a keyed-by-position pill would inherit a stranger's motion.
 
+## 5a. The pill becomes the page
+
+Opening the Files screen doesn't cut to a new screen — the **FILES** pill itself grows into it.
+Simplified from the source spec's own multi-stage "stretch, snap, fly, run the perimeter, flood"
+sequence into two continuous beats (`PillWrapReveal.kt`):
+
+| | |
+| --- | --- |
+| Wrap | 640ms, `cubic-bezier(0,.9,.1,1)` — the pill's own rect interpolates out to the full screen, closing a hue-coloured frame around it |
+| Flood | 420ms, same easing — a bottom-to-top wipe reveals the file explorer already inside the closed frame |
+| Header drop | 360ms — the top bar (close/parent/count chips) drops in from above the top edge |
+| Footer pop | 360ms, same clock — the bottom action bar rises in from below the bottom edge |
+
+The frame's border stays visible for as long as the screen is open, tying its hue back to
+whichever pill opened it. Closing plays the same two beats in reverse. Whenever there's a level
+open above the root, a yellow **…** chip drops in with the rest of the header — tap it to close
+the deepest open level, same as tapping its own capsule again.
+
 ## 6. Scale
 
 The menu's size isn't fixed — the shell categories are discovered live from what's actually

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -59,15 +59,17 @@ binary now, run in the Termux environment below, not a reimplementation of one.
 -   **Editor:** `edit <file>` opens the in-terminal editor — `ShellSession` has no pty, so a
     real terminal editor would render garbled if run through it. It also registers as a text
     file handler, so other apps can open files in it.
--   **Files:** the Files screen browses a sandboxed filesystem rooted at the app's private
-    storage (the `vfs` command's backing store) — separate from the real Termux filesystem the
-    shell operates on. A folder is a capsule: tap one to expand it while its siblings squish
-    into thin coloured rods beside it, two levels deep before you're looking at a plain list of
-    what's inside. From there: search across the whole sandbox, sort by name or newest, tap
-    **Select** to multi-select for a batch Move, Copy, Share or Delete, rename anything in place,
-    and a folder that's mostly photos renders itself as a thumbnail grid automatically — no
-    manual list/grid toggle. **Storage** breaks down what's using space by type, and names the
-    largest files.
+-   **Files:** tap the **FILES** pill and it grows into the whole screen — the pill's own colour
+    runs out around the edge, closes into a frame, and a vertical wipe reveals the file explorer
+    already inside it, browsing a sandboxed filesystem rooted at the app's private storage (the
+    `vfs` command's backing store) — separate from the real Termux filesystem the shell operates
+    on. A folder is a capsule: tap one to expand it while its siblings squish into thin coloured
+    rods beside it, two levels deep before you're looking at a plain list of what's inside; a
+    yellow **…** chip drops in next to **Close** whenever there's a level open, to step back up
+    one. From there: search across the whole sandbox, sort by name or newest, tap **Select** to
+    multi-select for a batch Move, Copy, Share or Delete, rename anything in place, and a folder
+    that's mostly photos renders itself as a thumbnail grid automatically — no manual list/grid
+    toggle. **Storage** breaks down what's using space by type, and names the largest files.
 -   **The Guide:** the command picker (reached the same way as the Files screen) has its own
     **THE GUIDE** pill in the top corner, opening a chaptered glossary of real commands paired
     with invented, Hitchhiker's-Guide-style definitions — reading material, not another way to


### PR DESCRIPTION
## Summary

- The **FILES** pill no longer hard-cuts to the file explorer: it grows out around the screen edge, closes into a hue-framed loop, then a bottom-to-top wipe reveals the explorer already open — the design source's own "run the perimeter" + "flood" beats, simplified into one continuous rect animation plus a clip wipe (`ui/menu/PillWrapReveal.kt`).
- The header (Close/parent/count chips) drops in from above the top edge and the bottom action bar pops up from below, in step with the reveal.
- A yellow **…** chip drops in next to **Close** whenever a level is open in the nested-accordion browser, to step back up one — there was previously no explicit "go up" affordance.
- `docs/DESIGN.md` and `docs/USER_GUIDE.md` updated to describe the new transition and the parent chip.

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlinAndroid`
- [x] `./gradlew :composeApp:testPlaystoreDebugUnitTest`
- [ ] Manual verification on-device (no device available in this environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Introduce a pill-to-page animated transition when opening and closing the Files screen, and update surrounding UI and docs to support it.

New Features:
- Add a pill wrap/flood animation component that expands the FILES pill into a framed full-screen page and reverses on close.
- Animate the Files screen header and footer chrome so they drop in from the top and rise from the bottom in sync with the transition.
- Add a parent-level "…" chip in the Files header to step back up one level in the nested file browser.

Enhancements:
- Restyle the Files pill in the terminal session tabs as a labeled FILES button that provides its geometry for use in the transition.
- Keep the Files explorer mounted under the animated frame while the pill transition runs, rather than cutting directly between screens.

Documentation:
- Update user and design documentation to describe the new Files pill transition, header/footer motion, and parent navigation chip.