### PR TITLE
Cherry-pick AzphaltTokens, SplashScreen, and dev DesignSystemScreen

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/SplashScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/SplashScreen.kt
@@ -1,0 +1,74 @@
+package com.hereliesaz.hg2gui.ui
+
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.hg2gui.ui.theme.AzphaltColors
+import com.hereliesaz.hg2gui.ui.theme.AzphaltMotion
+import kotlinx.coroutines.delay
+
+/*
+ * Launch sequence: pops up, counts down "4", then "2", then a thumbs-up, then hands off to the
+ * app. Timing/easing reuses the system's one curve (see AzphaltMotion) so it reads as the same
+ * hand as everywhere else in the app, just larger.
+ *
+ * `stageContent` is a seam for the real gesture artwork (the app already has a static logo) —
+ * default content is a plain glyph sequence so this compiles and plays standalone until that
+ * asset is wired in.
+ */
+private enum class SplashStage { HIDDEN, FOUR, TWO, THUMBS_UP, DONE }
+
+@Composable
+fun SplashScreen(
+    onFinish: () -> Unit,
+    modifier: Modifier = Modifier,
+    stageContent: @Composable (stage: Int) -> Unit = { s -> DefaultGlyph(s) }
+) {
+    var stage by remember { mutableStateOf(SplashStage.HIDDEN) }
+    val scale = remember { Animatable(0.6f) }
+
+    LaunchedEffect(Unit) {
+        stage = SplashStage.FOUR
+        scale.animateTo(1f, tween(AzphaltMotion.UNFOLD_MS, easing = AzphaltMotion.unfoldEasing))
+        delay(650)
+        stage = SplashStage.TWO
+        delay(650)
+        stage = SplashStage.THUMBS_UP
+        delay(750)
+        stage = SplashStage.DONE
+        onFinish()
+    }
+
+    Box(modifier.fillMaxSize().background(AzphaltColors.Ink), contentAlignment = Alignment.Center) {
+        AnimatedContent(targetState = stage, label = "splash-stage") { s ->
+            Box(Modifier.graphicsLayer { scaleX = scale.value; scaleY = scale.value }) {
+                when (s) {
+                    SplashStage.FOUR -> stageContent(4)
+                    SplashStage.TWO -> stageContent(2)
+                    SplashStage.THUMBS_UP -> stageContent(1)
+                    else -> {}
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun DefaultGlyph(stage: Int) {
+    Text(
+        text = if (stage == 1) "\uD83D\uDC4D" else stage.toString(),
+        color = AzphaltColors.Yellow,
+        fontSize = 96.sp,
+        fontWeight = FontWeight.Black
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/dev/DesignSystemScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/dev/DesignSystemScreen.kt
@@ -1,0 +1,61 @@
+package com.hereliesaz.hg2gui.ui.dev
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.hg2gui.ui.theme.AzphaltColors
+
+/*
+ * Dev-only specimen sheet: capsule anatomy, palette, type scale, and a jump list to every real
+ * surface in the app. Not a shipped user screen — mirrors what the HG2Gui style-guide / surfaces
+ * DCs show in the design tool, kept here as a single reference rather than four near-duplicate
+ * screens. Gate this behind a debug build flag before shipping.
+ */
+@Composable
+fun DesignSystemScreen(surfaces: List<Pair<String, () -> Unit>>, modifier: Modifier = Modifier) {
+    LazyColumn(modifier.fillMaxSize().background(AzphaltColors.page).padding(20.dp),
+        verticalArrangement = Arrangement.spacedBy(28.dp)) {
+        item { Eyebrow("01 — Palette") }
+        item {
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                AzphaltColors.hues.forEach { hue ->
+                    Box(Modifier.size(28.dp).clip(RoundedCornerShape(50)).background(hue))
+                }
+            }
+        }
+        item { Eyebrow("02 — Capsule") }
+        item {
+            Row(Modifier.clip(RoundedCornerShape(50)).background(AzphaltColors.hues[2])
+                .padding(start = 14.dp, end = 6.dp, top = 6.dp, bottom = 6.dp)) {
+                Text("EXAMPLE", color = AzphaltColors.White, fontSize = 11.sp,
+                    fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em)
+            }
+        }
+        item { Eyebrow("03 — Type") }
+        item { Text("DISPLAY 900", color = AzphaltColors.Ink, fontSize = 40.sp, fontWeight = FontWeight.Black) }
+        item { Text("Body 600 sentence case, the only lowercase in the system.",
+            color = AzphaltColors.Ink.copy(alpha = .78f), fontSize = 15.sp) }
+        item { Eyebrow("04 — Surfaces") }
+        items(surfaces) { (label, go) ->
+            Text(label.uppercase(), color = AzphaltColors.Ink, fontSize = 14.sp, fontWeight = FontWeight.ExtraBold,
+                modifier = Modifier.clickable(onClick = go).padding(vertical = 8.dp))
+        }
+    }
+}
+
+@Composable
+private fun Eyebrow(text: String) {
+    Text(text, color = AzphaltColors.Ink.copy(alpha = .72f), fontSize = 11.sp,
+        fontWeight = FontWeight.ExtraBold, letterSpacing = 0.28.em)
+}

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/theme/AzphaltTokens.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/theme/AzphaltTokens.kt
@@ -1,0 +1,97 @@
+package com.hereliesaz.hg2gui.ui.theme
+
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+
+/*
+ * Design tokens ported 1:1 from the Azphalt capsule style guide (see docs/DESIGN.md / the
+ * HG2Gui style-guide DC). PillMenu.kt keeps its own local `Azphalt` object for now — these are
+ * the same numbers, exposed as a proper token set for screens outside the menu (Files, the
+ * command reference reader, the splash) and for anything that wants to override a slice of the
+ * palette per category via [LocalAzphaltPalette].
+ */
+object AzphaltColors {
+    val Ink = Color(0xFF1E1A17)
+    val Yellow = Color(0xFFE8C81E)
+    val YellowFold = Color(0xFFD9B615)
+    val White = Color(0xFFFFFFFF)
+
+    // Fixed assignment order: violet, cyan, teal, green, amber, orange, red, magenta, purple, blue.
+    val hues = listOf(
+        Color(0xFF6B4FBB), Color(0xFF2FA9C4), Color(0xFF1F9E86), Color(0xFF5AAE34),
+        Color(0xFFD9A21C), Color(0xFFD9762A), Color(0xFFC6392F), Color(0xFFB03A6E),
+        Color(0xFF8E4FA8), Color(0xFF2E6FB7)
+    )
+    val hueCaps = listOf(
+        Color(0xFF4B3489), Color(0xFF1F7B90), Color(0xFF137060), Color(0xFF3E7D22),
+        Color(0xFFA2760F), Color(0xFFA6551A), Color(0xFF93251D), Color(0xFF7F2A4D),
+        Color(0xFF653578), Color(0xFF1E4E85)
+    )
+
+    // Semantic overrides — hue alone carries no meaning, these five do.
+    val Acquire = Color(0xFFC6392F) // red — primary / run
+    val Done = Color(0xFF1F9E86)    // teal — acquired / receipts
+    val Selected = Ink              // selected / open
+    val IdleWash = Ink.copy(alpha = 0.14f)
+
+    val page: Brush = Brush.linearGradient(0f to Yellow, 0.5f to YellowFold, 1f to Yellow)
+
+    /** Deterministic hue assignment by hashing an identifier — never by hand. */
+    fun hueOf(id: String): Int = (id.hashCode().let { if (it < 0) -it else it }) % hues.size
+}
+
+object AzphaltType {
+    val displayTracking = (-0.03).em
+    val capsuleLabelTracking = 0.09.em
+    val eyebrowTracking = 0.28.em
+    val microTracking = 0.18.em
+
+    val displaySize = 54.sp
+    val titleSize = 22.sp
+    val eyebrowSize = 11.sp
+    val microSize = 9.sp
+    val bodySize = 15.sp
+    val capsuleLabelSize = 11.sp
+}
+
+object AzphaltSpacing {
+    val capsuleGap = 9.dp
+    val sectionGap = 76.dp
+    val sidePadding = 44.dp
+    val recordRadius = 26.dp
+    val noteRadius = 20.dp
+    val previewRadius = 18.dp
+    val pillRadius = 999.dp
+    val pillHeight = 17.dp
+    val rowPitch = 20.dp
+}
+
+object AzphaltMotion {
+    // Fast-out, long-settle — the one curve the whole system uses. Nothing else.
+    val unfoldEasing = CubicBezierEasing(0f, .9f, .1f, 1f)
+    const val UNFOLD_MS = 420
+    const val STAGGER_MS = 26
+    const val MAX_STAGGER_ROWS = 20
+}
+
+/** A palette slice that can be swapped per top-level category (e.g. mauve/gold/navy grounds). */
+data class AzphaltPalette(
+    val ground: Brush = AzphaltColors.page,
+    val ink: Color = AzphaltColors.Ink,
+    val accent: Color = AzphaltColors.hues[0],
+    val accentCap: Color = AzphaltColors.hueCaps[0]
+)
+
+val LocalAzphaltPalette = staticCompositionLocalOf { AzphaltPalette() }
+
+@Composable
+fun AzphaltCategoryTheme(palette: AzphaltPalette, content: @Composable () -> Unit) {
+    CompositionLocalProvider(LocalAzphaltPalette provides palette, content = content)
+}


### PR DESCRIPTION
## Summary

Cherry-picks the three genuinely useful pieces out of a larger design-system drop, leaving the rest behind:

- `ui/theme/AzphaltTokens.kt` — `AzphaltColors`/`AzphaltType`/`AzphaltSpacing`/`AzphaltMotion` token objects, values checked 1:1 against `PillMenu.kt`'s existing local `Azphalt` object, plus a `LocalAzphaltPalette` composition local for per-category palette overrides.
- `ui/SplashScreen.kt` — a countdown launch animation (4 → 2 → 👍) using a placeholder glyph.
- `ui/dev/DesignSystemScreen.kt` — a debug-only specimen sheet (palette/capsule/type swatches + jump list to real screens).

## What was left out

The rest of the drop wasn't applied: it didn't migrate `PillMenu.kt` off its own duplicate `Azphalt` object onto the new tokens, and nothing consumes `LocalAzphaltPalette`'s override mechanism yet.

## Not done here

None of these three are wired into navigation or an `Activity` — they're additive-only, unused code paths, added as a base for a future pass that actually migrates `PillMenu.kt` and wires the splash/dev screens in.

## Test plan

- [x] `./gradlew :composeApp:compileKotlinMetadata` succeeds
- [ ] Manual verification once wired into an Activity (not part of this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Introduce Azphalt design tokens, a splash screen, and a dev-only design system screen as foundational UI building blocks without wiring them into navigation yet.

New Features:
- Add Azphalt design token objects for colors, typography, spacing, motion, and category palettes with a composition local for palette overrides.
- Add a configurable splash screen composable that runs a branded countdown animation before handing off to the app.
- Add a developer-only design system screen that showcases palette, capsule styling, type scale, and provides a jump list to app surfaces.

Enhancements:
- Centralize Azphalt styling into reusable theme primitives to support future migration of existing screens.