### PR TITLE
Add a self-scoped osint-lookup script to the bootstrap

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -206,6 +206,9 @@ class TerminalActivity : FragmentActivity() {
 
             LaunchedEffect(Unit) {
                 val built = withContext(Dispatchers.Default) {
+                    // A no-op before a bootstrap exists; picks up an install from before this
+                    // script existed too, not just a fresh one.
+                    DistroManager.ensureOsintTool(this@TerminalActivity)
                     val builtEngine = TerminalEngine(this@TerminalActivity)
                     val builtTree = CommandTree.from(this@TerminalActivity)
                     InitResult(
@@ -239,7 +242,10 @@ class TerminalActivity : FragmentActivity() {
                         if (i == entryId) e.copy(isRunning = false) else e
                     }
                     firstUi.running = false
-                    tree = withContext(Dispatchers.IO) { CommandTree.from(this@TerminalActivity) }
+                    tree = withContext(Dispatchers.IO) {
+                        DistroManager.ensureOsintTool(this@TerminalActivity)
+                        CommandTree.from(this@TerminalActivity)
+                    }
                 }
             }
 

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/DistroManager.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/DistroManager.kt
@@ -162,4 +162,68 @@ object DistroManager {
             }
         }
     }
+
+    private const val OSINT_SCRIPT_NAME = "osint-lookup"
+
+    /** Idempotent: a no-op before a bootstrap exists, and only writes once the script is
+     *  actually missing - called both right after a fresh bootstrap and on every launch
+     *  thereafter, so an install from before this script existed picks it up too. */
+    fun ensureOsintTool(context: Context) {
+        if (!isInstalled(context)) return
+        val prefix = prefixDir(context)
+        if (!File(prefix, "bin/$OSINT_SCRIPT_NAME").exists()) installOsintTool(prefix)
+    }
+
+    private fun installOsintTool(prefix: File) {
+        val script = File(prefix, "bin/$OSINT_SCRIPT_NAME")
+        val shebang = "#!${File(prefix, "bin/bash").absolutePath}\n"
+        script.writeText(shebang + OSINT_SCRIPT_BODY)
+        script.setExecutable(true)
+    }
+
+    // Self-scoped, read-only recon for a domain YOU name - your own domain, or one you have a
+    // legitimate reason to research (due diligence, checking your own exposure). Whois, DNS
+    // records, and certificate-transparency logs (crt.sh) are all passive lookups against
+    // publicly published data; nothing here scans, brute-forces, or contacts the target's own
+    // infrastructure. Not a tool for surveilling arbitrary third parties.
+    private const val OSINT_SCRIPT_BODY = """
+set -u
+target="${'$'}{1:-}"
+if [ -z "${'$'}target" ]; then
+  echo "usage: osint-lookup <domain>" >&2
+  exit 1
+fi
+
+echo "== whois: ${'$'}target =="
+if command -v whois >/dev/null 2>&1; then
+  whois "${'$'}target" 2>&1 | head -n 40
+else
+  echo "(whois not installed - pkg install whois)"
+fi
+
+echo
+echo "== DNS records: ${'$'}target =="
+if command -v dig >/dev/null 2>&1; then
+  for rtype in A AAAA MX TXT NS; do
+    echo "-- ${'$'}rtype --"
+    dig +short "${'$'}target" "${'$'}rtype"
+  done
+else
+  echo "(dig not installed - pkg install dnsutils)"
+fi
+
+echo
+echo "== certificate transparency (crt.sh): ${'$'}target =="
+if command -v curl >/dev/null 2>&1; then
+  if command -v jq >/dev/null 2>&1; then
+    curl -s "https://crt.sh/?q=%25.${'$'}target&output=json" | jq -r '.[].name_value' | sort -u | head -n 40
+  else
+    curl -s "https://crt.sh/?q=%25.${'$'}target&output=json" | head -c 2000
+    echo
+    echo "(install jq for readable output - pkg install jq)"
+  fi
+else
+  echo "(curl not installed - pkg install curl)"
+fi
+"""
 }

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/menu/CommandTree.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/menu/CommandTree.kt
@@ -40,7 +40,8 @@ object CommandTree {
         "ps" to listOf("-A"),
         "df" to listOf("-h"),
         "uname" to listOf("-a"),
-        "ping" to listOf("-c 4 1.1.1.1")
+        "ping" to listOf("-c 4 1.1.1.1"),
+        "osint-lookup" to listOf("example.com")
     )
 
     // A single category can carry far more names than the fan-out animation is built to show at

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -25,6 +25,12 @@ run. Host-key confirmation and password/passphrase prompts surface through the s
 prompt mechanism every other command uses (a Yes/No Answer stack, or a masked free-text field for
 passwords) — nothing ssh-specific happens at the shell layer.
 
+One more binary is installed by the app itself rather than `pkg`: **`osint-lookup <domain>`**,
+written into the bootstrap's `bin/` right after it installs (and backfilled on launch for an
+older install that predates it). Self-scoped, read-only reconnaissance — whois, DNS records, and
+a certificate-transparency search (crt.sh) — for a domain you name, not a generic scanner. See
+`docs/USER_GUIDE.md` for the full description.
+
 ## Built-in commands
 
 These ten are the only commands HG2Gui itself implements — see `terminal/Builtins.kt`. Every

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -85,6 +85,14 @@ binary now, run in the Termux environment below, not a reimplementation of one.
     shell commands through it is a separate switch, off by default, that asks for a biometric
     confirmation the first time you turn it on — the one setting here that lets a paired agent do
     more than touch its own sandbox.
+-   **osint-lookup:** installed automatically alongside the bootstrap, under Shell → Other (it
+    isn't part of any package, so it doesn't get a curated category). `osint-lookup <domain>`
+    runs whois, DNS records (A/AAAA/MX/TXT/NS) and a certificate-transparency search (crt.sh) for
+    a domain you name — your own, or one you have a legitimate reason to look up. All three are
+    passive lookups against publicly published data; it never scans, brute-forces or contacts the
+    target's own infrastructure, and it isn't a tool for looking up arbitrary third parties.
+    Missing tools (`whois`/`dig`/`curl`/`jq`) print a `pkg install` hint instead of failing
+    silently.
 
 ## Related Resources
 The shell is genuine Termux underneath, so third-party Termux material works here too:


### PR DESCRIPTION
## Summary

Adds `osint-lookup <domain>` as a shell script installed into the Termux bootstrap's `bin/` (right after a fresh bootstrap, and backfilled on launch for an install that predates this) — it shows up as an ordinary Shell pill the same way any other PATH binary does, no new Kotlin builtin or menu machinery needed.

**Scope, deliberately:** self-scoped, read-only reconnaissance for a domain the user names — their own domain, or one they have a legitimate reason to research (due diligence, checking their own exposure). It runs three passive lookups against publicly published data:
- `whois` for registration info
- DNS records (A/AAAA/MX/TXT/NS) via `dig`
- Certificate-transparency logs via crt.sh's public JSON API

It never scans, brute-forces, or actively contacts the target's own infrastructure, and isn't a generic scanner for arbitrary third parties. Missing tools (`whois`/`dig`/`curl`/`jq`) print a `pkg install` hint instead of failing silently.

## Changes

- `terminal/DistroManager.kt`: `ensureOsintTool(context)` (idempotent — a no-op before a bootstrap exists, only writes once) + the script body, shebang generated against the actual install path.
- `TerminalActivity.kt`: calls `ensureOsintTool` both after a fresh bootstrap and on every launch, so an existing install picks it up too.
- `ui/menu/CommandTree.kt`: `osint-lookup` gets a hint pill (`example.com`) via the existing `SHELL_HINTS` map, same as `ping`/`ls`/etc.
- `docs/COMMANDS.md`, `docs/USER_GUIDE.md`: describe it.

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlinAndroid`
- [x] `./gradlew :composeApp:testPlaystoreDebugUnitTest`
- [x] `bash -n` against the script body reconstructed from the Kotlin source (string-templated `$` escapes are easy to get wrong) — syntax valid
- [ ] Manual on-device (no device available in this environment): script appears as a pill after bootstrap, runs against a real domain, degrades gracefully with tools missing

---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Add a self-scoped, passive osint-lookup command to the Termux bootstrap and integrate it into the terminal UI and documentation.

New Features:
- Introduce an osint-lookup shell script installed into the Termux bootstrap for passive domain reconnaissance.

Enhancements:
- Ensure the osint-lookup script is idempotently installed both on fresh bootstraps and on existing installations at app launch.
- Add an example hint pill for osint-lookup in the shell command menu.

Documentation:
- Document the osint-lookup command, its scope, and usage in USER_GUIDE and COMMANDS documentation.