### PR TITLE
Reject a signing keystore whose alias has no private key

### DIFF
--- a/.github/actions/android-keystore/action.yml
+++ b/.github/actions/android-keystore/action.yml
@@ -241,6 +241,20 @@ runs:
           exit 1
         fi
 
+        # `keytool -list -v -alias` succeeds and prints an identical-looking certificate
+        # block for a trustedCertEntry (a certificate with no private key behind it) as
+        # for a PrivateKeyEntry - the alias/fingerprint checks above cannot tell them
+        # apart. Signing needs the private key: with a trustedCertEntry, Gradle's bundle
+        # signing task has nothing to sign with, yet still reports success and produces
+        # a bundle with no signature block - a failure this action would otherwise miss
+        # entirely, surfacing only ~5 minutes later as "contains no signature block" once
+        # the whole release build has already run.
+        entry_type=$(grep -m1 '^Entry type:' "$work/cert.txt" | sed 's/^Entry type: *//' | tr -d '\r')
+        if [ "$entry_type" != "PrivateKeyEntry" ]; then
+          echo "::error::Alias '$KEY_ALIAS' is a $entry_type, not a PrivateKeyEntry - there is no private key behind it, so nothing can actually sign with it. If this came from KEYSTORE_RAW, that secret holds a certificate-only keystore; if assembled from KEYSTORE_PRIVATE/KEYSTORE_RSA + KEYSTORE_PUBLIC, double-check KEYSTORE_PUBLIC actually holds the certificate that matches the private key (not KEYSTORE_CHAIN's intermediate/root certs) and that the private key secret is the real signing key, not a placeholder."
+          exit 1
+        fi
+
         norm() { tr -d ': \t' | tr '[:lower:]' '[:upper:]'; }
         actual_sha256=$(grep -m1 'SHA256:' "$work/cert.txt" | sed 's/.*SHA256: *//' | tr -d '\r')
         actual_sha1=$(grep -m1 'SHA1:' "$work/cert.txt" | sed 's/.*SHA1: *//' | tr -d '\r')


### PR DESCRIPTION
## Summary

`version.properties`'s `versionBuild`/`versionPatch` have never auto-incremented because the "Release to Play" workflow (`release-play.yml`) has never actually finished a release — all 12 manual runs I checked (Aug 6–8) fail at the same step, `Check bundle signature`, with `contains no signature block — the bundle is unsigned`. The final version-bump-and-commit step is downstream of a successful publish, so it's never been reached.

I reproduced the signing pipeline locally with an equivalent hand-built keystore (assembled the same way `.github/actions/android-keystore` does from key+cert PEM secrets) and it signed the bundle correctly — so `composeApp/build.gradle.kts`'s signing config wiring isn't the bug.

The gap is in the keystore verification itself: `keytool -list -v -keystore ... -alias "$KEY_ALIAS"` succeeds and prints an identical-looking certificate block whether the alias is a `PrivateKeyEntry` **or** a `trustedCertEntry` (a certificate with no private key attached) — the existing checks (alias exists, fingerprint matches) can't tell them apart. If the alias only has a certificate, Gradle's bundle-signing task has nothing to sign with, but doesn't fail — it just produces an unsigned `.aab` while the whole build still reports `BUILD SUCCESSFUL`.

## Changes

- `.github/actions/android-keystore/action.yml`: after the existing alias/fingerprint check, read `keytool`'s own `Entry type:` field and fail immediately (with a message pointing at which secret is likely wrong) if it isn't `PrivateKeyEntry`. Verified the `keytool -list -v` output format for both entry types locally.

This turns a failure that previously only surfaced ~5 minutes in, after a full release build, into an immediate, clear one at keystore-prep time. It doesn't fix whichever repo secret is actually wrong — only someone with access to those secrets can do that — but it should tell you decisively which one on the next "Release to Play" run.

## Test plan

- [x] Reproduced the signing pipeline locally with a hand-assembled keystore (mirroring the composite action's own PEM-assembly path) — confirmed `.aab` gets a real `META-INF/*.RSA` signature block.
- [x] Confirmed locally that `keytool -list -v`'s `Entry type:` line correctly reads `PrivateKeyEntry` vs `trustedCertEntry` for the two cases.
- [x] `action.yml` re-parses as valid YAML; the embedded bash passes `bash -n`.
- [ ] A real "Release to Play" run against the actual repo secrets (needed to confirm which secret is actually the problem).

---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Bug Fixes:
- Ensure the Android keystore composite action rejects aliases that point to certificate-only entries, preventing unsigned bundles from being produced.