### PR TITLE
Touch-native ssh pill + loopback MCP server, plus Termux resources doc

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.compose.compiler)
+    alias(libs.plugins.kotlinxSerialization)
 }
 
 val versionProps = Properties().apply {
@@ -69,15 +70,18 @@ kotlin {
             
             implementation(libs.okhttp)
             implementation(libs.comparestring2)
+            implementation(libs.kotlinx.serialization.json)
         }
         androidMain.dependencies {
             implementation(libs.androidx.appcompat)
             implementation(libs.androidx.core.ktx)
             implementation(libs.androidx.activity.compose)
+            implementation(libs.androidx.fragment)
+            implementation(libs.androidx.biometric)
             // localbroadcastmanager is legacy, but keeping for now
             implementation("androidx.localbroadcastmanager:localbroadcastmanager:1.1.0")
             implementation("com.google.android.material:material:1.14.0")
-            
+
             implementation(project(":terminal-emulator"))
             implementation(project(":termux-shared"))
         }

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -28,6 +28,17 @@
     <uses-permission android:name="android.permission.CALL_PHONE" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <!--
+      For McpServerService: a loopback-only JSON-RPC server an external AI agent can pair with
+      (see docs/HG2GUI_ARCHITECTURE.md). FOREGROUND_SERVICE_SPECIAL_USE is the closest fit
+      Android's typed foreground-service categories offer for "an on-device dev server the user
+      explicitly started" - there's no dedicated category for that. POST_NOTIFICATIONS is
+      requested at runtime, same lazy-request pattern as every other permission here, for the
+      ongoing notification the service shows while running.
+    -->
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_SPECIAL_USE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
 <!--
       No <permission> declarations here.
@@ -158,6 +169,21 @@
                 <data android:host="*" android:pathPattern=".*\.xml" android:scheme="file" />
             </intent-filter>
         </activity>
+
+        <!--
+          Loopback-only MCP server: binds 127.0.0.1, never LAN-exposed, gated by a pairing token
+          shown in McpServerScreen. Started/stopped explicitly by the user from Settings, never
+          on its own - a foreground service so the socket survives backgrounding while it runs,
+          with the ongoing notification Android requires for that.
+        -->
+        <service
+            android:name=".mcp.McpServerService"
+            android:exported="false"
+            android:foregroundServiceType="specialUse">
+            <property
+                android:name="android.app.PROPERTY_SPECIAL_USE_FGS_SUBTYPE"
+                android:value="Loopback MCP server for on-device AI agent pairing, user-started" />
+        </service>
 
     </application>
 

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -4,9 +4,9 @@ import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.biometric.BiometricPrompt
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -14,6 +14,7 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -22,21 +23,25 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Rect
+import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
 import androidx.core.content.edit
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+import androidx.fragment.app.FragmentActivity
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.hereliesaz.hg2gui.managers.ContactManager
 import com.hereliesaz.hg2gui.managers.SshPresets
 import com.hereliesaz.hg2gui.managers.TerminalHistoryEntry
 import com.hereliesaz.hg2gui.managers.VfsManager
+import com.hereliesaz.hg2gui.mcp.McpServerService
 import com.hereliesaz.hg2gui.terminal.Builtins
 import com.hereliesaz.hg2gui.terminal.DistroManager
 import com.hereliesaz.hg2gui.terminal.TerminalEngine
 import com.hereliesaz.hg2gui.util.GenericFileProvider
 import com.hereliesaz.hg2gui.util.Utils
 import com.hereliesaz.hg2gui.ui.HG2GuiTheme
+import com.hereliesaz.hg2gui.ui.McpServerScreen
 import com.hereliesaz.hg2gui.ui.SessionUiState
 import com.hereliesaz.hg2gui.ui.SettingsScreen
 import com.hereliesaz.hg2gui.ui.TerminalScreen
@@ -63,12 +68,30 @@ private const val PREFS_NAME = "hg2gui_prefs"
 private const val PREF_FULLSCREEN = "fullscreen"
 private const val PREF_FONT_SCALE_PERCENT = "font_scale_percent"
 
-class TerminalActivity : ComponentActivity() {
+class TerminalActivity : FragmentActivity() {
 
     private var sessions by mutableStateOf(listOf<TerminalSession>())
     private var nextSessionNumber = 2
 
-    private enum class Screen { Terminal, Settings, Guide, Files }
+    private enum class Screen { Terminal, Settings, Guide, Files, Mcp }
+
+    /** Confirms enabling shell.* MCP tools with a biometric prompt before persisting the flag -
+     *  this is the one switch that lets a paired agent run arbitrary commands, so it gets a
+     *  human-present confirmation step, not just a toggle. Disabling never needs this. */
+    private fun requestEnableShellExec() {
+        val executor = ContextCompat.getMainExecutor(this)
+        val prompt = BiometricPrompt(this, executor, object : BiometricPrompt.AuthenticationCallback() {
+            override fun onAuthenticationSucceeded(result: BiometricPrompt.AuthenticationResult) {
+                McpServerService.setShellExecEnabled(this@TerminalActivity, true)
+            }
+        })
+        val info = BiometricPrompt.PromptInfo.Builder()
+            .setTitle("Enable shell execution")
+            .setSubtitle("Lets a paired MCP client run real shell commands on this device")
+            .setNegativeButtonText("Cancel")
+            .build()
+        prompt.authenticate(info)
+    }
 
     private data class InitResult(
         val engine: TerminalEngine,
@@ -79,19 +102,39 @@ class TerminalActivity : ComponentActivity() {
 
     private val prefs: SharedPreferences by lazy { getSharedPreferences(PREFS_NAME, MODE_PRIVATE) }
 
+    // TerminalActivity is singleTop/intoExisting, so a notification tap while it's already
+    // running arrives via onNewIntent, not a fresh onCreate - this is how that reaches the
+    // Compose tree to switch screens, since setIntent() alone wouldn't trigger recomposition.
+    private var lastIntentExtra by mutableStateOf<Intent?>(null)
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        setIntent(intent)
+        lastIntentExtra = intent
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
         Utils.init(applicationContext)
+        McpServerService.ensureInitialized(applicationContext)
 
         setContent {
             var tree by remember { mutableStateOf<List<MenuNode>?>(null) }
             var activeSessionId by remember { mutableStateOf("") }
-            var screen by remember { mutableStateOf(Screen.Terminal) }
+            var screen by remember {
+                mutableStateOf(if (intent?.getBooleanExtra(McpServerService.EXTRA_OPEN_MCP, false) == true) Screen.Mcp else Screen.Terminal)
+            }
             var fullscreen by remember { mutableStateOf(false) }
             var fontScalePercent by remember { mutableStateOf(100) }
             val scope = rememberCoroutineScope()
+
+            LaunchedEffect(lastIntentExtra) {
+                if (lastIntentExtra?.getBooleanExtra(McpServerService.EXTRA_OPEN_MCP, false) == true) {
+                    screen = Screen.Mcp
+                }
+            }
 
             // "The pill becomes the page": the Files pill grows out around the screen edge,
             // then the loop it closes floods with a vertical wipe that reveals the file
@@ -219,8 +262,30 @@ class TerminalActivity : ComponentActivity() {
                             fontScalePercent = value
                             prefs.edit { putInt(PREF_FONT_SCALE_PERCENT, value) }
                         },
+                        onOpenMcpServer = { screen = Screen.Mcp },
                         onBack = { screen = Screen.Terminal }
                     )
+
+                    screen == Screen.Mcp -> {
+                        val running by McpServerService.isRunning.collectAsState()
+                        val token by McpServerService.token.collectAsState()
+                        val port by McpServerService.port.collectAsState()
+                        val shellExecEnabled by McpServerService.shellExecEnabled.collectAsState()
+                        McpServerScreen(
+                            fullscreen = fullscreen,
+                            running = running,
+                            port = port,
+                            token = token,
+                            shellExecEnabled = shellExecEnabled,
+                            onStart = { ContextCompat.startForegroundService(this@TerminalActivity, Intent(this@TerminalActivity, McpServerService::class.java)) },
+                            onStop = {
+                                startService(Intent(this@TerminalActivity, McpServerService::class.java).apply { action = McpServerService.ACTION_STOP })
+                            },
+                            onRequestShellExec = { requestEnableShellExec() },
+                            onDisableShellExec = { McpServerService.setShellExecEnabled(this@TerminalActivity, false) },
+                            onBack = { screen = Screen.Settings }
+                        )
+                    }
 
                     screen == Screen.Guide -> CommandGuideScreen(
                         tree = currentTree.orEmpty(),

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -28,6 +28,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.hereliesaz.hg2gui.managers.ContactManager
+import com.hereliesaz.hg2gui.managers.SshPresets
 import com.hereliesaz.hg2gui.managers.TerminalHistoryEntry
 import com.hereliesaz.hg2gui.managers.VfsManager
 import com.hereliesaz.hg2gui.terminal.Builtins
@@ -50,6 +51,7 @@ import com.hereliesaz.hg2gui.ui.menu.CommandTree
 import com.hereliesaz.hg2gui.ui.menu.MenuNode
 import com.hereliesaz.hg2gui.ui.menu.PillWrapReveal
 import com.hereliesaz.hg2gui.ui.menu.PillWrapRevealState
+import com.hereliesaz.hg2gui.ui.ssh.SshFlow
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -268,6 +270,17 @@ class TerminalActivity : ComponentActivity() {
                         onOpenGuide = { screen = Screen.Guide },
                         onOpenFiles = { openFiles() },
                         onFilesButtonPositioned = { filesOrigin = it },
+                        onWizard = { wizardId ->
+                            if (wizardId == "ssh-new") {
+                                sessions.firstOrNull { it.ui.id == activeSessionId }?.let { session ->
+                                    scope.launch {
+                                        SshFlow.runNewConnectionWizard(session.ui) { preset ->
+                                            withContext(Dispatchers.IO) { SshPresets.save(this@TerminalActivity, preset) }
+                                        }
+                                    }
+                                }
+                            }
+                        },
                         onRun = { sessionId, line, onOutput, onNeedInput ->
                             val session = sessions.first { it.ui.id == sessionId }
                             session.engine.run(line, onNeedInput).collect { output -> onOutput(output) }

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/SshPresets.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/SshPresets.kt
@@ -1,0 +1,55 @@
+package com.hereliesaz.hg2gui.managers
+
+import android.content.Context
+import androidx.core.content.edit
+import com.hereliesaz.hg2gui.ui.ssh.SshPreset
+
+private const val PREFS_NAME = "hg2gui_ssh_presets"
+private const val KEY_NAMES = "preset_names"
+
+/**
+ * Saved ssh connection presets, one flat SharedPreferences file rather than JSON - mirrors
+ * TerminalActivity's own settings pattern (a handful of scalars, no serialization needed).
+ * Preset names live in one Set<String>; each preset's fields are flat "$name.field" keys.
+ */
+object SshPresets {
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun list(context: Context): List<SshPreset> {
+        val p = prefs(context)
+        val names = p.getStringSet(KEY_NAMES, emptySet()).orEmpty()
+        return names.mapNotNull { name ->
+            val host = p.getString("$name.host", null) ?: return@mapNotNull null
+            val user = p.getString("$name.user", "") ?: ""
+            val port = p.getInt("$name.port", 22)
+            val keyPath = p.getString("$name.key", null)
+            SshPreset(name, user, host, port, keyPath)
+        }.sortedBy { it.name }
+    }
+
+    fun save(context: Context, preset: SshPreset) {
+        val p = prefs(context)
+        val names = p.getStringSet(KEY_NAMES, emptySet()).orEmpty() + preset.name
+        p.edit {
+            putStringSet(KEY_NAMES, names)
+            putString("${preset.name}.host", preset.host)
+            putString("${preset.name}.user", preset.user)
+            putInt("${preset.name}.port", preset.port)
+            if (preset.keyPath != null) putString("${preset.name}.key", preset.keyPath)
+            else remove("${preset.name}.key")
+        }
+    }
+
+    fun delete(context: Context, name: String) {
+        val p = prefs(context)
+        val names = p.getStringSet(KEY_NAMES, emptySet()).orEmpty() - name
+        p.edit {
+            putStringSet(KEY_NAMES, names)
+            remove("$name.host")
+            remove("$name.user")
+            remove("$name.port")
+            remove("$name.key")
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/mcp/McpJsonRpc.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/mcp/McpJsonRpc.kt
@@ -1,0 +1,122 @@
+package com.hereliesaz.hg2gui.mcp
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonObject
+
+/*
+ * Newline-delimited JSON-RPC 2.0 - the same per-line framing MCP's own stdio transport uses, so
+ * a thin adb-forward + stdio<->TCP relay could speak to a stock stdio MCP client later. Kept
+ * fully protocol-only and testable on its own: nothing here knows about VfsManager, ShellSession
+ * or the pairing token - McpServerService owns the socket/auth, McpTools owns what the tools
+ * actually do, this just owns the envelope and the method switch.
+ */
+
+@Serializable
+data class JsonRpcRequest(
+    val jsonrpc: String = "2.0",
+    val id: JsonElement? = null,
+    val method: String = "",
+    val params: JsonElement? = null
+)
+
+@Serializable
+data class JsonRpcError(val code: Int, val message: String)
+
+@Serializable
+data class JsonRpcResponse(
+    val jsonrpc: String = "2.0",
+    val id: JsonElement? = null,
+    val result: JsonElement? = null,
+    val error: JsonRpcError? = null
+)
+
+/** What a tool call resolved to - success carries its MCP `content`, failure a JSON-RPC error. */
+sealed interface ToolCallResult {
+    data class Success(val content: JsonElement) : ToolCallResult
+    data class Failure(val code: Int, val message: String) : ToolCallResult
+}
+
+/** Implemented by McpTools; kept as an interface so McpJsonRpc doesn't need to know about
+ *  VfsManager/ShellSession/the shell-exec gate to be unit-tested. */
+interface McpToolProvider {
+    fun listTools(): JsonArray
+    suspend fun callTool(name: String, arguments: JsonObject?): ToolCallResult
+}
+
+object McpJsonRpc {
+    const val PARSE_ERROR = -32700
+    const val INVALID_REQUEST = -32600
+    const val METHOD_NOT_FOUND = -32601
+    const val INVALID_PARAMS = -32602
+    const val INTERNAL_ERROR = -32603
+    /** App-specific: a shell.* tool was called while the shell-exec toggle is off. Enforced here
+     *  in the request-handling path (McpTools.callTool), not just by what tools/list omits. */
+    const val SHELL_EXEC_DISABLED = -32001
+
+    val json = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    /** Parses one line, dispatches it, and serializes the reply - never throws: a malformed
+     *  line becomes a Parse error response, same as any other JSON-RPC failure mode. */
+    suspend fun handleLine(line: String, tools: McpToolProvider): String {
+        val request = try {
+            json.decodeFromString(JsonRpcRequest.serializer(), line)
+        } catch (e: Exception) {
+            return json.encodeToString(
+                JsonRpcResponse.serializer(),
+                JsonRpcResponse(error = JsonRpcError(PARSE_ERROR, "Parse error: ${e.message}"))
+            )
+        }
+        val response = dispatch(request, tools)
+        return json.encodeToString(JsonRpcResponse.serializer(), response)
+    }
+
+    suspend fun dispatch(request: JsonRpcRequest, tools: McpToolProvider): JsonRpcResponse {
+        val response = when (request.method) {
+            "initialize" -> JsonRpcResponse(id = request.id, result = buildJsonObject {
+                put("protocolVersion", "2025-06-18")
+                putJsonObject("capabilities") { putJsonObject("tools") {} }
+                putJsonObject("serverInfo") {
+                    put("name", "hg2gui")
+                    put("version", "1.0.0")
+                }
+            })
+
+            "tools/list" -> JsonRpcResponse(id = request.id, result = buildJsonObject {
+                put("tools", tools.listTools())
+            })
+
+            "tools/call" -> {
+                val params = request.params as? JsonObject
+                val name = (params?.get("name") as? JsonPrimitive)?.content
+                if (name == null) {
+                    JsonRpcResponse(id = request.id, error = JsonRpcError(INVALID_PARAMS, "Missing tool name"))
+                } else {
+                    val arguments = params["arguments"] as? JsonObject
+                    when (val result = tools.callTool(name, arguments)) {
+                        is ToolCallResult.Success -> JsonRpcResponse(id = request.id, result = buildJsonObject {
+                            put("content", result.content)
+                            put("isError", false)
+                        })
+                        is ToolCallResult.Failure -> JsonRpcResponse(
+                            id = request.id,
+                            error = JsonRpcError(result.code, result.message)
+                        )
+                    }
+                }
+            }
+
+            else -> JsonRpcResponse(
+                id = request.id,
+                error = JsonRpcError(METHOD_NOT_FOUND, "Unknown method: ${request.method}")
+            )
+        }
+        return response
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/mcp/McpServerService.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/mcp/McpServerService.kt
@@ -1,0 +1,235 @@
+package com.hereliesaz.hg2gui.mcp
+
+import android.app.Notification
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.app.Service
+import android.content.Context
+import android.content.Intent
+import android.os.Build
+import android.os.IBinder
+import androidx.core.app.NotificationCompat
+import androidx.core.content.edit
+import com.hereliesaz.hg2gui.TerminalActivity
+import com.hereliesaz.hg2gui.terminal.TerminalEngine
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.io.OutputStreamWriter
+import java.net.InetAddress
+import java.net.ServerSocket
+import java.net.Socket
+import java.security.SecureRandom
+
+private const val PREFS_NAME = "hg2gui_mcp_prefs"
+private const val PREF_SHELL_EXEC_ENABLED = "shell_exec_enabled"
+private const val CHANNEL_ID = "mcp_server"
+private const val NOTIFICATION_ID = 4201
+private const val DEFAULT_PORT = 4827
+
+/**
+ * A loopback-only JSON-RPC 2.0 server (newline-delimited, matching MCP's own stdio framing) an
+ * external AI agent can pair with to drive HG2Gui's sandboxed filesystem and, once separately
+ * enabled, its real shell - see McpJsonRpc/McpTools for the protocol and tool surface, and
+ * McpServerScreen for the UI this is started/stopped from. Foreground so the socket survives
+ * backgrounding while running; started only by explicit user action, never on its own.
+ */
+class McpServerService : Service() {
+
+    companion object {
+        val isRunning = MutableStateFlow(false)
+        // Memory-only: regenerated fresh on every server start, never persisted or logged - a
+        // loopback socket is reachable by any app on the device, not just via `adb forward`, so
+        // this token is load-bearing against other installed apps, not just network defense.
+        val token = MutableStateFlow<String?>(null)
+        val port = MutableStateFlow(DEFAULT_PORT)
+
+        private var shellExecFlow: MutableStateFlow<Boolean>? = null
+
+        /** Must be called once (TerminalActivity.onCreate) before any UI reads [shellExecEnabled]
+         *  or McpTools is constructed, so the persisted value is loaded before first use. */
+        fun ensureInitialized(context: Context) {
+            if (shellExecFlow == null) {
+                shellExecFlow = MutableStateFlow(readShellExecPref(context))
+            }
+        }
+
+        val shellExecEnabled: StateFlow<Boolean>
+            get() = shellExecFlow?.asStateFlow() ?: MutableStateFlow(false).asStateFlow()
+
+        /** Disabling never needs the biometric gate McpServerScreen applies to enabling - turning
+         *  capability off is always safe to do immediately. */
+        fun setShellExecEnabled(context: Context, enabled: Boolean) {
+            ensureInitialized(context)
+            shellExecFlow?.value = enabled
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE).edit {
+                putBoolean(PREF_SHELL_EXEC_ENABLED, enabled)
+            }
+        }
+
+        private fun readShellExecPref(context: Context): Boolean =
+            context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+                .getBoolean(PREF_SHELL_EXEC_ENABLED, false)
+
+        const val ACTION_START = "com.hereliesaz.hg2gui.mcp.START"
+        const val ACTION_STOP = "com.hereliesaz.hg2gui.mcp.STOP"
+        /** Set on the notification's tap intent; TerminalActivity reads this to land on the MCP
+         *  screen instead of the terminal when the user taps the running-server notification. */
+        const val EXTRA_OPEN_MCP = "open_mcp"
+
+        private fun generateToken(): String {
+            val bytes = ByteArray(24)
+            SecureRandom().nextBytes(bytes)
+            return bytes.joinToString("") { "%02x".format(it) }
+        }
+    }
+
+    private val scope = CoroutineScope(Dispatchers.IO + Job())
+    private var serverSocket: ServerSocket? = null
+    private var engine: TerminalEngine? = null
+    private var tools: McpTools? = null
+
+    override fun onBind(intent: Intent?): IBinder? = null
+
+    override fun onCreate() {
+        super.onCreate()
+        ensureInitialized(applicationContext)
+        createNotificationChannel()
+    }
+
+    override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
+        if (intent?.action == ACTION_STOP) {
+            stopServer()
+            stopSelf()
+        } else {
+            startServer()
+        }
+        return START_NOT_STICKY
+    }
+
+    private fun startServer() {
+        if (isRunning.value) return
+
+        val generatedToken = generateToken()
+        val builtEngine = TerminalEngine(applicationContext)
+        engine = builtEngine
+        tools = McpTools(applicationContext, shellExecEnabled, builtEngine)
+
+        startForeground(NOTIFICATION_ID, buildNotification())
+
+        scope.launch {
+            try {
+                val socket = ServerSocket(port.value, 0, InetAddress.getByName("127.0.0.1"))
+                serverSocket = socket
+                token.value = generatedToken
+                isRunning.value = true
+                while (isRunning.value) {
+                    val client = try {
+                        socket.accept()
+                    } catch (e: Exception) {
+                        break
+                    }
+                    handleClient(client, generatedToken)
+                }
+            } catch (e: Exception) {
+                // Most likely the port's already taken - fail closed, nothing partially running.
+                isRunning.value = false
+                token.value = null
+            }
+        }
+    }
+
+    /** One client at a time for v1: the accept loop above calls this inline rather than
+     *  launching it concurrently, so a second connection simply queues at the OS accept backlog
+     *  until this one closes. */
+    private suspend fun handleClient(client: Socket, expectedToken: String) {
+        client.use { socket ->
+            val reader = BufferedReader(InputStreamReader(socket.getInputStream()))
+            val writer = OutputStreamWriter(socket.getOutputStream())
+
+            // The pairing token rides as one bespoke line before any JSON-RPC traffic - layered
+            // under MCP's own newline-delimited framing rather than baked into it, so a stock
+            // stdio MCP client speaking plain JSON-RPC still works once paired.
+            val authLine = reader.readLine() ?: return
+            val authorized = try {
+                val obj = McpJsonRpc.json.parseToJsonElement(authLine) as? JsonObject
+                (obj?.get("token") as? JsonPrimitive)?.content == expectedToken
+            } catch (e: Exception) {
+                false
+            }
+
+            if (!authorized) {
+                writer.write("{\"authorized\":false}\n")
+                writer.flush()
+                return
+            }
+            writer.write("{\"authorized\":true}\n")
+            writer.flush()
+
+            val currentTools = tools ?: return
+            while (isRunning.value) {
+                val line = reader.readLine() ?: break
+                if (line.isBlank()) continue
+                val response = McpJsonRpc.handleLine(line, currentTools)
+                writer.write(response)
+                writer.write("\n")
+                writer.flush()
+            }
+        }
+    }
+
+    private fun stopServer() {
+        isRunning.value = false
+        try {
+            serverSocket?.close()
+        } catch (e: Exception) {
+            // Already closed or never opened - nothing to clean up.
+        }
+        serverSocket = null
+        engine?.destroy()
+        engine = null
+        tools = null
+        token.value = null
+        stopForeground(STOP_FOREGROUND_REMOVE)
+    }
+
+    override fun onDestroy() {
+        stopServer()
+        scope.cancel()
+        super.onDestroy()
+    }
+
+    private fun createNotificationChannel() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(CHANNEL_ID, "MCP server", NotificationManager.IMPORTANCE_LOW)
+            getSystemService(NotificationManager::class.java).createNotificationChannel(channel)
+        }
+    }
+
+    private fun buildNotification(): Notification {
+        val openIntent = Intent(this, TerminalActivity::class.java).apply {
+            putExtra(EXTRA_OPEN_MCP, true)
+        }
+        val pending = PendingIntent.getActivity(
+            this, 0, openIntent,
+            PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
+        )
+        return NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("HG2Gui MCP server running")
+            .setContentText("Loopback only — port ${port.value}")
+            .setSmallIcon(android.R.drawable.ic_menu_manage)
+            .setContentIntent(pending)
+            .setOngoing(true)
+            .build()
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/mcp/McpTools.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/mcp/McpTools.kt
@@ -1,0 +1,200 @@
+package com.hereliesaz.hg2gui.mcp
+
+import android.content.Context
+import com.hereliesaz.hg2gui.managers.VfsManager
+import com.hereliesaz.hg2gui.terminal.TerminalEngine
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.toList
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.addJsonObject
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import kotlinx.serialization.json.putJsonArray
+
+private fun JsonObject.stringArg(key: String): String? = (this[key] as? JsonPrimitive)?.content
+
+private fun textContent(text: String): JsonArray = buildJsonArray {
+    addJsonObject { put("type", "text"); put("text", text) }
+}
+
+/**
+ * The MCP tool registry: `vfs.*` wraps VfsManager 1:1 (sandbox-escape-proof for free, via
+ * VfsManager.resolve's own containment check), `shell.*` wraps a Service-owned TerminalEngine
+ * kept separate from the user's visible terminal tabs. The shell-exec gate is enforced here, in
+ * callTool - the one place every "tools/call" request for a shell.* name actually passes through
+ * - not just by what tools/list chooses to advertise (it always advertises both groups, for
+ * honest discoverability).
+ */
+class McpTools(
+    private val context: Context,
+    private val shellExecEnabled: StateFlow<Boolean>,
+    private val shellEngine: TerminalEngine
+) : McpToolProvider {
+
+    private data class ToolSpec(
+        val name: String,
+        val description: String,
+        val inputSchema: JsonObject,
+        val handler: suspend (JsonObject?) -> ToolCallResult
+    )
+
+    private fun schema(properties: JsonObject, required: List<String>): JsonObject = buildJsonObject {
+        put("type", "object")
+        put("properties", properties)
+        putJsonArray("required") { required.forEach { add(it) } }
+    }
+
+    private fun stringProp(description: String): JsonObject = buildJsonObject {
+        put("type", "string")
+        put("description", description)
+    }
+
+    private fun props(vararg pairs: Pair<String, JsonObject>): JsonObject = buildJsonObject {
+        pairs.forEach { (k, v) -> put(k, v) }
+    }
+
+    private val vfsTools: List<ToolSpec> = listOf(
+        ToolSpec(
+            "vfs.list",
+            "List entries (name, type) in a directory of HG2Gui's app-private sandboxed filesystem.",
+            schema(props("path" to stringProp("Directory path, e.g. \"/\" or \"/Downloads\"")), listOf("path"))
+        ) { args ->
+            val path = args?.stringArg("path")
+                ?: return@ToolSpec ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Missing \"path\"")
+            val dir = VfsManager.resolve(context, path)
+            if (dir == null || !dir.isDirectory) {
+                ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Not a directory: $path")
+            } else {
+                val listing = (dir.listFiles() ?: emptyArray())
+                    .sortedBy { it.name.lowercase() }
+                    .joinToString("\n") { "${if (it.isDirectory) "d" else "f"} ${it.name}" }
+                ToolCallResult.Success(textContent(listing.ifEmpty { "(empty)" }))
+            }
+        },
+        ToolSpec(
+            "vfs.read",
+            "Read a text file's contents from HG2Gui's app-private sandboxed filesystem.",
+            schema(props("path" to stringProp("File path, e.g. \"/notes.txt\"")), listOf("path"))
+        ) { args ->
+            val path = args?.stringArg("path")
+                ?: return@ToolSpec ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Missing \"path\"")
+            val text = VfsManager.readText(context, path)
+            if (text == null) ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Not a file: $path")
+            else ToolCallResult.Success(textContent(text))
+        },
+        ToolSpec(
+            "vfs.write",
+            "Write (overwrite or create) a text file in HG2Gui's app-private sandboxed filesystem.",
+            schema(
+                props(
+                    "path" to stringProp("File path, e.g. \"/notes.txt\""),
+                    "content" to stringProp("Text to write")
+                ),
+                listOf("path", "content")
+            )
+        ) { args ->
+            val path = args?.stringArg("path")
+                ?: return@ToolSpec ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Missing \"path\"")
+            val content = args.stringArg("content")
+                ?: return@ToolSpec ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Missing \"content\"")
+            if (VfsManager.writeText(context, path, content)) ToolCallResult.Success(textContent("ok"))
+            else ToolCallResult.Failure(McpJsonRpc.INTERNAL_ERROR, "Failed to write: $path")
+        },
+        ToolSpec(
+            "vfs.mkdir",
+            "Create a directory (and parents) in HG2Gui's app-private sandboxed filesystem.",
+            schema(props("path" to stringProp("Directory path to create")), listOf("path"))
+        ) { args ->
+            val path = args?.stringArg("path")
+                ?: return@ToolSpec ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Missing \"path\"")
+            if (VfsManager.mkdir(context, path)) ToolCallResult.Success(textContent("ok"))
+            else ToolCallResult.Failure(McpJsonRpc.INTERNAL_ERROR, "Failed to create: $path")
+        },
+        ToolSpec(
+            "vfs.delete",
+            "Delete a file or directory (recursively) in HG2Gui's app-private sandboxed filesystem.",
+            schema(props("path" to stringProp("Path to delete")), listOf("path"))
+        ) { args ->
+            val path = args?.stringArg("path")
+                ?: return@ToolSpec ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Missing \"path\"")
+            if (VfsManager.delete(context, path)) ToolCallResult.Success(textContent("ok"))
+            else ToolCallResult.Failure(McpJsonRpc.INTERNAL_ERROR, "Failed to delete: $path")
+        },
+        ToolSpec(
+            "vfs.move",
+            "Move/rename a file or directory within HG2Gui's app-private sandboxed filesystem.",
+            schema(
+                props("from" to stringProp("Source path"), "to" to stringProp("Destination path")),
+                listOf("from", "to")
+            )
+        ) { args ->
+            val from = args?.stringArg("from")
+                ?: return@ToolSpec ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Missing \"from\"")
+            val to = args.stringArg("to")
+                ?: return@ToolSpec ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Missing \"to\"")
+            if (VfsManager.move(context, from, to)) ToolCallResult.Success(textContent("ok"))
+            else ToolCallResult.Failure(McpJsonRpc.INTERNAL_ERROR, "Failed to move $from -> $to")
+        },
+        ToolSpec(
+            "vfs.copy",
+            "Copy a file or directory within HG2Gui's app-private sandboxed filesystem.",
+            schema(
+                props("from" to stringProp("Source path"), "to" to stringProp("Destination path")),
+                listOf("from", "to")
+            )
+        ) { args ->
+            val from = args?.stringArg("from")
+                ?: return@ToolSpec ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Missing \"from\"")
+            val to = args.stringArg("to")
+                ?: return@ToolSpec ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Missing \"to\"")
+            if (VfsManager.copy(context, from, to)) ToolCallResult.Success(textContent("ok"))
+            else ToolCallResult.Failure(McpJsonRpc.INTERNAL_ERROR, "Failed to copy $from -> $to")
+        }
+    )
+
+    private val shellTools: List<ToolSpec> = listOf(
+        ToolSpec(
+            "shell.exec",
+            "Run a shell command in HG2Gui's real Termux environment, on a session separate from " +
+                "the user's own visible terminal tabs. Disabled unless the user has explicitly " +
+                "enabled shell execution for the MCP server (a biometric-gated toggle in-app).",
+            schema(props("command" to stringProp("The shell command line to run")), listOf("command"))
+        ) { args ->
+            val command = args?.stringArg("command")
+                ?: return@ToolSpec ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Missing \"command\"")
+            // No human is necessarily present to answer an interactive prompt an agent-issued
+            // command triggers (ssh/sudo/etc.). TerminalEngine.run's onNeedInput must return a
+            // String, not the null ShellSession.exec() uses inline to mean "leave it stalled" -
+            // an empty answer is the closest equivalent this API can express; most confirmation
+            // prompts will reject it, and the idle-gap timeout reclaims control either way rather
+            // than hanging forever.
+            val output = shellEngine.run(command) { "" }.toList().lastOrNull().orEmpty()
+            ToolCallResult.Success(textContent(output))
+        }
+    )
+
+    private val allTools: List<ToolSpec> = vfsTools + shellTools
+
+    override fun listTools(): JsonArray = buildJsonArray {
+        allTools.forEach { tool ->
+            addJsonObject {
+                put("name", tool.name)
+                put("description", tool.description)
+                put("inputSchema", tool.inputSchema)
+            }
+        }
+    }
+
+    override suspend fun callTool(name: String, arguments: JsonObject?): ToolCallResult {
+        val tool = allTools.firstOrNull { it.name == name }
+            ?: return ToolCallResult.Failure(McpJsonRpc.METHOD_NOT_FOUND, "Unknown tool: $name")
+        if (name.startsWith("shell.") && !shellExecEnabled.value) {
+            return ToolCallResult.Failure(McpJsonRpc.SHELL_EXEC_DISABLED, "Shell execution is disabled")
+        }
+        return tool.handler(arguments)
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/McpServerScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/McpServerScreen.kt
@@ -1,0 +1,180 @@
+package com.hereliesaz.hg2gui.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.hg2gui.ui.menu.Azphalt
+
+private val PageYellow = Brush.linearGradient(
+    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
+)
+
+/**
+ * Server on/off, the shell-exec toggle (biometric-gated on enable - the actual BiometricPrompt
+ * call happens one layer up, in TerminalActivity, which owns the FragmentActivity context; this
+ * screen only ever asks for it via [onRequestShellExec] and shows whatever the caller decides),
+ * and a tap-to-reveal pairing token. Reached from Settings, not the terminal's own pill stack -
+ * this is device configuration, not something to run.
+ */
+@Composable
+fun McpServerScreen(
+    fullscreen: Boolean,
+    running: Boolean,
+    port: Int,
+    token: String?,
+    shellExecEnabled: Boolean,
+    onStart: () -> Unit,
+    onStop: () -> Unit,
+    onRequestShellExec: () -> Unit,
+    onDisableShellExec: () -> Unit,
+    onBack: () -> Unit
+) {
+    var tokenRevealed by remember { mutableStateOf(false) }
+
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(PageYellow)
+            .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
+    ) {
+        Row(
+            Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                Modifier
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.Ink)
+                    .clickable(onClick = onBack)
+                    .padding(horizontal = 14.dp, vertical = 7.dp)
+            ) {
+                Text(
+                    "‹ BACK", color = Azphalt.Yellow,
+                    fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+                )
+            }
+        }
+
+        Eyebrow("MCP server")
+
+        McpSettingRow(
+            title = "Server",
+            description = if (running)
+                "Running on 127.0.0.1:$port. An external AI agent can pair with it after " +
+                    "presenting the token below — nothing else on the network can reach it."
+            else
+                "Off. Starting it opens a loopback-only socket an AI agent can connect to " +
+                    "(e.g. via adb forward) to read/write this app's sandboxed files."
+        ) {
+            McpToggle(leftLabel = "OFF", rightLabel = "ON", rightSelected = running) { wantOn ->
+                if (wantOn) onStart() else onStop()
+            }
+        }
+
+        if (running) {
+            McpSettingRow(
+                title = "Pairing token",
+                description = "Required on every connection. Regenerated fresh each time the " +
+                    "server starts — never shown to anyone but you."
+            ) {
+                Box(
+                    Modifier
+                        .clip(RoundedCornerShape(percent = 50))
+                        .background(Azphalt.Ink)
+                        .clickable { tokenRevealed = !tokenRevealed }
+                        .padding(horizontal = 16.dp, vertical = 9.dp)
+                ) {
+                    Text(
+                        if (tokenRevealed) (token ?: "") else "•••• tap to reveal",
+                        color = Azphalt.Yellow, fontSize = 11.sp,
+                        fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+
+            McpSettingRow(
+                title = "Connect",
+                description = "adb forward tcp:$port tcp:$port"
+            ) {}
+
+            McpSettingRow(
+                title = "Shell execution",
+                description = if (shellExecEnabled)
+                    "Enabled — a paired agent can run real shell commands, on a session " +
+                        "separate from your own terminal tabs. Confirmed by biometric unlock."
+                else
+                    "Disabled by default. Enabling it requires a biometric confirmation — this " +
+                        "is the one switch in this screen that lets a connected agent run " +
+                        "arbitrary commands, not just read/write sandboxed files."
+            ) {
+                McpToggle(leftLabel = "OFF", rightLabel = "ON", rightSelected = shellExecEnabled) { wantOn ->
+                    if (wantOn) onRequestShellExec() else onDisableShellExec()
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun McpSettingRow(title: String, description: String, control: @Composable () -> Unit) {
+    Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp)) {
+        Text(
+            title.uppercase(), color = Azphalt.Ink,
+            fontSize = 13.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+        )
+        Text(
+            description, color = Azphalt.Ink.copy(alpha = .6f),
+            fontSize = 11.sp, lineHeight = 15.sp,
+            modifier = Modifier.padding(top = 4.dp, bottom = 10.dp)
+        )
+        control()
+    }
+}
+
+@Composable
+private fun McpToggle(
+    leftLabel: String,
+    rightLabel: String,
+    rightSelected: Boolean,
+    onSelectRight: (Boolean) -> Unit
+) {
+    Row(
+        Modifier
+            .clip(RoundedCornerShape(percent = 50))
+            .background(Azphalt.Ink.copy(alpha = .14f))
+            .padding(3.dp)
+    ) {
+        listOf(leftLabel to false, rightLabel to true).forEach { (label, selected) ->
+            val on = selected == rightSelected
+            Box(
+                Modifier
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(if (on) Azphalt.Ink else Color.Transparent)
+                    .clickable { onSelectRight(selected) }
+                    .padding(horizontal = 16.dp, vertical = 9.dp)
+            ) {
+                Text(
+                    label, color = if (on) Azphalt.Yellow else Azphalt.Ink.copy(alpha = .55f),
+                    fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+                )
+            }
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/SettingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/SettingsScreen.kt
@@ -32,6 +32,7 @@ fun SettingsScreen(
     onFullscreenChange: (Boolean) -> Unit,
     fontScalePercent: Int,
     onFontScalePercentChange: (Int) -> Unit,
+    onOpenMcpServer: () -> Unit,
     onBack: () -> Unit
 ) {
     Column(
@@ -87,6 +88,25 @@ fun SettingsScreen(
                 label = { "$it%" },
                 onChange = onFontScalePercentChange
             )
+        }
+
+        SettingRow(
+            title = "Developer",
+            description = "A loopback-only MCP server a paired AI agent can connect to, and the " +
+                "biometric-gated switch that lets it run real shell commands."
+        ) {
+            Box(
+                Modifier
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.Ink)
+                    .clickable(onClick = onOpenMcpServer)
+                    .padding(horizontal = 16.dp, vertical = 9.dp)
+            ) {
+                Text(
+                    "MCP SERVER ›", color = Azphalt.Yellow,
+                    fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+                )
+            }
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/menu/CommandTree.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/menu/CommandTree.kt
@@ -1,8 +1,10 @@
 package com.hereliesaz.hg2gui.ui.menu
 
 import android.content.Context
+import com.hereliesaz.hg2gui.managers.SshPresets
 import com.hereliesaz.hg2gui.terminal.DistroManager
 import com.hereliesaz.hg2gui.terminal.DpkgCatalog
+import com.hereliesaz.hg2gui.ui.ssh.SshFlow
 import java.io.File
 
 /*
@@ -112,6 +114,34 @@ object CommandTree {
         )
     }
 
+    /** The ssh pill: saved connection presets as picks, plus a "new…" leaf that launches the
+     *  host/user/port/key wizard (PillMenu's onWizard) instead of drilling into more pills - ssh
+     *  needs to accumulate several fields, which a plain pill chain can't do (see PillMenu.kt).
+     *  resolveChildren (not eager children) means a freshly-saved preset shows up the next time
+     *  this pill opens, without waiting on the next unrelated command's tree rebuild. */
+    private fun sshLeaf(context: Context): MenuNode = MenuNode(
+        id = "sh/ssh",
+        label = "ssh",
+        value = "ssh",
+        resolveChildren = {
+            val presets = SshPresets.list(context).map { p ->
+                MenuNode(
+                    id = "sh/ssh/preset/${p.name}",
+                    label = p.name,
+                    cap = "pick",
+                    value = SshFlow.argsFor(p.user, p.host, p.port, p.keyPath)
+                )
+            }
+            presets + MenuNode(
+                id = "sh/ssh/new",
+                label = "new…",
+                cap = "new",
+                emitsToken = false,
+                wizardId = "ssh-new"
+            )
+        }
+    )
+
     private fun shellLeaf(fullName: String, label: String, filePickerRoot: File): MenuNode {
         val hints = SHELL_HINTS[fullName].orEmpty().map { MenuNode("sh/$fullName/$it", it) }
         val children = hints + FileBrowser.pickerNode("sh/$fullName/file", filePickerRoot)
@@ -131,7 +161,7 @@ object CommandTree {
      * siblings count toward the "at least 2" threshold: a lone hyphenated name isn't worth a
      * parent of its own, and a name with no hyphen was never part of a family to begin with.
      */
-    private fun groupByFamily(names: List<String>, filePickerRoot: File): List<MenuNode> {
+    private fun groupByFamily(context: Context, names: List<String>, filePickerRoot: File): List<MenuNode> {
         val families = names.filter { it.contains('-') }
             .groupBy { it.substringBefore('-') }
             .filterValues { it.size >= 2 }
@@ -161,7 +191,7 @@ object CommandTree {
 
         for (name in names) {
             if (name in consumed) continue
-            nodes.add(shellLeaf(name, name, filePickerRoot))
+            nodes.add(if (name == "ssh") sshLeaf(context) else shellLeaf(name, name, filePickerRoot))
         }
 
         return nodes.sortedBy { it.label }
@@ -204,7 +234,7 @@ object CommandTree {
 
         return byCategory.entries.sortedBy { it.key }.map { (category, members) ->
             val capped = members.take(MAX_SHELL_ENTRIES)
-            val children = groupByFamily(capped, filePickerRoot) + if (members.size > capped.size) {
+            val children = groupByFamily(context, capped, filePickerRoot) + if (members.size > capped.size) {
                 listOf(
                     MenuNode(
                         id = "sh/$category/more",

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/terminal/ShellAliases.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/terminal/ShellAliases.kt
@@ -71,6 +71,11 @@ object ShellAliases {
 
     fun looksLikeYesNo(prompt: String): Boolean = YES_NO_PATTERN.containsMatchIn(prompt)
 
+    // Matches ssh/sudo/su's own prompt text: "password:", "Enter passphrase for key '...'", etc.
+    private val PASSWORD_PATTERN = Regex("""(?i)password\s*:|passphrase\s+for\s+key""")
+
+    fun looksLikePassword(prompt: String): Boolean = PASSWORD_PATTERN.containsMatchIn(prompt)
+
     /** Closest known command word to [failed], among alias keys/expansions plus [known] extras. */
     fun didYouMean(failed: String, known: List<String> = emptyList()): String? {
         if (failed.isBlank() || table.containsKey(failed)) return null

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
@@ -27,6 +27,8 @@ import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
@@ -54,6 +56,7 @@ fun TerminalScreen(
     onOpenGuide: () -> Unit,
     onOpenFiles: () -> Unit,
     onFilesButtonPositioned: (Rect) -> Unit = {},
+    onWizard: (wizardId: String) -> Unit = {},
     onRun: suspend (
         sessionId: String,
         line: String,
@@ -230,8 +233,15 @@ fun TerminalScreen(
                 // away instead of waiting for a separate tap on RUN - or, if a prompt is
                 // pending, sends the pick as that prompt's answer the same way.
                 if (isTerminal) executeCommand()
-            }
+            },
+            onWizard = onWizard
         )
+
+        // A password/passphrase prompt (ssh, sudo, su - anything ShellSession's own idle-gap
+        // detector catches) masks the free-text answer field the same way any password field
+        // would; a yes/no prompt never reaches here as text at all, it gets the Answer pill
+        // stack above instead, so no need to exclude it explicitly.
+        val maskInput = pendingPrompt != null && ShellAliases.looksLikePassword(pendingPrompt)
 
         CommandLine(
             tokens = active.tokens,
@@ -246,6 +256,7 @@ fun TerminalScreen(
             },
             runLabel = if (pendingPrompt != null) "SEND" else "RUN",
             enabled = pendingPrompt != null || (!active.running && (active.tokens.isNotEmpty() || active.inputText.isNotBlank())),
+            masked = maskInput,
             onRun = executeCommand
         )
 
@@ -451,7 +462,8 @@ private fun CommandLine(
     hint: String,
     enabled: Boolean,
     onRun: () -> Unit,
-    runLabel: String = "RUN"
+    runLabel: String = "RUN",
+    masked: Boolean = false
 ) {
     Column(Modifier.padding(horizontal = 20.dp).padding(top = 16.dp)) {
         Text(
@@ -505,6 +517,7 @@ private fun CommandLine(
                     ),
                     cursorBrush = SolidColor(Azphalt.Yellow),
                     singleLine = true,
+                    visualTransformation = if (masked) PasswordVisualTransformation() else VisualTransformation.None,
                     keyboardOptions = KeyboardOptions(imeAction = ImeAction.Go),
                     keyboardActions = KeyboardActions(onGo = { onRun() })
                 )

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -89,7 +89,12 @@ data class MenuNode(
     // False for purely navigational nodes (a "browse for a file" trigger, a directory on the way
     // to one) that should never themselves become part of the command line - only the leaf a
     // pick chain actually resolves to should.
-    val emitsToken: Boolean = true
+    val emitsToken: Boolean = true,
+    // Non-null for a pill that launches a multi-step UI-state wizard (e.g. the ssh "new…" leaf,
+    // which collects host/port/key through SessionUiState's prompt machinery) instead of
+    // contributing a token or drilling into more children. Picking it still settles into the
+    // trail like any other pick, but PillMenu calls onWizard instead of onRun for it.
+    val wizardId: String? = null
 )
 
 /** The literal command-line text this node contributes when picked, or null if it never does. */
@@ -111,7 +116,10 @@ fun PillMenu(
     // isTerminal is true only when this call reports a pick that just fully resolved a
     // parameter (nothing left to drill into) - the signal a caller needs to auto-run instead of
     // waiting for a separate confirmation.
-    onRun: (tokens: List<String>, isTerminal: Boolean) -> Unit = { _, _ -> }
+    onRun: (tokens: List<String>, isTerminal: Boolean) -> Unit = { _, _ -> },
+    // Called instead of onRun when the picked child has a wizardId - the caller owns whatever
+    // multi-step flow that id names.
+    onWizard: (wizardId: String) -> Unit = {}
 ) {
     var phase by remember { mutableStateOf<Phase>(Phase.Browsing) }
     // Everything picked below the root host. Each pick drops out of the band it was chosen
@@ -172,8 +180,12 @@ fun PillMenu(
                             children = effectiveChildren,
                             hueOwner = host.id,
                             onPick = { child ->
-                                tokens = (trail + child).mapNotNull { it.tokenValue() }
-                                onRun(tokens, child.isTerminal())
+                                if (child.wizardId != null) {
+                                    onWizard(child.wizardId)
+                                } else {
+                                    tokens = (trail + child).mapNotNull { it.tokenValue() }
+                                    onRun(tokens, child.isTerminal())
+                                }
                                 scope.launch {
                                     // Let the pick's own drop-and-grow finish, plus one beat to
                                     // settle, before swapping the band for its children - so the

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/ssh/SshFlow.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/ssh/SshFlow.kt
@@ -1,0 +1,68 @@
+package com.hereliesaz.hg2gui.ui.ssh
+
+import com.hereliesaz.hg2gui.ui.SessionUiState
+
+data class SshPreset(
+    val name: String,
+    val user: String,
+    val host: String,
+    val port: Int = 22,
+    val keyPath: String? = null
+)
+
+/**
+ * Drives the ssh "new…" pill: a short sequence of prompts reusing SessionUiState's existing
+ * awaitPromptAnswer/answerPrompt machinery (the same CompletableDeferred bridge ShellSession's
+ * own interactive stdin prompts use) as pure UI-state orchestration - no shell process involved
+ * until the assembled command is actually run.
+ */
+object SshFlow {
+    fun argsFor(user: String, host: String, port: Int, keyPath: String?): String {
+        val target = if (user.isNotBlank()) "$user@$host" else host
+        val parts = mutableListOf(target)
+        if (port != 22) parts += listOf("-p", port.toString())
+        if (keyPath != null) parts += listOf("-i", keyPath)
+        return parts.joinToString(" ")
+    }
+
+    fun buildCommand(user: String, host: String, port: Int, keyPath: String?): String =
+        "ssh " + argsFor(user, host, port, keyPath)
+
+    /**
+     * Collects host/user/port/key through sequential prompts, optionally saves the result as a
+     * preset, then writes the assembled command into the session's input field for the user to
+     * review and run themselves - there's no single well-defined "connection succeeded" moment
+     * to hook a save-preset step to after the fact, given how ShellSession's prompt detection
+     * works, so presets are offered up front instead.
+     */
+    suspend fun runNewConnectionWizard(
+        session: SessionUiState,
+        savePreset: suspend (SshPreset) -> Unit
+    ) {
+        val hostInput = session.awaitPromptAnswer("ssh — user@host (or just host)").trim()
+        if (hostInput.isEmpty()) return
+
+        val user: String
+        val host: String
+        if ("@" in hostInput) {
+            val (u, h) = hostInput.split("@", limit = 2)
+            user = u
+            host = h
+        } else {
+            host = hostInput
+            user = session.awaitPromptAnswer("ssh — username (blank = don't specify)").trim()
+        }
+
+        val port = session.awaitPromptAnswer("ssh — port (blank = 22)").trim().toIntOrNull() ?: 22
+        val keyPath = session.awaitPromptAnswer("ssh — private key path (blank = password auth)")
+            .trim().ifBlank { null }
+
+        val saveName = session.awaitPromptAnswer("Save as preset? (name, blank to skip)").trim()
+        if (saveName.isNotEmpty()) {
+            savePreset(SshPreset(saveName, user, host, port, keyPath))
+        }
+
+        session.tokens = emptyList()
+        session.inputText = buildCommand(user, host, port, keyPath)
+    }
+}

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -17,6 +17,14 @@ Before a bootstrap is installed, Shell offers exactly one pill: **`bootstrap`** 
 runs automatically on first launch, the same way the official Termux app installs itself before
 ever showing a prompt.
 
+One binary gets a dedicated pill instead of the generic hint/file-picker treatment: **`ssh`**
+(under Network) opens saved connection presets plus a **new…** pill that walks a short prompt
+sequence — host, user, port, an optional private key path, and an optional preset name to save
+it under — then drops the assembled `ssh` command onto the command line for you to review and
+run. Host-key confirmation and password/passphrase prompts surface through the same interactive-
+prompt mechanism every other command uses (a Yes/No Answer stack, or a masked free-text field for
+passwords) — nothing ssh-specific happens at the shell layer.
+
 ## Built-in commands
 
 These ten are the only commands HG2Gui itself implements — see `terminal/Builtins.kt`. Every

--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -73,6 +73,24 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
     children are resolved lazily from a real directory listing (`MenuNode.resolveChildren`),
     attached to `edit` and to every discovered shell binary.
 
+### 7. `McpServerService` and the `mcp` package (Kotlin, `androidMain`)
+*   **Role**: An optional, loopback-only JSON-RPC 2.0 server (`mcp/McpServerService.kt`) an
+    external AI agent can pair with — the app-embedded equivalent of a standalone Termux MCP
+    server. Started/stopped only by explicit user action from Settings → MCP server
+    (`ui/McpServerScreen.kt`), never on its own.
+*   **Protocol**: `mcp/McpJsonRpc.kt` frames messages newline-delimited, matching MCP's own stdio
+    transport, over a raw `ServerSocket` bound to `127.0.0.1` — never LAN-exposed. A pairing
+    token (generated fresh per server start, memory-only) is required as one bespoke line before
+    any JSON-RPC traffic is accepted.
+*   **Tools**: `mcp/McpTools.kt` exposes two groups. `vfs.*` (`list`/`read`/`write`/`mkdir`/
+    `delete`/`move`/`copy`) wraps `VfsManager` 1:1, inheriting its sandbox-escape-proof `resolve`
+    for free, and is available whenever the server is running. `shell.*` (`exec`) wraps a
+    Service-owned `TerminalEngine`, kept separate from the user's own visible terminal tabs, and
+    is gated behind a second, explicit toggle — off by default, and only enableable through a
+    `BiometricPrompt` confirmation (`TerminalActivity.requestEnableShellExec`). The gate is
+    enforced server-side, in `McpTools.callTool`, on every `shell.*` invocation — not just by
+    what `tools/list` chooses to advertise (it always advertises both groups).
+
 ## Data Flow
 1.  **Input**: The user taps `wifi`. No text is typed. Since `wifi` leaves no further
     parameters, it runs immediately on that tap.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -74,6 +74,11 @@ binary now, run in the Termux environment below, not a reimplementation of one.
     **THE GUIDE** pill in the top corner, opening a chaptered glossary of real commands paired
     with invented, Hitchhiker's-Guide-style definitions — reading material, not another way to
     run something.
+-   **SSH:** the `ssh` pill (under the Network shell category) opens your saved connections plus
+    a **new…** pill that asks for host, user, port and an optional key file one step at a time,
+    then hands you the assembled command to run. Host-key confirmation and password/passphrase
+    prompts work exactly like any other command's interactive prompts — a tap for yes/no, a
+    masked field for a password.
 
 ## Related Resources
 The shell is genuine Termux underneath, so third-party Termux material works here too:

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -74,3 +74,14 @@ binary now, run in the Termux environment below, not a reimplementation of one.
     **THE GUIDE** pill in the top corner, opening a chaptered glossary of real commands paired
     with invented, Hitchhiker's-Guide-style definitions — reading material, not another way to
     run something.
+
+## Related Resources
+The shell is genuine Termux underneath, so third-party Termux material works here too:
+
+-   [termux-scripts](https://github.com/schnatterer/termux-scripts) — shell scripts for backing
+    up and restoring Android apps over local, SSH, or cloud storage, with incremental encrypted
+    transfers.
+-   [termux.holehan.org](https://termux.holehan.org/) — an APT repository adding extra packages
+    (Hugo, sift) installable with `pkg install` once added as a source.
+-   [termux-commands-free](https://github.com/Mortarelplait/termux-commands-free) — a free
+    reference collection of 200+ Termux commands and tutorials, organized by category.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -79,6 +79,12 @@ binary now, run in the Termux environment below, not a reimplementation of one.
     then hands you the assembled command to run. Host-key confirmation and password/passphrase
     prompts work exactly like any other command's interactive prompts — a tap for yes/no, a
     masked field for a password.
+-   **MCP server:** Settings → **MCP SERVER** starts a loopback-only server (reachable via
+    `adb forward`, never over the network) that an external AI agent can pair with using a
+    pairing token shown on that screen, to read/write this app's sandboxed files. Running real
+    shell commands through it is a separate switch, off by default, that asks for a biometric
+    confirmation the first time you turn it on — the one setting here that lets a paired agent do
+    more than touch its own sandbox.
 
 ## Related Resources
 The shell is genuine Termux underneath, so third-party Termux material works here too:

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,8 @@ compose-multiplatform = "1.11.1"
 androidx-activityCompose = "1.13.0"
 androidx-appcompat = "1.7.1"
 androidx-core-ktx = "1.19.0"
+androidx-fragment = "1.8.9"
+androidx-biometric = "1.1.0"
 junit = "4.13.2"
 mockito = "5.23.0"
 okhttp = "5.4.0"
@@ -12,11 +14,14 @@ htmlcleaner = "2.29"
 jsonpath = "3.0.0"
 jsoup = "1.23.1"
 comparestring2 = "1.0.9"
+kotlinx-serialization-json = "1.9.0"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activityCompose" }
 androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version.ref = "androidx-appcompat" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "androidx-core-ktx" }
+androidx-fragment = { group = "androidx.fragment", name = "fragment-ktx", version.ref = "androidx-fragment" }
+androidx-biometric = { group = "androidx.biometric", name = "biometric", version.ref = "androidx-biometric" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 mockito-core = { group = "org.mockito", name = "mockito-core", version.ref = "mockito" }
 okhttp = { group = "com.squareup.okhttp3", name = "okhttp", version.ref = "okhttp" }
@@ -24,6 +29,7 @@ htmlcleaner = { group = "net.sourceforge.htmlcleaner", name = "htmlcleaner", ver
 json-path = { group = "com.jayway.jsonpath", name = "json-path", version.ref = "jsonpath" }
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 comparestring2 = { group = "it.andreuzzi", name = "CompareString2", version.ref = "comparestring2" }
+kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -32,3 +38,4 @@ jetbrainsCompose = { id = "org.jetbrains.compose", version.ref = "compose-multip
 compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinAndroid = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
+kotlinxSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary

Three changes landed on this branch across this session, in build order:

**Docs:** a "Related Resources" section in `docs/USER_GUIDE.md` linking to three third-party Termux resources, since the app's shell is a genuine Termux environment underneath ([termux-scripts](https://github.com/schnatterer/termux-scripts), [termux.holehan.org](https://termux.holehan.org/), [termux-commands-free](https://github.com/Mortarelplait/termux-commands-free)).

**SSH UI:** `ssh` gets a dedicated pill (under the Network shell category) instead of the generic shell-binary treatment — saved connection presets plus a "new…" pill that walks host/user/port/key through a short prompt sequence, then drops the assembled command on the line to run. Host-key confirmation and password/passphrase prompts reuse the existing interactive-prompt machinery unchanged; the only shell-layer addition is masking the free-text answer field when a prompt looks like a password. Introduces one small additive primitive — `MenuNode.wizardId` / `PillMenu`'s `onWizard` — for pills that need to collect several fields through sequential prompts instead of a single token.

**MCP server:** an external AI agent can pair with a loopback-only (`127.0.0.1`, never LAN-exposed) JSON-RPC 2.0 server, started/stopped explicitly from Settings → MCP server. Hand-rolled newline-delimited JSON-RPC over a raw socket, matching MCP's own stdio line framing, rather than the official SDK or ktor — the SDK's transports don't define the pairing-token handshake this needs anyway, and this avoids a network-stack dependency the codebase has otherwise avoided. Two tool groups: `vfs.*` wraps `VfsManager` 1:1 (sandbox-escape-proof for free) and is always available once the server runs; `shell.*` wraps a Service-owned `TerminalEngine` kept separate from the user's own terminal tabs, gated behind a second toggle enforced server-side on every call, only enableable through a `BiometricPrompt` confirmation.

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlinAndroid`
- [x] `./gradlew :composeApp:testPlaystoreDebugUnitTest`
- [ ] Manual on-device (no device available in this environment): ssh preset round-trips with password and key-file auth; MCP server pairs over `adb forward` and rejects `vfs.*`/`shell.*` calls without a valid token; `shell.*` stays rejected until the biometric-gated toggle is on

---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_