### PR TITLE
Gradle-driven versionBuild increment, plus Workflows/Blocks/AI chat

### DIFF
--- a/.github/workflows/release-play.yml
+++ b/.github/workflows/release-play.yml
@@ -77,8 +77,8 @@ jobs:
   build-publish:
     name: Build signed AAB${{ inputs.publish && ' + publish' || '' }}
     runs-on: ubuntu-latest
-    # contents: write so the consumed versionCode can be committed back — see
-    # the last step. Everything else here only talks to Google.
+    # contents: write so "Increment and push versionBuild" can commit and push the bumped
+    # version.properties. Everything else here only talks to Google.
     permissions:
       contents: write
     steps:
@@ -190,39 +190,25 @@ jobs:
           echo "PLAY_MAX_VERSION_CODE=$play_max" >> "$GITHUB_ENV"
           echo "Play API access OK — proceeding to build."
 
-      # composeApp/build.gradle.kts uses version.properties' versionBuild directly as
-      # versionCode (resolvedVersionCode = maxOf(buildNumber, legacyVersionCode + 1), no +1
-      # applied to buildNumber itself) - so the code this run would produce is exactly the
-      # committed value, not committed + 1. If that can't clear what Play already holds, the
-      # release is dead on arrival — Play accepts the upload and then refuses the rollout.
-      #
-      # The counter drifts by design: nothing commits version.properties back until the very
-      # last step of this job, so the file is stale the moment anything ships. `auto` therefore
-      # treats Play as the authority and takes the next code after whatever it holds, which
-      # cannot collide no matter how far behind the file is.
-      - name: Resolve the versionCode
+      # The actual increment lives in composeApp/build.gradle.kts's incrementVersionBuild task,
+      # not here - this step's only job is invoking it with what only CI knows (Play's current
+      # max) before bundleRelease ever runs, so version.properties is already bumped AND already
+      # pushed to master by the time compilation starts; the versionCode gets "solidified" into
+      # the AAB from a file that's already final, not one a later shell step reverse-engineers.
+      # strict mode omits playMaxVersionCode (defaults to 0 inside the task), so the task fails
+      # outright - nothing written, nothing pushed, nothing built - if the committed number alone
+      # wouldn't already clear Play.
+      - name: Increment and push versionBuild
         if: ${{ inputs.publish }}
         run: |
           set -euo pipefail
-          committed=$(grep -E '^versionBuild=' version.properties | cut -d= -f2 | tr -d '[:space:]')
-          play_max=${PLAY_MAX_VERSION_CODE:-0}
-          echo "version.properties versionBuild=$committed (this is the versionCode the build will actually produce)"
-          echo "Play's highest versionCode: $play_max"
-
-          if [ "$committed" -gt "$play_max" ]; then
-            echo "$committed clears Play. Building that."
-            exit 0
-          fi
-
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           if [ "${{ inputs.version_code_mode }}" = "strict" ]; then
-            echo "::error::versionCode $committed would not clear Play, which already has $play_max. Set versionBuild=$((play_max + 1)) in version.properties and commit, or re-run in auto mode."
-            exit 1
+            ./gradlew -q :composeApp:incrementVersionBuild -PversionCodeMode=strict
+          else
+            ./gradlew -q :composeApp:incrementVersionBuild -PversionCodeMode=auto -PplayMaxVersionCode="${PLAY_MAX_VERSION_CODE:-0}"
           fi
-
-          # Play is ahead of the file — take the next code after Play's.
-          next=$((play_max + 1))
-          sed -i "s/^versionBuild=.*/versionBuild=$next/" version.properties
-          echo "::notice::version.properties was behind Play ($committed vs $play_max). Building versionCode $next instead; it will be committed back after publishing."
 
       - name: Build signed release bundle
         env:
@@ -259,10 +245,11 @@ jobs:
           artifact: ${{ env.AAB_PATH }}
           expected-sha256: ${{ steps.keystore.outputs.sha256 }}
 
-      # Read AFTER "Resolve the versionCode" (which may have bumped version.properties on
-      # disk) and the build itself, so this matches the .aab's actual versionName/versionCode.
-      # Same marker-grep pattern as "Read application id" - Gradle/AGP can print other
-      # lines to stdout on a given invocation, so the command's whole output isn't trusted.
+      # Read AFTER "Increment and push versionBuild" (which already bumped version.properties,
+      # before the build even started) and the build itself, so this matches the .aab's actual
+      # versionName/versionCode. Same marker-grep pattern as "Read application id" - Gradle/AGP
+      # can print other lines to stdout on a given invocation, so the command's whole output
+      # isn't trusted.
       - name: Get app version
         run: |
           set -euo pipefail
@@ -331,46 +318,8 @@ jobs:
             echo "::warning::No draft tracks were set. Check the warnings above for which ones Play refused."
           fi
 
-      # The versionCode is now spent, but the increment only ever happened on
-      # this runner. Commit it so the repo tracks what actually shipped and the
-      # GitHub release tag (v<versionName>) keeps advancing too.
-      #
-      # Deliberately non-fatal: the bundle is already published, so a protected
-      # branch or a push race must not turn a successful release into a red run.
-      # If this fails, the next run's auto resolution reads the number from Play
-      # again and still can't collide — the commit is convergence, not
-      # correctness.
-      - name: Commit the versionCode that shipped
-        if: ${{ inputs.publish && steps.play.outputs.version-code != '' }}
-        continue-on-error: true
-        run: |
-          set -uo pipefail
-          published="${{ steps.play.outputs.version-code }}"
-          for attempt in 1 2 3; do
-            git fetch origin master --quiet || true
-            # The build mutated version.properties on disk; start from master, this repo's
-            # actual default branch (not main).
-            git reset --hard origin/master --quiet
-            current=$(grep -E '^versionBuild=' version.properties | cut -d= -f2 | tr -d '[:space:]')
-            if [ "$current" -ge "$published" ]; then
-              echo "master already has versionBuild=$current (>= $published) — nothing to commit."
-              exit 0
-            fi
-            sed -i "s/^versionBuild=.*/versionBuild=$published/" version.properties
-            git -c user.name="github-actions[bot]" \
-                -c user.email="41898282+github-actions[bot]@users.noreply.github.com" \
-                commit -q -am "chore: versionCode $published shipped to Play [skip ci]"
-            if git push --quiet origin HEAD:master; then
-              echo "Committed versionBuild=$published to master."
-              exit 0
-            fi
-            echo "Push attempt $attempt failed (master probably moved) — retrying."
-            sleep $((attempt * 3))
-          done
-          echo "::warning::Published versionCode $published but could not commit the bump to master. Set versionBuild=$published in version.properties by hand. Releases still work without it — auto mode reads the next code from Play."
-          {
-            echo "### Commit this by hand"
-            echo ""
-            echo "versionCode **$published** shipped, but the bump could not be pushed to \`master\`."
-            echo "Set \`versionBuild=$published\` in \`version.properties\`."
-          } >> "$GITHUB_STEP_SUMMARY"
+      # No separate "commit the versionCode that shipped" step - "Increment and push
+      # versionBuild" already committed and pushed this run's number to master before
+      # bundleRelease ever ran, so the repo is already converged with what got built (and, if
+      # publish succeeded, with what shipped) by the time this job finishes. Nothing left to
+      # reconcile after the fact.

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -17,7 +17,16 @@ val versionProps = Properties().apply {
 }
 
 val legacyVersionCode = 205
-val buildNumber = (project.findProperty("versionBuild")?.toString() ?: versionProps.getProperty("versionBuild", "0")).toInt()
+
+// versionBuild in version.properties is versionCode's single source of truth. This is a plain
+// read - incrementing it is a dedicated, standalone task (incrementVersionBuild, below), run as
+// its own separate, earlier Gradle invocation in CI, strictly before ./gradlew bundleRelease is
+// ever invoked. By the time this build configures, whatever's on disk (and already pushed to
+// master) is final. -PversionBuild=<n> remains an explicit override, used by merged-build.yml's
+// debug workflow with its own commit-count-derived number, independent of this file.
+val buildNumber = project.findProperty("versionBuild")?.toString()?.toIntOrNull()
+    ?: versionProps.getProperty("versionBuild", "0").toIntOrNull() ?: 0
+
 val resolvedVersionCode = maxOf(buildNumber, legacyVersionCode + 1)
 
 val resolvedVersionName = project.findProperty("versionName")?.toString() ?: String.format(
@@ -175,8 +184,8 @@ tasks.register("printApplicationId") {
 }
 
 // Same reasoning and marker-line convention as printApplicationId above. Read by
-// release-play.yml's "Get app version" step, run AFTER bundleRelease so these reflect the
-// version.properties value that build just incremented.
+// release-play.yml's "Get app version" step, run after incrementVersionBuild has already run
+// (and bundleRelease has run against that same, already-final value), so these match the .aab.
 tasks.register("printVersionName") {
     doLast {
         println("VERSION_NAME=$resolvedVersionName")
@@ -186,5 +195,81 @@ tasks.register("printVersionName") {
 tasks.register("printVersionCode") {
     doLast {
         println("VERSION_CODE=$resolvedVersionCode")
+    }
+}
+
+/**
+ * The ONLY place versionBuild is incremented - a standalone task, run as its own explicit,
+ * earlier CI step (release-play.yml's "Increment and push versionBuild"), strictly before
+ * ./gradlew bundleRelease is ever invoked. Reads the freshest committed version.properties
+ * (fetch + reset first, so a concurrent run's push isn't clobbered), decides the next number,
+ * writes it to disk, and commits + pushes it to master itself - "push to GitHub before
+ * compilation" is the literal requirement this satisfies. It is not a mutation buried in this
+ * script's configuration phase, and not a bash script wrapped around Gradle either: the decision
+ * of what the next number is, and the act of persisting it, both happen here.
+ *
+ * -PversionCodeMode=strict fails outright (nothing written, nothing pushed, nothing built) if
+ * the committed number wouldn't already clear Play's max. auto (the default) always takes the
+ * next code after Play's max, so it can't collide no matter how stale the file is.
+ * -PplayMaxVersionCode=<n> supplies that max; CI reads it from the Play API before calling this
+ * task, since Gradle has no business making that network call itself - this task only ever
+ * consumes the one external fact it cannot know on its own, never decides what to ask Play.
+ */
+tasks.register("incrementVersionBuild") {
+    doLast {
+        val versionCodeMode = project.findProperty("versionCodeMode")?.toString() ?: "auto"
+        val playMax = project.findProperty("playMaxVersionCode")?.toString()?.toIntOrNull() ?: 0
+        val versionFile = rootProject.file("version.properties")
+
+        fun git(vararg args: String) {
+            val process = ProcessBuilder(listOf("git") + args)
+                .directory(rootProject.projectDir)
+                .redirectErrorStream(true)
+                .start()
+            process.inputStream.bufferedReader().forEachLine { println(it) }
+            val exit = process.waitFor()
+            if (exit != 0) throw GradleException("git ${args.joinToString(" ")} failed (exit $exit)")
+        }
+
+        val maxAttempts = 3
+        for (attempt in 1..maxAttempts) {
+            git("fetch", "origin", "master", "--quiet")
+            git("reset", "--hard", "origin/master", "--quiet")
+
+            val freshProps = Properties().apply { versionFile.inputStream().use { load(it) } }
+            val current = freshProps.getProperty("versionBuild", "0").toIntOrNull() ?: 0
+
+            if (versionCodeMode == "strict" && current <= playMax) {
+                throw GradleException(
+                    "versionCode $current would not clear Play, which already has $playMax. " +
+                        "Set versionBuild=$playMax in version.properties and commit, or use auto mode."
+                )
+            }
+
+            val next = maxOf(current, playMax) + 1
+            // A targeted line substitution, not Properties.store() - store() rewrites the whole
+            // file with its own field order and an auto-generated timestamp comment, which would
+            // turn every single release into a full-file diff instead of a one-line change.
+            val versionBuildLine = Regex("(?m)^versionBuild=.*$")
+            val text = versionFile.readText()
+            versionFile.writeText(
+                if (versionBuildLine.containsMatchIn(text)) {
+                    text.replace(versionBuildLine, "versionBuild=$next")
+                } else {
+                    text.trimEnd('\n') + "\nversionBuild=$next\n"
+                }
+            )
+
+            git("commit", "-q", "-am", "chore: bump versionBuild to $next [skip ci]")
+            try {
+                git("push", "-q", "origin", "HEAD:master")
+                println("VERSION_BUILD=$next")
+                break
+            } catch (e: GradleException) {
+                if (attempt == maxAttempts) throw e
+                println("Push attempt $attempt failed (master probably moved) - retrying.")
+                Thread.sleep((attempt * 3000).toLong())
+            }
+        }
     }
 }

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -87,6 +87,7 @@ kotlin {
             implementation(libs.androidx.activity.compose)
             implementation(libs.androidx.fragment)
             implementation(libs.androidx.biometric)
+            implementation(libs.anthropic.java)
             // localbroadcastmanager is legacy, but keeping for now
             implementation("androidx.localbroadcastmanager:localbroadcastmanager:1.1.0")
             implementation("com.google.android.material:material:1.14.0")

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -118,6 +118,11 @@ android {
     packaging {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
+            // anthropic-java pulls in Apache HttpClient5, whose jars (httpclient5, httpcore5,
+            // httpcore5-h2) all ship their own copy of this file under the same path - only
+            // the release build's resource-merge step catches this (debug compile doesn't
+            // merge Java resources), which is why it didn't surface locally until bundleRelease.
+            excludes += "/META-INF/DEPENDENCIES"
         }
     }
 

--- a/composeApp/proguard-rules.pro
+++ b/composeApp/proguard-rules.pro
@@ -8,3 +8,8 @@
 -dontwarn okhttp3.**
 -dontwarn okio.**
 -keepnames class okhttp3.internal.publicsuffix.PublicSuffixDatabase
+
+# anthropic-java pulls in Jackson, whose optional java.beans.* introspection path (Java7SupportImpl)
+# references JDK classes that don't exist on Android - never reached at runtime on this platform.
+-dontwarn java.beans.ConstructorProperties
+-dontwarn java.beans.Transient

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -1,5 +1,7 @@
 package com.hereliesaz.hg2gui
 
+import android.content.ClipData
+import android.content.ClipboardManager
 import android.content.Intent
 import android.content.SharedPreferences
 import android.content.pm.PackageManager
@@ -30,21 +32,29 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.fragment.app.FragmentActivity
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import com.hereliesaz.hg2gui.ai.AiClient
+import com.hereliesaz.hg2gui.ai.AiReply
+import com.hereliesaz.hg2gui.managers.AiSettings
 import com.hereliesaz.hg2gui.managers.ContactManager
 import com.hereliesaz.hg2gui.managers.SshPresets
 import com.hereliesaz.hg2gui.managers.TerminalHistoryEntry
 import com.hereliesaz.hg2gui.managers.VfsManager
+import com.hereliesaz.hg2gui.managers.WorkflowStore
 import com.hereliesaz.hg2gui.mcp.McpServerService
 import com.hereliesaz.hg2gui.terminal.Builtins
 import com.hereliesaz.hg2gui.terminal.DistroManager
 import com.hereliesaz.hg2gui.terminal.TerminalEngine
 import com.hereliesaz.hg2gui.util.GenericFileProvider
 import com.hereliesaz.hg2gui.util.Utils
+import com.hereliesaz.hg2gui.ui.AiSettingsScreen
 import com.hereliesaz.hg2gui.ui.HG2GuiTheme
 import com.hereliesaz.hg2gui.ui.McpServerScreen
 import com.hereliesaz.hg2gui.ui.SessionUiState
 import com.hereliesaz.hg2gui.ui.SettingsScreen
 import com.hereliesaz.hg2gui.ui.TerminalScreen
+import com.hereliesaz.hg2gui.ui.WorkflowFlow
+import com.hereliesaz.hg2gui.ui.ai.AiChatScreen
+import com.hereliesaz.hg2gui.ui.ai.AiMessage
 import com.hereliesaz.hg2gui.ui.files.FilesScreen
 import com.hereliesaz.hg2gui.ui.files.StorageCategoryStat
 import com.hereliesaz.hg2gui.ui.files.StorageStats
@@ -73,7 +83,7 @@ class TerminalActivity : FragmentActivity() {
     private var sessions by mutableStateOf(listOf<TerminalSession>())
     private var nextSessionNumber = 2
 
-    private enum class Screen { Terminal, Settings, Guide, Files, Mcp }
+    private enum class Screen { Terminal, Settings, Guide, Files, Mcp, Ai, AiSettings }
 
     /** Confirms enabling shell.* MCP tools with a biometric prompt before persisting the flag -
      *  this is the one switch that lets a paired agent run arbitrary commands, so it gets a
@@ -128,6 +138,9 @@ class TerminalActivity : FragmentActivity() {
             }
             var fullscreen by remember { mutableStateOf(false) }
             var fontScalePercent by remember { mutableStateOf(100) }
+            var aiApiKey by remember { mutableStateOf(AiSettings.apiKey(this@TerminalActivity)) }
+            var aiMessages by remember { mutableStateOf<List<AiMessage>>(emptyList()) }
+            var aiBusy by remember { mutableStateOf(false) }
             val scope = rememberCoroutineScope()
 
             LaunchedEffect(lastIntentExtra) {
@@ -269,6 +282,53 @@ class TerminalActivity : FragmentActivity() {
                             prefs.edit { putInt(PREF_FONT_SCALE_PERCENT, value) }
                         },
                         onOpenMcpServer = { screen = Screen.Mcp },
+                        onOpenAiSettings = { screen = Screen.AiSettings },
+                        onBack = { screen = Screen.Terminal }
+                    )
+
+                    screen == Screen.AiSettings -> AiSettingsScreen(
+                        fullscreen = fullscreen,
+                        apiKey = aiApiKey,
+                        onSave = { newKey ->
+                            aiApiKey = newKey
+                            AiSettings.setApiKey(this@TerminalActivity, newKey)
+                            screen = Screen.Settings
+                        },
+                        onBack = { screen = Screen.Settings }
+                    )
+
+                    screen == Screen.Ai -> AiChatScreen(
+                        fullscreen = fullscreen,
+                        messages = aiMessages,
+                        apiKeyConfigured = !aiApiKey.isNullOrBlank(),
+                        busy = aiBusy,
+                        onAsk = { question ->
+                            val key = aiApiKey
+                            val session = sessions.firstOrNull { it.ui.id == activeSessionId }
+                            if (key != null && session != null) {
+                                aiMessages = aiMessages + AiMessage(fromUser = true, text = question)
+                                aiBusy = true
+                                scope.launch {
+                                    val reply = try {
+                                        AiClient.ask(key, session.ui.cwd, question)
+                                    } catch (e: Exception) {
+                                        AiReply(text = "error: ${e.message}", command = null)
+                                    }
+                                    aiMessages = aiMessages + AiMessage(
+                                        fromUser = false, text = reply.text, command = reply.command
+                                    )
+                                    aiBusy = false
+                                }
+                            }
+                        },
+                        onUseCommand = { command ->
+                            sessions.firstOrNull { it.ui.id == activeSessionId }?.let { session ->
+                                session.ui.tokens = emptyList()
+                                session.ui.inputText = command
+                            }
+                            screen = Screen.Terminal
+                        },
+                        onOpenSettings = { screen = Screen.AiSettings },
                         onBack = { screen = Screen.Terminal }
                     )
 
@@ -341,15 +401,40 @@ class TerminalActivity : FragmentActivity() {
                         onOpenGuide = { screen = Screen.Guide },
                         onOpenFiles = { openFiles() },
                         onFilesButtonPositioned = { filesOrigin = it },
+                        onCopy = { text ->
+                            val clipboard = getSystemService(ClipboardManager::class.java)
+                            clipboard?.setPrimaryClip(ClipData.newPlainText("HG2Gui", text))
+                        },
+                        onShare = { text ->
+                            val intent = Intent(Intent.ACTION_SEND).apply {
+                                type = "text/plain"
+                                putExtra(Intent.EXTRA_TEXT, text)
+                            }
+                            startActivity(Intent.createChooser(intent, "Share"))
+                        },
                         onWizard = { wizardId ->
-                            if (wizardId == "ssh-new") {
-                                sessions.firstOrNull { it.ui.id == activeSessionId }?.let { session ->
-                                    scope.launch {
-                                        SshFlow.runNewConnectionWizard(session.ui) { preset ->
-                                            withContext(Dispatchers.IO) { SshPresets.save(this@TerminalActivity, preset) }
-                                        }
+                            val session = sessions.firstOrNull { it.ui.id == activeSessionId }
+                            when {
+                                wizardId == "ssh-new" && session != null -> scope.launch {
+                                    SshFlow.runNewConnectionWizard(session.ui) { preset ->
+                                        withContext(Dispatchers.IO) { SshPresets.save(this@TerminalActivity, preset) }
                                     }
                                 }
+                                wizardId == "workflow-new" && session != null -> scope.launch {
+                                    WorkflowFlow.runNewWorkflowWizard(session.ui) { workflow ->
+                                        withContext(Dispatchers.IO) { WorkflowStore.save(this@TerminalActivity, workflow) }
+                                    }
+                                }
+                                wizardId.startsWith("workflow-run:") && session != null -> {
+                                    val name = wizardId.removePrefix("workflow-run:")
+                                    scope.launch {
+                                        val workflow = withContext(Dispatchers.IO) {
+                                            WorkflowStore.list(this@TerminalActivity).find { it.name == name }
+                                        }
+                                        if (workflow != null) WorkflowFlow.runWorkflowWizard(session.ui, workflow)
+                                    }
+                                }
+                                wizardId == "ai-chat" -> screen = Screen.Ai
                             }
                         },
                         onRun = { sessionId, line, onOutput, onNeedInput ->

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -34,7 +34,10 @@ import androidx.fragment.app.FragmentActivity
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.hereliesaz.hg2gui.ai.AiClient
 import com.hereliesaz.hg2gui.ai.AiReply
+import com.hereliesaz.hg2gui.azp.AzpClient
+import com.hereliesaz.hg2gui.azp.AzpInstaller
 import com.hereliesaz.hg2gui.managers.AiSettings
+import com.hereliesaz.hg2gui.managers.AzpLibrary
 import com.hereliesaz.hg2gui.managers.ContactManager
 import com.hereliesaz.hg2gui.managers.SshPresets
 import com.hereliesaz.hg2gui.managers.TerminalHistoryEntry
@@ -55,6 +58,8 @@ import com.hereliesaz.hg2gui.ui.TerminalScreen
 import com.hereliesaz.hg2gui.ui.WorkflowFlow
 import com.hereliesaz.hg2gui.ui.ai.AiChatScreen
 import com.hereliesaz.hg2gui.ui.ai.AiMessage
+import com.hereliesaz.hg2gui.ui.azp.AzpListing
+import com.hereliesaz.hg2gui.ui.azp.AzpStoreScreen
 import com.hereliesaz.hg2gui.ui.files.FilesScreen
 import com.hereliesaz.hg2gui.ui.files.StorageCategoryStat
 import com.hereliesaz.hg2gui.ui.files.StorageStats
@@ -83,7 +88,7 @@ class TerminalActivity : FragmentActivity() {
     private var sessions by mutableStateOf(listOf<TerminalSession>())
     private var nextSessionNumber = 2
 
-    private enum class Screen { Terminal, Settings, Guide, Files, Mcp, Ai, AiSettings }
+    private enum class Screen { Terminal, Settings, Guide, Files, Mcp, Ai, AiSettings, Azp }
 
     /** Confirms enabling shell.* MCP tools with a biometric prompt before persisting the flag -
      *  this is the one switch that lets a paired agent run arbitrary commands, so it gets a
@@ -141,6 +146,9 @@ class TerminalActivity : FragmentActivity() {
             var aiApiKey by remember { mutableStateOf(AiSettings.apiKey(this@TerminalActivity)) }
             var aiMessages by remember { mutableStateOf<List<AiMessage>>(emptyList()) }
             var aiBusy by remember { mutableStateOf(false) }
+            var azpResults by remember { mutableStateOf<List<AzpListing>>(emptyList()) }
+            var azpBusy by remember { mutableStateOf(false) }
+            var azpInstallingId by remember { mutableStateOf<String?>(null) }
             val scope = rememberCoroutineScope()
 
             LaunchedEffect(lastIntentExtra) {
@@ -310,7 +318,10 @@ class TerminalActivity : FragmentActivity() {
                                 aiBusy = true
                                 scope.launch {
                                     val reply = try {
-                                        AiClient.ask(key, session.ui.cwd, question)
+                                        val skills = withContext(Dispatchers.IO) {
+                                            AzpLibrary.installedSkillTexts(this@TerminalActivity)
+                                        }
+                                        AiClient.ask(key, session.ui.cwd, question, skills)
                                     } catch (e: Exception) {
                                         AiReply(text = "error: ${e.message}", command = null)
                                     }
@@ -329,6 +340,54 @@ class TerminalActivity : FragmentActivity() {
                             screen = Screen.Terminal
                         },
                         onOpenSettings = { screen = Screen.AiSettings },
+                        onBack = { screen = Screen.Terminal }
+                    )
+
+                    screen == Screen.Azp -> AzpStoreScreen(
+                        fullscreen = fullscreen,
+                        results = azpResults,
+                        busy = azpBusy,
+                        installingId = azpInstallingId,
+                        onSearch = { query, kind ->
+                            azpBusy = true
+                            scope.launch {
+                                val response = try {
+                                    AzpClient.search(query, kind.takeUnless { it == "all" })
+                                } catch (e: Exception) {
+                                    null
+                                }
+                                val installed = withContext(Dispatchers.IO) {
+                                    AzpLibrary.installed(this@TerminalActivity).map { it.id }.toSet()
+                                }
+                                azpResults = response?.packages.orEmpty().map { pkg ->
+                                    AzpListing(
+                                        id = pkg.id, name = pkg.name, author = pkg.author,
+                                        description = pkg.description, version = pkg.version,
+                                        kind = pkg.kind, installed = pkg.id in installed
+                                    )
+                                }
+                                azpBusy = false
+                            }
+                        },
+                        onInstall = { listing ->
+                            azpInstallingId = listing.id
+                            scope.launch {
+                                val result = withContext(Dispatchers.IO) {
+                                    val bytes = AzpClient.download(listing.id, listing.version) ?: return@withContext null
+                                    val install = AzpInstaller.install(this@TerminalActivity, listing.id, listing.version, bytes)
+                                        ?: return@withContext null
+                                    AzpLibrary.record(
+                                        this@TerminalActivity, listing.id, listing.name, listing.version,
+                                        install.kind, install.skillIds
+                                    )
+                                    install
+                                }
+                                if (result != null) {
+                                    azpResults = azpResults.map { if (it.id == listing.id) it.copy(installed = true) else it }
+                                }
+                                azpInstallingId = null
+                            }
+                        },
                         onBack = { screen = Screen.Terminal }
                     )
 
@@ -435,6 +494,7 @@ class TerminalActivity : FragmentActivity() {
                                     }
                                 }
                                 wizardId == "ai-chat" -> screen = Screen.Ai
+                                wizardId == "azp-store" -> screen = Screen.Azp
                             }
                         },
                         onRun = { sessionId, line, onOutput, onNeedInput ->

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ai/AiClient.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ai/AiClient.kt
@@ -21,12 +21,23 @@ If the user's request can be satisfied by a single shell command, reply with ONL
  * the MCP server's biometric-gated shell.exec tool, a separate and more guarded surface.
  */
 object AiClient {
-    suspend fun ask(apiKey: String, cwd: String, question: String): AiReply = withContext(Dispatchers.IO) {
+    suspend fun ask(
+        apiKey: String,
+        cwd: String,
+        question: String,
+        skills: List<Pair<String, String>> = emptyList(),
+    ): AiReply = withContext(Dispatchers.IO) {
         val client = AnthropicOkHttpClient.builder().apiKey(apiKey).build()
+        var system = SYSTEM_PROMPT.replace("{cwd}", cwd)
+        if (skills.isNotEmpty()) {
+            system += "\n\nThe user has installed the following skills from the azphalt store. " +
+                "Use them as reference when relevant:\n" +
+                skills.joinToString("\n\n") { (id, text) -> "## Skill: $id\n$text" }
+        }
         val params = MessageCreateParams.builder()
             .model("claude-opus-5")
             .maxTokens(2048L)
-            .system(SYSTEM_PROMPT.replace("{cwd}", cwd))
+            .system(system)
             .outputConfig(OutputConfig.builder().effort(OutputConfig.Effort.LOW).build())
             .addUserMessage(question)
             .build()

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ai/AiClient.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ai/AiClient.kt
@@ -1,0 +1,51 @@
+package com.hereliesaz.hg2gui.ai
+
+import com.anthropic.client.okhttp.AnthropicOkHttpClient
+import com.anthropic.models.messages.MessageCreateParams
+import com.anthropic.models.messages.OutputConfig
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+data class AiReply(val text: String, val command: String?)
+
+private const val SYSTEM_PROMPT = """You are a command-line assistant inside HG2Gui, a Termux-based Android terminal app. The user's current working directory is {cwd}.
+
+If the user's request can be satisfied by a single shell command, reply with ONLY that command, prefixed with "CMD:" and nothing else - no explanation, no markdown fences. Otherwise reply with a short plain-text answer, prefixed with "TEXT:"."""
+
+/**
+ * Single-turn natural-language -> shell-command suggestion (or plain-text reply), via the
+ * official Anthropic Java SDK (Kotlin uses the Java SDK, not a hand-rolled HTTP client). Never
+ * executes anything itself - a suggested command is handed back to the caller to drop into the
+ * terminal's input line, exactly like every wizard-produced command, for the user to review and
+ * press Run. This is deliberately not a second way for an agent to run code unattended; that's
+ * the MCP server's biometric-gated shell.exec tool, a separate and more guarded surface.
+ */
+object AiClient {
+    suspend fun ask(apiKey: String, cwd: String, question: String): AiReply = withContext(Dispatchers.IO) {
+        val client = AnthropicOkHttpClient.builder().apiKey(apiKey).build()
+        val params = MessageCreateParams.builder()
+            .model("claude-opus-5")
+            .maxTokens(2048L)
+            .system(SYSTEM_PROMPT.replace("{cwd}", cwd))
+            .outputConfig(OutputConfig.builder().effort(OutputConfig.Effort.LOW).build())
+            .addUserMessage(question)
+            .build()
+
+        val raw = client.messages().create(params).content()
+            .joinToString("") { block -> block.text().map { it.text() }.orElse("") }
+
+        parse(raw)
+    }
+
+    internal fun parse(raw: String): AiReply {
+        val trimmed = raw.trim()
+        return when {
+            trimmed.startsWith("CMD:") -> {
+                val command = trimmed.removePrefix("CMD:").trim()
+                AiReply(text = command, command = command)
+            }
+            trimmed.startsWith("TEXT:") -> AiReply(text = trimmed.removePrefix("TEXT:").trim(), command = null)
+            else -> AiReply(text = trimmed, command = null)
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpClient.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpClient.kt
@@ -1,0 +1,53 @@
+package com.hereliesaz.hg2gui.azp
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import okhttp3.HttpUrl.Companion.toHttpUrl
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import java.util.concurrent.TimeUnit
+
+private const val REPOSITORY_BASE = "https://www.azphalt.store"
+
+/**
+ * A thin client for the azphalt Repository API (spec/repository-api.md) - the same standard
+ * interface `pkg`/`apt` play for Debian packages, but for `.azp` extensions: search, then
+ * download the raw archive. HG2Gui never executes a `.azp`'s sandboxed code or WASM payload (it
+ * has no such runtime) - see AzpInstaller for what "install" actually means here.
+ */
+object AzpClient {
+    private val json = Json { ignoreUnknownKeys = true }
+    private val http = OkHttpClient.Builder()
+        .connectTimeout(15, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .build()
+
+    suspend fun search(query: String, kind: String?, page: Int = 1): AzpSearchResponse =
+        withContext(Dispatchers.IO) {
+            val url = "$REPOSITORY_BASE/packages".toHttpUrl().newBuilder()
+                .apply {
+                    if (query.isNotBlank()) addQueryParameter("q", query)
+                    if (!kind.isNullOrBlank()) addQueryParameter("kind", kind)
+                    addQueryParameter("page", page.toString())
+                }
+                .build()
+            val request = Request.Builder().url(url).get().build()
+            http.newCall(request).execute().use { resp ->
+                if (!resp.isSuccessful) return@withContext AzpSearchResponse()
+                val body = resp.body.string()
+                json.decodeFromString(AzpSearchResponse.serializer(), body)
+            }
+        }
+
+    /** Downloads the raw `.azp` (a ZIP archive) for the given package/version. Free packages
+     *  only - paid packages need a Bearer entitlement HG2Gui does not yet implement. */
+    suspend fun download(id: String, version: String): ByteArray? = withContext(Dispatchers.IO) {
+        val url = "$REPOSITORY_BASE/packages/$id/versions/$version/download"
+        val request = Request.Builder().url(url).get().build()
+        http.newCall(request).execute().use { resp ->
+            if (!resp.isSuccessful) return@withContext null
+            resp.body.bytes()
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpInstaller.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpInstaller.kt
@@ -1,0 +1,71 @@
+package com.hereliesaz.hg2gui.azp
+
+import android.content.Context
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.io.File
+import java.util.zip.ZipInputStream
+
+data class AzpInstallResult(val kind: String, val skillIds: List<String>)
+
+/**
+ * Unpacks a downloaded `.azp` - a plain ZIP archive per spec/package-format.md, `manifest.json`
+ * at the root - into `filesDir/azp/<id>/<version>/`. HG2Gui has no `.azp` code/WASM runtime, so
+ * for every kind except `skill` this is just "download and keep, for use elsewhere" - the same
+ * as `apt download` versus `apt install`. A `skill` package's `SKILL.md` files are real usable
+ * content here: AzpLibrary reads them back to extend the AI chat's system prompt.
+ *
+ * Signature verification (package-format.md's Ed25519 model) is NOT implemented in this v1 -
+ * packages are trusted at the same level as this app's other locally-stored, unverified settings
+ * (e.g. the MCP pairing token). Only free packages are supported; paid packages need a Bearer
+ * entitlement this client does not yet obtain.
+ */
+object AzpInstaller {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    fun rootDir(context: Context, id: String, version: String): File =
+        File(File(context.filesDir, "azp"), "$id/$version")
+
+    suspend fun install(context: Context, id: String, version: String, bytes: ByteArray): AzpInstallResult? =
+        withContext(Dispatchers.IO) {
+            val dest = rootDir(context, id, version)
+            dest.mkdirs()
+
+            ZipInputStream(bytes.inputStream()).use { zip ->
+                var entry = zip.nextEntry
+                while (entry != null) {
+                    val name = entry.name
+                    // Path containment: refuse any entry that would escape dest via .. or an
+                    // absolute path (package-format.md's own path-containment requirement).
+                    val target = File(dest, name).canonicalFile
+                    if (!target.path.startsWith(dest.canonicalPath + File.separator) && target != dest) {
+                        zip.closeEntry(); entry = zip.nextEntry; continue
+                    }
+                    if (entry.isDirectory) {
+                        target.mkdirs()
+                    } else {
+                        target.parentFile?.mkdirs()
+                        target.outputStream().use { out -> zip.copyTo(out) }
+                    }
+                    zip.closeEntry()
+                    entry = zip.nextEntry
+                }
+            }
+
+            val manifestFile = File(dest, "manifest.json")
+            if (!manifestFile.exists()) return@withContext null
+            val manifest = json.parseToJsonElement(manifestFile.readText()).jsonObject
+            val kind = manifest["kind"]?.jsonPrimitive?.content ?: "asset"
+            val skillIds = if (kind == "skill") {
+                manifest["skill"]?.jsonObject?.get("skills")?.jsonArray
+                    ?.mapNotNull { it.jsonObject["id"]?.jsonPrimitive?.content }
+                    ?: emptyList()
+            } else emptyList()
+
+            AzpInstallResult(kind, skillIds)
+        }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpModels.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpModels.kt
@@ -1,0 +1,37 @@
+package com.hereliesaz.hg2gui.azp
+
+import kotlinx.serialization.Serializable
+
+/**
+ * Wire shapes for the azphalt Repository API (spec/repository-api.md), trimmed to the fields
+ * HG2Gui actually reads. Extra server fields are ignored by kotlinx.serialization's default
+ * lenient decoding.
+ */
+@Serializable
+data class AzpPackageSummary(
+    val id: String,
+    val name: String,
+    val description: String = "",
+    val author: String = "",
+    val version: String = "",
+    val kind: String = "asset",
+    val priceStatus: String = "free",
+    val downloads: Long = 0,
+    val byteSize: Long = 0,
+)
+
+@Serializable
+data class AzpSearchResponse(
+    val packages: List<AzpPackageSummary> = emptyList(),
+    val total: Int = 0,
+    val page: Int = 1,
+    val pages: Int = 1,
+)
+
+/** A locally installed package, as tracked by [com.hereliesaz.hg2gui.managers.AzpLibrary]. */
+data class AzpInstalled(
+    val id: String,
+    val name: String,
+    val version: String,
+    val kind: String,
+)

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/AiSettings.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/AiSettings.kt
@@ -1,0 +1,26 @@
+package com.hereliesaz.hg2gui.managers
+
+import android.content.Context
+import androidx.core.content.edit
+
+private const val PREFS_NAME = "hg2gui_ai_settings"
+private const val KEY_API_KEY = "api_key"
+
+/**
+ * The user-supplied Anthropic API key backing AI command search/chat, stored in plain
+ * SharedPreferences - matching this app's existing security posture (no
+ * EncryptedSharedPreferences is used anywhere else in the app either; SSH key paths and the MCP
+ * pairing token get the same treatment). Flagged as a risk in docs, not hidden as a non-issue.
+ */
+object AiSettings {
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun apiKey(context: Context): String? = prefs(context).getString(KEY_API_KEY, null)?.ifBlank { null }
+
+    fun setApiKey(context: Context, apiKey: String?) {
+        prefs(context).edit {
+            if (apiKey.isNullOrBlank()) remove(KEY_API_KEY) else putString(KEY_API_KEY, apiKey)
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/AzpLibrary.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/AzpLibrary.kt
@@ -1,0 +1,84 @@
+package com.hereliesaz.hg2gui.managers
+
+import android.content.Context
+import androidx.core.content.edit
+import com.hereliesaz.hg2gui.azp.AzpInstalled
+import com.hereliesaz.hg2gui.azp.AzpInstaller
+
+private const val PREFS_NAME = "hg2gui_azp"
+private const val KEY_IDS = "azp_ids"
+
+/** Total budget for skill text folded into the AI system prompt - keeps a handful of installed
+ *  skills from ballooning every AI request's token count. */
+private const val SKILL_TEXT_BUDGET_CHARS = 6000
+
+/**
+ * Locally installed azphalt packages - one flat SharedPreferences file, mirrors WorkflowStore's
+ * shape. "Installed" means AzpInstaller already unpacked the `.azp` into `filesDir/azp/...`;
+ * this store just remembers which packages are present so the store screen can show
+ * INSTALLED instead of INSTALL, and so [installedSkillTexts] knows where to look.
+ */
+object AzpLibrary {
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun installed(context: Context): List<AzpInstalled> {
+        val p = prefs(context)
+        val ids = p.getStringSet(KEY_IDS, emptySet()).orEmpty()
+        return ids.mapNotNull { id ->
+            val name = p.getString("$id.name", null) ?: return@mapNotNull null
+            val version = p.getString("$id.version", "") ?: ""
+            val kind = p.getString("$id.kind", "asset") ?: "asset"
+            AzpInstalled(id, name, version, kind)
+        }.sortedBy { it.name }
+    }
+
+    fun isInstalled(context: Context, id: String): Boolean =
+        prefs(context).getStringSet(KEY_IDS, emptySet()).orEmpty().contains(id)
+
+    fun record(context: Context, id: String, name: String, version: String, kind: String, skillIds: List<String>) {
+        val p = prefs(context)
+        val ids = p.getStringSet(KEY_IDS, emptySet()).orEmpty() + id
+        p.edit {
+            putStringSet(KEY_IDS, ids)
+            putString("$id.name", name)
+            putString("$id.version", version)
+            putString("$id.kind", kind)
+            putString("$id.skillIds", skillIds.joinToString(","))
+        }
+    }
+
+    fun remove(context: Context, id: String) {
+        val p = prefs(context)
+        val ids = p.getStringSet(KEY_IDS, emptySet()).orEmpty() - id
+        p.edit {
+            putStringSet(KEY_IDS, ids)
+            remove("$id.name"); remove("$id.version"); remove("$id.kind"); remove("$id.skillIds")
+        }
+    }
+
+    /** Reads every installed skill package's SKILL.md files back off disk, as (skillId, text)
+     *  pairs, truncated to a total character budget so AiClient's system prompt stays bounded. */
+    fun installedSkillTexts(context: Context): List<Pair<String, String>> {
+        val p = prefs(context)
+        val ids = p.getStringSet(KEY_IDS, emptySet()).orEmpty()
+        val out = mutableListOf<Pair<String, String>>()
+        var remaining = SKILL_TEXT_BUDGET_CHARS
+        for (id in ids) {
+            if (remaining <= 0) break
+            if (p.getString("$id.kind", "asset") != "skill") continue
+            val version = p.getString("$id.version", "") ?: continue
+            val skillIds = p.getString("$id.skillIds", "")?.split(",")?.filter { it.isNotBlank() } ?: continue
+            val root = AzpInstaller.rootDir(context, id, version)
+            for (skillId in skillIds) {
+                if (remaining <= 0) break
+                val skillMd = root.resolve("skills/$skillId/SKILL.md")
+                if (!skillMd.exists()) continue
+                val text = skillMd.readText().take(remaining)
+                remaining -= text.length
+                out += skillId to text
+            }
+        }
+        return out
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/WorkflowStore.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/WorkflowStore.kt
@@ -1,0 +1,44 @@
+package com.hereliesaz.hg2gui.managers
+
+import android.content.Context
+import androidx.core.content.edit
+import com.hereliesaz.hg2gui.ui.Workflow
+
+private const val PREFS_NAME = "hg2gui_workflows"
+private const val KEY_NAMES = "workflow_names"
+
+/**
+ * Saved command-template workflows, one flat SharedPreferences file - mirrors SshPresets.kt's
+ * shape exactly (a name Set<String>, one "$name.field" scalar per field).
+ */
+object WorkflowStore {
+    private fun prefs(context: Context) =
+        context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun list(context: Context): List<Workflow> {
+        val p = prefs(context)
+        val names = p.getStringSet(KEY_NAMES, emptySet()).orEmpty()
+        return names.mapNotNull { name ->
+            val template = p.getString("$name.template", null) ?: return@mapNotNull null
+            Workflow(name, template)
+        }.sortedBy { it.name }
+    }
+
+    fun save(context: Context, workflow: Workflow) {
+        val p = prefs(context)
+        val names = p.getStringSet(KEY_NAMES, emptySet()).orEmpty() + workflow.name
+        p.edit {
+            putStringSet(KEY_NAMES, names)
+            putString("${workflow.name}.template", workflow.template)
+        }
+    }
+
+    fun delete(context: Context, name: String) {
+        val p = prefs(context)
+        val names = p.getStringSet(KEY_NAMES, emptySet()).orEmpty() - name
+        p.edit {
+            putStringSet(KEY_NAMES, names)
+            remove("$name.template")
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/AiSettingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/AiSettingsScreen.kt
@@ -1,0 +1,148 @@
+package com.hereliesaz.hg2gui.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.hg2gui.ui.menu.Azphalt
+
+private val PageYellow = Brush.linearGradient(
+    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
+)
+
+/**
+ * A single masked API-key field + Save, same tap-to-reveal idiom McpServerScreen uses for its
+ * pairing token. Stored unencrypted (see AiSettings' own doc comment) - flagged in USER_GUIDE.md
+ * the same way the MCP token risk is, not hidden as a non-issue.
+ */
+@Composable
+fun AiSettingsScreen(
+    fullscreen: Boolean,
+    apiKey: String?,
+    onSave: (String?) -> Unit,
+    onBack: () -> Unit
+) {
+    var revealed by remember { mutableStateOf(false) }
+    var draft by remember { mutableStateOf(apiKey.orEmpty()) }
+
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(PageYellow)
+            .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
+    ) {
+        Row(
+            Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                Modifier
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.Ink)
+                    .clickable(onClick = onBack)
+                    .padding(horizontal = 14.dp, vertical = 7.dp)
+            ) {
+                Text(
+                    "‹ BACK", color = Azphalt.Yellow,
+                    fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+                )
+            }
+        }
+
+        Eyebrow("AI settings")
+
+        Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp)) {
+            Text(
+                "API KEY", color = Azphalt.Ink,
+                fontSize = 13.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+            )
+            Text(
+                "An Anthropic API key, used only for the AI command-search chat. Stored " +
+                    "unencrypted on this device, same as this app's other local settings.",
+                color = Azphalt.Ink.copy(alpha = .6f), fontSize = 11.sp, lineHeight = 15.sp,
+                modifier = Modifier.padding(top = 4.dp, bottom = 10.dp)
+            )
+
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .heightIn(min = 32.dp)
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.Ink)
+                    .clickable(enabled = !revealed) { revealed = true }
+                    .padding(start = 14.dp, end = 10.dp, top = 6.dp, bottom = 6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                if (revealed) {
+                    BasicTextField(
+                        value = draft,
+                        onValueChange = { draft = it },
+                        modifier = Modifier.weight(1f),
+                        textStyle = MaterialTheme.typography.bodyMedium.copy(
+                            color = Azphalt.Yellow, fontSize = 12.sp, fontFamily = FontFamily.Monospace
+                        ),
+                        cursorBrush = SolidColor(Azphalt.Yellow),
+                        singleLine = true,
+                        visualTransformation = if (draft.isNotEmpty()) PasswordVisualTransformation() else VisualTransformation.None,
+                        keyboardOptions = KeyboardOptions(imeAction = ImeAction.Done),
+                        keyboardActions = KeyboardActions(onDone = { onSave(draft.ifBlank { null }) })
+                    )
+                } else {
+                    Text(
+                        if (draft.isNotBlank()) "•••• tap to edit" else "not set — tap to add",
+                        color = Azphalt.Yellow, fontSize = 11.sp,
+                        fontFamily = FontFamily.Monospace, fontWeight = FontWeight.Bold
+                    )
+                }
+            }
+
+            Spacer(Modifier.height(10.dp))
+
+            Box(
+                Modifier
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.hues[6])
+                    .clickable { onSave(draft.ifBlank { null }) }
+                    .padding(horizontal = 16.dp, vertical = 9.dp)
+            ) {
+                Text(
+                    "SAVE", color = Azphalt.White,
+                    fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Eyebrow(text: String) {
+    Text(
+        text.uppercase(),
+        style = MaterialTheme.typography.labelSmall,
+        modifier = Modifier.padding(start = 20.dp, top = 8.dp, bottom = 9.dp)
+    )
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/SettingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/SettingsScreen.kt
@@ -33,6 +33,7 @@ fun SettingsScreen(
     fontScalePercent: Int,
     onFontScalePercentChange: (Int) -> Unit,
     onOpenMcpServer: () -> Unit,
+    onOpenAiSettings: () -> Unit,
     onBack: () -> Unit
 ) {
     Column(
@@ -88,6 +89,25 @@ fun SettingsScreen(
                 label = { "$it%" },
                 onChange = onFontScalePercentChange
             )
+        }
+
+        SettingRow(
+            title = "AI",
+            description = "The API key AI command search/chat uses to suggest shell commands. " +
+                "Off until a key is set."
+        ) {
+            Box(
+                Modifier
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.Ink)
+                    .clickable(onClick = onOpenAiSettings)
+                    .padding(horizontal = 16.dp, vertical = 9.dp)
+            ) {
+                Text(
+                    "AI SETTINGS ›", color = Azphalt.Yellow,
+                    fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+                )
+            }
         }
 
         SettingRow(

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/menu/CommandTree.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/menu/CommandTree.kt
@@ -2,6 +2,7 @@ package com.hereliesaz.hg2gui.ui.menu
 
 import android.content.Context
 import com.hereliesaz.hg2gui.managers.SshPresets
+import com.hereliesaz.hg2gui.managers.WorkflowStore
 import com.hereliesaz.hg2gui.terminal.DistroManager
 import com.hereliesaz.hg2gui.terminal.DpkgCatalog
 import com.hereliesaz.hg2gui.ui.ssh.SshFlow
@@ -143,6 +144,45 @@ object CommandTree {
         }
     )
 
+    /** The Workflows root pill: saved templates as picks (each launches its own fill-in-the-
+     *  placeholders wizard), plus a "new…" leaf that launches the save wizard. Same lazy
+     *  resolveChildren reasoning as [sshLeaf] - a freshly-saved workflow shows up next time this
+     *  pill opens. This is a synthesized root like sys/apps/feat, not a shell binary, so it's
+     *  added in [from] rather than discovered from PATH. */
+    private fun workflowsRoot(context: Context): MenuNode = MenuNode(
+        id = "wf",
+        label = "Workflows",
+        resolveChildren = {
+            val saved = WorkflowStore.list(context).map { workflow ->
+                MenuNode(
+                    id = "wf/${workflow.name}",
+                    label = workflow.name,
+                    cap = "run",
+                    emitsToken = false,
+                    wizardId = "workflow-run:${workflow.name}"
+                )
+            }
+            saved + MenuNode(
+                id = "wf/new",
+                label = "new…",
+                cap = "new",
+                emitsToken = false,
+                wizardId = "workflow-new"
+            )
+        }
+    )
+
+    /** The AI root pill: one leaf that opens the AI chat screen (a wizardId consumer that
+     *  navigates rather than collecting prompt answers - a valid reuse of the same "the tree
+     *  wants this id handled outside normal token emission" hook). */
+    private fun aiRoot(): MenuNode = MenuNode(
+        id = "ai",
+        label = "AI",
+        children = listOf(
+            MenuNode(id = "ai/chat", label = "chat…", cap = "open", emitsToken = false, wizardId = "ai-chat")
+        )
+    )
+
     private fun shellLeaf(fullName: String, label: String, filePickerRoot: File): MenuNode {
         val hints = SHELL_HINTS[fullName].orEmpty().map { MenuNode("sh/$fullName/$it", it) }
         val children = hints + FileBrowser.pickerNode("sh/$fullName/file", filePickerRoot)
@@ -263,7 +303,9 @@ object CommandTree {
         return shellRoots + listOf(
             MenuNode("sys", "System", SYSTEM.size.toString(), SYSTEM.sorted().map { node(it, filePickerRoot) }),
             MenuNode("apps", "Apps & nav", APPS.size.toString(), APPS.sorted().map { node(it, filePickerRoot) }),
-            MenuNode("feat", "Features", FEATURES.size.toString(), FEATURES.sorted().map { node(it, filePickerRoot) })
+            MenuNode("feat", "Features", FEATURES.size.toString(), FEATURES.sorted().map { node(it, filePickerRoot) }),
+            workflowsRoot(context),
+            aiRoot()
         )
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/menu/CommandTree.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/menu/CommandTree.kt
@@ -183,6 +183,17 @@ object CommandTree {
         )
     )
 
+    /** The Store root pill: azphalt.store package search, plus a leaf listing what's already
+     *  installed. Both navigate to the AzpStoreScreen rather than collecting prompt answers -
+     *  same wizardId-as-navigation reuse as [aiRoot]. */
+    private fun azpRoot(): MenuNode = MenuNode(
+        id = "azp",
+        label = "Store",
+        children = listOf(
+            MenuNode(id = "azp/search", label = "search…", cap = "open", emitsToken = false, wizardId = "azp-store")
+        )
+    )
+
     private fun shellLeaf(fullName: String, label: String, filePickerRoot: File): MenuNode {
         val hints = SHELL_HINTS[fullName].orEmpty().map { MenuNode("sh/$fullName/$it", it) }
         val children = hints + FileBrowser.pickerNode("sh/$fullName/file", filePickerRoot)
@@ -305,7 +316,8 @@ object CommandTree {
             MenuNode("apps", "Apps & nav", APPS.size.toString(), APPS.sorted().map { node(it, filePickerRoot) }),
             MenuNode("feat", "Features", FEATURES.size.toString(), FEATURES.sorted().map { node(it, filePickerRoot) }),
             workflowsRoot(context),
-            aiRoot()
+            aiRoot(),
+            azpRoot()
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/AsciiArt.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/AsciiArt.kt
@@ -9,8 +9,8 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
-import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 
@@ -43,34 +43,102 @@ fun looksLikeAsciiArt(text: String): Boolean {
     return alnum.toFloat() / chars.length < 0.35f
 }
 
+private const val ISO_LEVEL = 0.42f
+
+/** Linearly interpolates the point along a-b where the density field crosses [ISO_LEVEL]. */
+private fun edgePoint(pa: Offset, va: Float, pb: Offset, vb: Float): Offset {
+    val t = if (vb == va) 0.5f else ((ISO_LEVEL - va) / (vb - va)).coerceIn(0f, 1f)
+    return Offset(pa.x + (pb.x - pa.x) * t, pa.y + (pb.y - pa.y) * t)
+}
+
+private fun Path.polygon(points: List<Offset>) {
+    if (points.isEmpty()) return
+    moveTo(points[0].x, points[0].y)
+    for (i in 1 until points.size) lineTo(points[i].x, points[i].y)
+    close()
+}
+
 /**
- * Renders a block of ASCII/box-drawing art as flat filled cells sized by character density,
- * instead of literal monospace glyphs - matching Azphalt's flat, no-gradient, no-blur look
- * rather than trying to reproduce a font's actual letterforms at a tiny size.
+ * Traces the character-density field into a single filled vector silhouette via marching squares
+ * - the same contour-tracing idea Potrace-style vectorizers use, applied to the density grid
+ * instead of raster pixels. No model, no network call: each 2x2 neighborhood of sample points is
+ * classified against [ISO_LEVEL] and contributes an interpolated sub-polygon, so the traced edges
+ * come out smooth rather than stair-stepped along the character grid. All sub-polygons are filled
+ * with one flat color into one [Path] - Azphalt's flat, no-gradient, no-blur look, constructed as
+ * an actual vector shape rather than reproduced glyph-by-glyph.
+ */
+private fun buildContourPath(density: Array<FloatArray>, cellPx: Float): Path {
+    val path = Path()
+    val rows = density.size
+    val cols = density[0].size
+    for (r in 0 until rows - 1) {
+        for (c in 0 until cols - 1) {
+            val a = density[r][c]         // top-left
+            val b = density[r][c + 1]     // top-right
+            val cc = density[r + 1][c + 1] // bottom-right
+            val d = density[r + 1][c]     // bottom-left
+            val case = (if (a >= ISO_LEVEL) 1 else 0) or (if (b >= ISO_LEVEL) 2 else 0) or
+                (if (cc >= ISO_LEVEL) 4 else 0) or (if (d >= ISO_LEVEL) 8 else 0)
+            if (case == 0) continue
+
+            val tl = Offset(c * cellPx, r * cellPx)
+            val tr = Offset((c + 1) * cellPx, r * cellPx)
+            val br = Offset((c + 1) * cellPx, (r + 1) * cellPx)
+            val bl = Offset(c * cellPx, (r + 1) * cellPx)
+            val top = edgePoint(tl, a, tr, b)
+            val right = edgePoint(tr, b, br, cc)
+            val bottom = edgePoint(bl, d, br, cc)
+            val left = edgePoint(tl, a, bl, d)
+
+            val polygon = when (case) {
+                1 -> listOf(tl, top, left)
+                2 -> listOf(top, tr, right)
+                3 -> listOf(tl, tr, right, left)
+                4 -> listOf(right, br, bottom)
+                // 5 and 10 are the ambiguous saddle cases - resolved as two separate corners
+                // joined by the path, a fixed (not topologically "correct") choice that's fine
+                // for decorative tracing.
+                5 -> { path.polygon(listOf(tl, top, left)); listOf(right, br, bottom) }
+                6 -> listOf(top, tr, br, bottom)
+                7 -> listOf(tl, tr, br, bottom, left)
+                8 -> listOf(left, bl, bottom)
+                9 -> listOf(tl, top, bottom, bl)
+                10 -> { path.polygon(listOf(top, tr, right)); listOf(left, bl, bottom) }
+                11 -> listOf(tl, tr, right, bottom, bl)
+                12 -> listOf(left, bl, br, right)
+                13 -> listOf(tl, top, right, br, bl)
+                14 -> listOf(top, tr, br, bl, left)
+                else -> listOf(tl, tr, br, bl) // 15: fully inside
+            }
+            path.polygon(polygon)
+        }
+    }
+    return path
+}
+
+/**
+ * Renders a block of ASCII/box-drawing art as one traced flat vector silhouette instead of
+ * literal monospace glyphs - see [buildContourPath].
  */
 @Composable
 fun AsciiArtCanvas(text: String, ink: Color, modifier: Modifier = Modifier, maxCell: Dp = 7.dp) {
     val lines = text.lines()
     val cols = lines.maxOf { it.length }.coerceAtLeast(1)
     val rows = lines.size
+    // A 1-sample zero border on every side so art touching the block's edge still closes into a
+    // shape instead of being cut off mid-contour.
+    val density = Array(rows + 2) { r ->
+        FloatArray(cols + 2) { c ->
+            if (r == 0 || c == 0 || r == rows + 1 || c == cols + 1) 0f
+            else charDensity(lines[r - 1].getOrElse(c - 1) { ' ' })
+        }
+    }
 
     BoxWithConstraints(modifier.horizontalScroll(rememberScrollState())) {
         val cell = min(maxCell, maxWidth / cols)
-        Canvas(Modifier.width(cell * cols).height(cell * rows)) {
-            val cellPx = cell.toPx()
-            lines.forEachIndexed { row, line ->
-                line.forEachIndexed { col, c ->
-                    val density = charDensity(c)
-                    if (density <= 0f) return@forEachIndexed
-                    val side = cellPx * (0.35f + 0.65f * density)
-                    val offset = (cellPx - side) / 2f
-                    drawRect(
-                        color = ink.copy(alpha = density.coerceIn(0.15f, 1f)),
-                        topLeft = Offset(col * cellPx + offset, row * cellPx + offset),
-                        size = Size(side, side)
-                    )
-                }
-            }
+        Canvas(Modifier.width(cell * (cols + 2)).height(cell * (rows + 2))) {
+            val path = buildContourPath(density, cell.toPx())
+            drawPath(path, color = ink)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/AsciiArt.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/AsciiArt.kt
@@ -1,0 +1,78 @@
+package com.hereliesaz.hg2gui.ui
+
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+// Light -> dense, the same ramp image-to-ASCII converters use in reverse. A character's position
+// in this ramp is read as its "ink density" for AsciiArtCanvas, not rendered as a literal glyph.
+private const val DENSITY_RAMP = " .'`^\",:;Il!i><~+_-?][}{1)(|\\/tfjrxnuvczXYUJCLQ0OZmwqpdbkhao*#MW&8%B@\$"
+
+private fun charDensity(c: Char): Float {
+    if (c.isWhitespace()) return 0f
+    // Box-drawing (U+2500-U+257F) and block elements (U+2580-U+259F) are literal solid/partial
+    // blocks already, not glyphs to rank - treat them as fully dense.
+    if (c.code in 0x2500..0x259F) return 1f
+    val i = DENSITY_RAMP.indexOf(c)
+    return if (i < 0) 0.7f else i.toFloat() / (DENSITY_RAMP.length - 1)
+}
+
+/**
+ * Heuristic: does this block of text read as ASCII/box-drawing art rather than prose or a table?
+ * Conservative on purpose - a false negative just falls back to plain monospace text (always
+ * fine), a false positive would render real prose as an unreadable block grid. Requires at least
+ * a few lines and a low ratio of alphanumeric characters among the non-whitespace ones, since art
+ * leans on symbols/box-drawing where prose and tables lean on letters and digits.
+ */
+fun looksLikeAsciiArt(text: String): Boolean {
+    val lines = text.lines().filter { it.isNotBlank() }
+    if (lines.size < 3) return false
+    val chars = lines.joinToString("").filter { !it.isWhitespace() }
+    if (chars.length < 40) return false
+    val alnum = chars.count { it.isLetterOrDigit() }
+    return alnum.toFloat() / chars.length < 0.35f
+}
+
+/**
+ * Renders a block of ASCII/box-drawing art as flat filled cells sized by character density,
+ * instead of literal monospace glyphs - matching Azphalt's flat, no-gradient, no-blur look
+ * rather than trying to reproduce a font's actual letterforms at a tiny size.
+ */
+@Composable
+fun AsciiArtCanvas(text: String, ink: Color, modifier: Modifier = Modifier, maxCell: Dp = 7.dp) {
+    val lines = text.lines()
+    val cols = lines.maxOf { it.length }.coerceAtLeast(1)
+    val rows = lines.size
+
+    BoxWithConstraints(modifier.horizontalScroll(rememberScrollState())) {
+        val cell = min(maxCell, maxWidth / cols)
+        Canvas(Modifier.width(cell * cols).height(cell * rows)) {
+            val cellPx = cell.toPx()
+            lines.forEachIndexed { row, line ->
+                line.forEachIndexed { col, c ->
+                    val density = charDensity(c)
+                    if (density <= 0f) return@forEachIndexed
+                    val side = cellPx * (0.35f + 0.65f * density)
+                    val offset = (cellPx - side) / 2f
+                    drawRect(
+                        color = ink.copy(alpha = density.coerceIn(0.15f, 1f)),
+                        topLeft = Offset(col * cellPx + offset, row * cellPx + offset),
+                        size = Size(side, side)
+                    )
+                }
+            }
+        }
+    }
+}
+
+private fun min(a: Dp, b: Dp) = if (a.value < b.value) a else b

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
@@ -321,6 +321,8 @@ private fun BufferEntry(
     // fires the command itself - same "assemble, then let the user press Run" rule every
     // wizard-produced command already follows.
     var expanded by remember { mutableStateOf(false) }
+    val isArt = remember(entry.output) { looksLikeAsciiArt(entry.output) }
+    var showRaw by remember(entry.output) { mutableStateOf(false) }
     Column(
         Modifier
             .fillMaxWidth()
@@ -352,14 +354,20 @@ private fun BufferEntry(
         }
         if (entry.output.isNotEmpty()) {
             Spacer(Modifier.height(4.dp))
-            Text(
-                entry.output,
-                style = MaterialTheme.typography.bodyMedium.copy(
-                    color = Azphalt.Ink.copy(alpha = .8f),
-                    fontFamily = FontFamily.Monospace,
-                    fontSize = 12.sp
+            if (isArt && !showRaw) {
+                // Vector-style rendering: flat filled cells sized by character density, not
+                // literal glyphs - a script's ASCII/box-drawing art reads as art, not text.
+                AsciiArtCanvas(entry.output, Azphalt.Ink.copy(alpha = .8f))
+            } else {
+                Text(
+                    entry.output,
+                    style = MaterialTheme.typography.bodyMedium.copy(
+                        color = Azphalt.Ink.copy(alpha = .8f),
+                        fontFamily = FontFamily.Monospace,
+                        fontSize = 12.sp
+                    )
                 )
-            )
+            }
         }
         if (expanded) {
             Spacer(Modifier.height(8.dp))
@@ -368,6 +376,9 @@ private fun BufferEntry(
                 BlockActionPill("COPY") { onCopy(copyText) }
                 BlockActionPill("RE-RUN") { onRerun(entry.command) }
                 BlockActionPill("SHARE") { onShare(copyText) }
+                if (isArt) {
+                    BlockActionPill(if (showRaw) "ART" else "PLAIN TEXT") { showRaw = !showRaw }
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
@@ -57,6 +57,8 @@ fun TerminalScreen(
     onOpenFiles: () -> Unit,
     onFilesButtonPositioned: (Rect) -> Unit = {},
     onWizard: (wizardId: String) -> Unit = {},
+    onCopy: (String) -> Unit = {},
+    onShare: (String) -> Unit = {},
     onRun: suspend (
         sessionId: String,
         line: String,
@@ -193,7 +195,15 @@ fun TerminalScreen(
                 contentPadding = PaddingValues(bottom = 8.dp)
             ) {
                 items(active.buffer) { entry ->
-                    BufferEntry(entry)
+                    BufferEntry(
+                        entry = entry,
+                        onCopy = onCopy,
+                        onShare = onShare,
+                        onRerun = { command ->
+                            active.tokens = emptyList()
+                            active.inputText = command
+                        }
+                    )
                 }
             }
         }
@@ -300,12 +310,23 @@ fun TerminalScreen(
 }
 
 @Composable
-private fun BufferEntry(entry: TerminalHistoryEntry) {
+private fun BufferEntry(
+    entry: TerminalHistoryEntry,
+    onCopy: (String) -> Unit,
+    onShare: (String) -> Unit,
+    onRerun: (String) -> Unit
+) {
+    // Blocks: tap an entry to reveal COPY/RE-RUN/SHARE - the tap-to-reveal idiom already used
+    // for the MCP pairing token. Re-run only ever populates the input line for review, never
+    // fires the command itself - same "assemble, then let the user press Run" rule every
+    // wizard-produced command already follows.
+    var expanded by remember { mutableStateOf(false) }
     Column(
         Modifier
             .fillMaxWidth()
             .clip(RoundedCornerShape(12.dp))
             .background(Azphalt.Ink.copy(alpha = .05f))
+            .clickable { expanded = !expanded }
             .padding(12.dp)
     ) {
         Row(verticalAlignment = Alignment.CenterVertically) {
@@ -340,6 +361,35 @@ private fun BufferEntry(entry: TerminalHistoryEntry) {
                 )
             )
         }
+        if (expanded) {
+            Spacer(Modifier.height(8.dp))
+            Row(horizontalArrangement = Arrangement.spacedBy(6.dp)) {
+                val copyText = entry.output.ifEmpty { entry.command }
+                BlockActionPill("COPY") { onCopy(copyText) }
+                BlockActionPill("RE-RUN") { onRerun(entry.command) }
+                BlockActionPill("SHARE") { onShare(copyText) }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BlockActionPill(label: String, onClick: () -> Unit) {
+    Box(
+        Modifier
+            .clip(RoundedCornerShape(percent = 50))
+            .background(Azphalt.Ink.copy(alpha = .14f))
+            .clickable(onClick = onClick)
+            .padding(horizontal = 10.dp, vertical = 5.dp)
+    ) {
+        Text(
+            label,
+            style = MaterialTheme.typography.titleMedium.copy(
+                color = Azphalt.Ink,
+                fontSize = 8.sp,
+                fontWeight = FontWeight.Black
+            )
+        )
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/WorkflowFlow.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/WorkflowFlow.kt
@@ -1,0 +1,42 @@
+package com.hereliesaz.hg2gui.ui
+
+data class Workflow(val name: String, val template: String)
+
+/**
+ * Drives the Workflows pill: saving and running named command templates. `{placeholder}`
+ * substrings in the template are the only thing that makes a workflow parameterized - no
+ * separate arg-declaration step. Reuses SessionUiState's awaitPromptAnswer machinery exactly
+ * like SshFlow does; a run always ends by writing the assembled command into the session's
+ * input field for the user to review and press Run themselves, never by executing it.
+ */
+object WorkflowFlow {
+    private val placeholderRegex = Regex("\\{([a-zA-Z0-9_]+)\\}")
+
+    fun placeholders(template: String): List<String> =
+        placeholderRegex.findAll(template).map { it.groupValues[1] }.distinct().toList()
+
+    fun render(template: String, values: Map<String, String>): String =
+        placeholderRegex.replace(template) { match -> values[match.groupValues[1]] ?: match.value }
+
+    suspend fun runNewWorkflowWizard(session: SessionUiState, save: suspend (Workflow) -> Unit) {
+        val name = session.awaitPromptAnswer("Workflow name?").trim()
+        if (name.isEmpty()) return
+
+        val template = session.awaitPromptAnswer(
+            "Command template? Use {name} for a value you'll fill in each time, " +
+                "e.g. git commit -m \"{message}\""
+        ).trim()
+        if (template.isEmpty()) return
+
+        save(Workflow(name, template))
+    }
+
+    suspend fun runWorkflowWizard(session: SessionUiState, workflow: Workflow) {
+        val values = mutableMapOf<String, String>()
+        for (placeholder in placeholders(workflow.template)) {
+            values[placeholder] = session.awaitPromptAnswer("$placeholder?").trim()
+        }
+        session.tokens = emptyList()
+        session.inputText = render(workflow.template, values)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/ai/AiChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/ai/AiChatScreen.kt
@@ -1,0 +1,208 @@
+package com.hereliesaz.hg2gui.ui.ai
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.hg2gui.ui.menu.Azphalt
+
+data class AiMessage(val fromUser: Boolean, val text: String, val command: String? = null)
+
+private val PageYellow = Brush.linearGradient(
+    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
+)
+
+/**
+ * Single-turn natural-language -> command suggestion, styled like every other full-screen
+ * surface (McpServerScreen, CommandGuideScreen): back pill, Eyebrow, then content. Never runs
+ * anything itself - a reply with a command shows a USE pill that hands it to the terminal's
+ * input line for the user to review and press Run, the same "assemble, don't auto-execute" rule
+ * every wizard-produced command already follows.
+ */
+@Composable
+fun AiChatScreen(
+    fullscreen: Boolean,
+    messages: List<AiMessage>,
+    apiKeyConfigured: Boolean,
+    busy: Boolean,
+    onAsk: (String) -> Unit,
+    onUseCommand: (String) -> Unit,
+    onOpenSettings: () -> Unit,
+    onBack: () -> Unit
+) {
+    var input by remember { mutableStateOf("") }
+    val listState = remember { LazyListState() }
+
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(PageYellow)
+            .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
+    ) {
+        Row(
+            Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                Modifier
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.Ink)
+                    .clickable(onClick = onBack)
+                    .padding(horizontal = 14.dp, vertical = 7.dp)
+            ) {
+                Text(
+                    "‹ BACK", color = Azphalt.Yellow,
+                    fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+                )
+            }
+        }
+
+        Eyebrow("AI")
+
+        if (!apiKeyConfigured) {
+            Column(Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 12.dp)) {
+                Text(
+                    "Add an Anthropic API key in Settings → AI first.",
+                    color = Azphalt.Ink.copy(alpha = .7f), fontSize = 12.sp,
+                    modifier = Modifier.padding(bottom = 10.dp)
+                )
+                Box(
+                    Modifier
+                        .clip(RoundedCornerShape(percent = 50))
+                        .background(Azphalt.Ink)
+                        .clickable(onClick = onOpenSettings)
+                        .padding(horizontal = 16.dp, vertical = 9.dp)
+                ) {
+                    Text(
+                        "AI SETTINGS ›", color = Azphalt.Yellow,
+                        fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+                    )
+                }
+            }
+            return@Column
+        }
+
+        LazyColumn(
+            state = listState,
+            modifier = Modifier.weight(1f).fillMaxWidth().padding(horizontal = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(bottom = 8.dp)
+        ) {
+            items(messages) { message ->
+                AiBubble(message, onUseCommand)
+            }
+        }
+
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 16.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(7.dp)
+        ) {
+            Row(
+                Modifier
+                    .weight(1f)
+                    .heightIn(min = 32.dp)
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.Ink)
+                    .padding(start = 14.dp, end = 10.dp, top = 6.dp, bottom = 6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                BasicTextField(
+                    value = input,
+                    onValueChange = { input = it },
+                    modifier = Modifier.weight(1f),
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(color = Azphalt.Yellow, fontSize = 12.sp),
+                    cursorBrush = SolidColor(Azphalt.Yellow),
+                    singleLine = true,
+                    enabled = !busy,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
+                    keyboardActions = KeyboardActions(onSend = {
+                        if (input.isNotBlank() && !busy) {
+                            onAsk(input.trim())
+                            input = ""
+                        }
+                    })
+                )
+            }
+            Row(
+                Modifier
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(if (!busy && input.isNotBlank()) Azphalt.hues[6] else Azphalt.hues[6].copy(alpha = .4f))
+                    .clickable(enabled = !busy && input.isNotBlank()) {
+                        onAsk(input.trim())
+                        input = ""
+                    }
+                    .padding(horizontal = 16.dp, vertical = 9.dp)
+            ) {
+                Text(
+                    if (busy) "…" else "SEND",
+                    style = MaterialTheme.typography.titleMedium.copy(color = Azphalt.White, fontSize = 9.sp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AiBubble(message: AiMessage, onUseCommand: (String) -> Unit) {
+    Column(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(Azphalt.Ink.copy(alpha = if (message.fromUser) .10f else .05f))
+            .padding(12.dp)
+    ) {
+        Text(
+            message.text,
+            style = MaterialTheme.typography.bodyMedium.copy(color = Azphalt.Ink)
+        )
+        if (message.command != null) {
+            Spacer(Modifier.height(8.dp))
+            Box(
+                Modifier
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.Ink)
+                    .clickable { onUseCommand(message.command) }
+                    .padding(horizontal = 12.dp, vertical = 6.dp)
+            ) {
+                Text(
+                    "USE ▸", color = Azphalt.Yellow,
+                    fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun Eyebrow(text: String) {
+    Text(
+        text.uppercase(),
+        style = MaterialTheme.typography.labelSmall,
+        modifier = Modifier.padding(start = 20.dp, top = 8.dp, bottom = 9.dp)
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
@@ -1,0 +1,236 @@
+package com.hereliesaz.hg2gui.ui.azp
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+import com.hereliesaz.hg2gui.ui.menu.Azphalt
+
+/** A search result row, or an already-installed package - shared shape for the list. */
+data class AzpListing(
+    val id: String,
+    val name: String,
+    val author: String,
+    val description: String,
+    val version: String,
+    val kind: String,
+    val installed: Boolean,
+)
+
+private val KINDS = listOf("all", "skill", "mcp", "code", "pack", "asset", "app")
+
+private val PageYellow = Brush.linearGradient(
+    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
+)
+
+/**
+ * Browses the azphalt registry (spec/repository-api.md) - the same `pkg`/`apt` idiom, but for
+ * `.azp` extensions: search, filter by kind, install. HG2Gui has no `.azp` execution runtime, so
+ * "install" downloads + unpacks the archive; only `kind:"skill"` packages do anything further
+ * (their SKILL.md content feeds the AI chat's system prompt - see AiClient/AzpLibrary). Every
+ * other kind is downloaded for the user's own use elsewhere, same as `apt download`.
+ */
+@Composable
+fun AzpStoreScreen(
+    fullscreen: Boolean,
+    results: List<AzpListing>,
+    busy: Boolean,
+    installingId: String?,
+    onSearch: (query: String, kind: String) -> Unit,
+    onInstall: (AzpListing) -> Unit,
+    onBack: () -> Unit,
+) {
+    var query by remember { mutableStateOf("") }
+    var kind by remember { mutableStateOf("all") }
+
+    Column(
+        Modifier
+            .fillMaxSize()
+            .background(PageYellow)
+            .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
+    ) {
+        Row(
+            Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp),
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Box(
+                Modifier
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.Ink)
+                    .clickable(onClick = onBack)
+                    .padding(horizontal = 14.dp, vertical = 7.dp)
+            ) {
+                Text(
+                    "‹ BACK", color = Azphalt.Yellow,
+                    fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+                )
+            }
+        }
+
+        Eyebrow("STORE")
+
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 6.dp),
+            horizontalArrangement = Arrangement.spacedBy(6.dp)
+        ) {
+            KINDS.forEach { k ->
+                val selected = k == kind
+                Box(
+                    Modifier
+                        .clip(RoundedCornerShape(percent = 50))
+                        .background(if (selected) Azphalt.Ink else Azphalt.Ink.copy(alpha = .12f))
+                        .clickable {
+                            kind = k
+                            onSearch(query.trim(), k)
+                        }
+                        .padding(horizontal = 12.dp, vertical = 6.dp)
+                ) {
+                    Text(
+                        k.uppercase(),
+                        color = if (selected) Azphalt.Yellow else Azphalt.Ink,
+                        fontSize = 8.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+                    )
+                }
+            }
+        }
+
+        Row(
+            Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 10.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(7.dp)
+        ) {
+            Row(
+                Modifier
+                    .weight(1f)
+                    .heightIn(min = 32.dp)
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.Ink)
+                    .padding(start = 14.dp, end = 10.dp, top = 6.dp, bottom = 6.dp),
+                verticalAlignment = Alignment.CenterVertically
+            ) {
+                BasicTextField(
+                    value = query,
+                    onValueChange = { query = it },
+                    modifier = Modifier.weight(1f),
+                    textStyle = MaterialTheme.typography.bodyMedium.copy(color = Azphalt.Yellow, fontSize = 12.sp),
+                    cursorBrush = SolidColor(Azphalt.Yellow),
+                    singleLine = true,
+                    enabled = !busy,
+                    keyboardOptions = KeyboardOptions(imeAction = ImeAction.Search),
+                    keyboardActions = KeyboardActions(onSearch = { onSearch(query.trim(), kind) })
+                )
+            }
+            Row(
+                Modifier
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(if (!busy) Azphalt.hues[6] else Azphalt.hues[6].copy(alpha = .4f))
+                    .clickable(enabled = !busy) { onSearch(query.trim(), kind) }
+                    .padding(horizontal = 16.dp, vertical = 9.dp)
+            ) {
+                Text(
+                    if (busy) "…" else "SEARCH",
+                    style = MaterialTheme.typography.titleMedium.copy(color = Azphalt.White, fontSize = 9.sp)
+                )
+            }
+        }
+
+        LazyColumn(
+            modifier = Modifier.weight(1f).fillMaxWidth().padding(horizontal = 20.dp),
+            verticalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(bottom = 12.dp)
+        ) {
+            items(results) { listing ->
+                AzpRow(listing, installingId == listing.id, onInstall)
+            }
+        }
+    }
+}
+
+@Composable
+private fun AzpRow(listing: AzpListing, installing: Boolean, onInstall: (AzpListing) -> Unit) {
+    Row(
+        Modifier
+            .fillMaxWidth()
+            .clip(RoundedCornerShape(12.dp))
+            .background(Azphalt.Ink.copy(alpha = .05f))
+            .padding(12.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Column(Modifier.weight(1f)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Text(
+                    listing.name,
+                    style = MaterialTheme.typography.bodyMedium.copy(color = Azphalt.Ink, fontWeight = FontWeight.ExtraBold)
+                )
+                Spacer(Modifier.width(8.dp))
+                Text(
+                    listing.kind.uppercase(),
+                    color = Azphalt.Ink.copy(alpha = .5f),
+                    fontSize = 8.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+                )
+            }
+            if (listing.description.isNotBlank()) {
+                Text(
+                    listing.description,
+                    color = Azphalt.Ink.copy(alpha = .65f), fontSize = 10.sp,
+                    modifier = Modifier.padding(top = 2.dp)
+                )
+            }
+            Text(
+                "${listing.author} · v${listing.version}",
+                color = Azphalt.Ink.copy(alpha = .45f), fontSize = 9.sp,
+                modifier = Modifier.padding(top = 2.dp)
+            )
+        }
+        Spacer(Modifier.width(10.dp))
+        Box(
+            Modifier
+                .clip(RoundedCornerShape(percent = 50))
+                .background(if (listing.installed) Azphalt.Ink.copy(alpha = .3f) else Azphalt.Ink)
+                .clickable(enabled = !listing.installed && !installing) { onInstall(listing) }
+                .padding(horizontal = 12.dp, vertical = 7.dp)
+        ) {
+            Text(
+                when {
+                    listing.installed -> "INSTALLED"
+                    installing -> "…"
+                    else -> "INSTALL"
+                },
+                color = Azphalt.Yellow,
+                fontSize = 8.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
+            )
+        }
+    }
+}
+
+@Composable
+private fun Eyebrow(text: String) {
+    Text(
+        text.uppercase(),
+        style = MaterialTheme.typography.labelSmall,
+        modifier = Modifier.padding(start = 20.dp, top = 8.dp, bottom = 9.dp)
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideContent.kt
@@ -104,6 +104,42 @@ private val CHAPTERS = listOf(
         )
     ),
     Chapter(
+        "Chapter 12", "Version Control",
+        "The Guide notes that git is the closest thing this galaxy has invented to a time machine — one that only ever travels backward, and only ever to show you exactly how you broke everything.",
+        listOf(
+            Triple("git init", "git initialize", "Initiates an empty, innocent void, blissfully unaware of the catastrophic commit history about to be inflicted upon it."),
+            Triple("git commit", "git commit", "Commits you, irrevocably and in writing, to whatever questionable decision you just made, timestamped for future ridicule."),
+            Triple("git push", "git push", "Propels your private embarrassments into a public, permanent, and painfully searchable record for the rest of the team to find.")
+        )
+    ),
+    Chapter(
+        "Chapter 13", "Reconnaissance & Security",
+        "Before harden-check was written, the Guide notes, curious users simply pointed these three tools at things and hoped for the best. It does not recommend abandoning that tradition, only supplementing it.",
+        listOf(
+            Triple("nmap", "network mapper", "Methodically maps every open, oblivious port on a machine, mostly so you can stare at the results and still not know what to do next."),
+            Triple("whois", "who is", "Whispers back exactly who is responsible for a domain, so you finally have someone specific to blame."),
+            Triple("openssl", "open secure sockets layer", "Offers one thousand ways to encrypt, decrypt, sign, and verify, exactly none of which you will remember the flags for tomorrow.")
+        )
+    ),
+    Chapter(
+        "Chapter 14", "Automation",
+        "The Guide observes that automation is simply the art of making your mistakes happen on a schedule, unattended, and without a witness.",
+        listOf(
+            Triple("cron", "chronos", "Commits your future self to unattended, unsupervised chaos, precisely on schedule, forever, until you remember it exists."),
+            Triple("xargs", "extended arguments", "Extracts every argument you piped it and hurls them at the next command, whether or not that command was prepared to catch them."),
+            Triple("watch", "watch", "Watches a command fail, again and again, at an interval you chose specifically so you wouldn't have to.")
+        )
+    ),
+    Chapter(
+        "Chapter 15", "Artificial Wisdom",
+        "The Guide is famously ambivalent about artificial intelligence, mostly because every civilization that built one eventually asked it a shell command and got a very confident, occasionally correct, answer. Note: none of the following are typed commands - they are pills, tapped, like everything else here.",
+        listOf(
+            Triple("AI chat", "natural-language to command", "Answers plain, foolish English with a command it is fairly, if not entirely, confident about, then has the decency to make you press the button yourself."),
+            Triple("Store", "azphalt package browser", "Sells you a stranger's skills, agents, and extensions by the package, most of which this particular Guide has absolutely no way to run."),
+            Triple("skill", "installed skill package", "Quietly reads a stranger's homework over your assistant's shoulder, then lets it answer your next question as though it always knew.")
+        )
+    ),
+    Chapter(
         "chapter_01", "The Absurdity of Redundancy",
         "It is a well-documented phenomenon that any sufficiently advanced filesystem will spontaneously generate duplicate files with slightly altered casing, just to see if the user is paying attention.",
         listOf(Triple("ls -a", "list, all", "Lifts the veil on the lurking, hidden files, highlighting the horrific reality that your system has secrets."))

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideContent.kt
@@ -94,6 +94,16 @@ private val CHAPTERS = listOf(
         )
     ),
     Chapter(
+        "Chapter 11", "Self-Knowledge",
+        "The Guide notes that HG2Gui also ships four small oracles of its own, bootstrapped straight into the shell rather than fetched by any package manager. Three turn the lens inward. One dares to look outward, but only ever as far as the single address you hand it.",
+        listOf(
+            Triple("osint-lookup", "open-source intelligence lookup", "Obsessively obtains obscure open-source omens about the one domain you dared to name, then offers them up without a shred of context or comfort."),
+            Triple("net-inventory", "network inventory", "Narrates the naked, humiliating truth of your own network - every interface, route, and DNS server you never bothered to name."),
+            Triple("harden-check", "harden check", "Halfheartedly hunts for holes in your own home, then hands you a list of horrors you now cannot un-know."),
+            Triple("sysinfo", "system information", "Surveys the sprawling, sorry state of everything you've installed, and solemnly informs you exactly how much storage it cost you.")
+        )
+    ),
+    Chapter(
         "chapter_01", "The Absurdity of Redundancy",
         "It is a well-documented phenomenon that any sufficiently advanced filesystem will spontaneously generate duplicate files with slightly altered casing, just to see if the user is paying attention.",
         listOf(Triple("ls -a", "list, all", "Lifts the veil on the lurking, hidden files, highlighting the horrific reality that your system has secrets."))

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -89,11 +89,48 @@ object Azphalt {
         val pool = grounds.filter { it !== exclude }.ifEmpty { grounds }
         val total = pool.sumOf { it.weight }
         var roll = (0 until total).random()
+        return groundFrom(pool, roll)
+    }
+
+    private fun groundFrom(pool: List<Ground>, rollIn: Int): Ground {
+        var roll = rollIn
         for (g in pool) {
             if (roll < g.weight) return g
             roll -= g.weight
         }
         return pool.last()
+    }
+
+    /** Max grounds rerolls in one app session - "may reroll once, twice at most" per the style
+     *  guide, so a long session doesn't feel static without ever feeling arbitrary. */
+    const val MAX_GROUND_REROLLS = 2
+
+    /** Session-scoped ground selection, holding the current [Ground] and a reroll budget.
+     *  [reroll] is a no-op past [MAX_GROUND_REROLLS] - callers should only invoke it when no
+     *  pill gesture (drag, swing, cascade) is in flight, same as any other state mutation that
+     *  would fight an in-progress animation. */
+    class GroundState(initial: Ground) {
+        var current by mutableStateOf(initial)
+            private set
+        var rerollsUsed by mutableStateOf(0)
+            private set
+
+        val canReroll: Boolean get() = rerollsUsed < MAX_GROUND_REROLLS
+
+        fun reroll() {
+            if (!canReroll) return
+            current = randomGround(exclude = current)
+            rerollsUsed++
+        }
+    }
+
+    /** One ground roll per composition, persisted across recomposition (not process death) via
+     *  [remember] - a config change or process restart gets a fresh roll, same as any other
+     *  `remember`-scoped session state in this app. */
+    @Composable
+    fun rememberGroundState(): GroundState {
+        val initial = remember { randomGround() }
+        return remember { GroundState(initial) }
     }
 
     /** A coordinated multi-hue combo pulled from a single film scene, for a screen that needs

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -34,7 +34,11 @@ import kotlinx.coroutines.launch
 
 object Azphalt {
     val Ink = Color(0xFF1E1A17)
-    val Yellow = Color(0xFFE8C81E)
+    // The real Azphalt design-system token is --yellow-bright: #F0D42A - distinct from --page
+    // (#E8C81E, the ground colour). Every existing use of this constant is as a text/accent
+    // colour on ink (selected pills, trail crumbs, badges), which is exactly what --yellow-bright
+    // is for; it was previously set to --page's value by mistake.
+    val Yellow = Color(0xFFF0D42A)
     val White = Color(0xFFFFFFFF)
 
     // Fourteen hues in fixed assignment order (hueOf hashes an id into this list - color carries

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -37,18 +37,75 @@ object Azphalt {
     val Yellow = Color(0xFFE8C81E)
     val White = Color(0xFFFFFFFF)
 
+    // Fourteen hues in fixed assignment order (hueOf hashes an id into this list - color carries
+    // no meaning beyond telling a stack of pills apart). The first ten sit on the default yellow
+    // ground; gray/sage/tan/brown extend the set for the rarer grounds and category recolors -
+    // per the HG2Gui style guide's "01 - Ground" / "02 - Palette" sections.
     val hues = listOf(
         Color(0xFF6B4FBB), Color(0xFF2FA9C4), Color(0xFF1F9E86), Color(0xFF5AAE34),
         Color(0xFFD9A21C), Color(0xFFD9762A), Color(0xFFC6392F), Color(0xFFB03A6E),
-        Color(0xFF8E4FA8), Color(0xFF2E6FB7)
+        Color(0xFF8E4FA8), Color(0xFF2E6FB7),
+        Color(0xFF8A9296), Color(0xFF4E7D6E), Color(0xFFC9A45C), Color(0xFF8C6E4E)
     )
     val caps = listOf(
         Color(0xFF4B3489), Color(0xFF1F7B90), Color(0xFF137060), Color(0xFF3E7D22),
         Color(0xFFA2760F), Color(0xFFA6551A), Color(0xFF93251D), Color(0xFF7F2A4D),
-        Color(0xFF653578), Color(0xFF1E4E85)
+        Color(0xFF653578), Color(0xFF1E4E85),
+        Color(0xFF616A6E), Color(0xFF365A4E), Color(0xFF96762F), Color(0xFF634B31)
+    )
+    val hueNames = listOf(
+        "violet", "cyan", "teal", "green", "amber", "orange", "red", "magenta", "purple", "blue",
+        "gray", "sage", "tan", "brown"
     )
 
     fun hueOf(id: String) = (id.hashCode().let { if (it < 0) -it else it }) % hues.size
+
+    /** A named background - "the page is yellow. Not black, not white." - plus its own fold
+     *  gradient. [weight] controls how often [randomGround] picks it; Mustard is weighted far
+     *  heavier since it's the primary. */
+    data class Ground(val name: String, val page: Color, val foldLight: Color, val foldDark: Color, val weight: Int = 1)
+
+    // Mustard's fold-light/fold-dark are the style guide's own literal tokens. The other six
+    // grounds are given as a single reference swatch each (no separate fold tokens in the
+    // source) - foldLight/foldDark are derived from that one swatch with a fixed lighten/darken
+    // step, matching Mustard's own light/dark offset, until real per-ground tokens exist.
+    val grounds: List<Ground> = listOf(
+        Ground("Mustard", Color(0xFFE8C81E), Color(0xFFF2D82C), Color(0xFFD9B615), weight = 6),
+        Ground("Maroon", Color(0xFF8F1F34), Color(0xFFA22940), Color(0xFF7A1A2C)),
+        Ground("Navy", Color(0xFF163A63), Color(0xFF204B7C), Color(0xFF0F2C4C)),
+        Ground("Cerulean", Color(0xFF2D6EA8), Color(0xFF3C82C2), Color(0xFF215A8C)),
+        Ground("Teal", Color(0xFF1D6B62), Color(0xFF267F74), Color(0xFF14554E)),
+        Ground("Pink", Color(0xFFD4728F), Color(0xFFDD879F), Color(0xFFC15D7A)),
+        Ground("Olive", Color(0xFF8F8A2E), Color(0xFFA29C36), Color(0xFF747024))
+    )
+
+    /** Picks a ground, weighted per [Ground.weight], optionally never returning [exclude] - used
+     *  for a mid-session reroll so it doesn't just pick the same ground back. */
+    fun randomGround(exclude: Ground? = null): Ground {
+        val pool = grounds.filter { it !== exclude }.ifEmpty { grounds }
+        val total = pool.sumOf { it.weight }
+        var roll = (0 until total).random()
+        for (g in pool) {
+            if (roll < g.weight) return g
+            roll -= g.weight
+        }
+        return pool.last()
+    }
+
+    /** A coordinated multi-hue combo pulled from a single film scene, for a screen that needs
+     *  more than one hue to cohere (a header plus its pills) - see the style guide's "02b -
+     *  Reference groupings". Picking freehand is the thing this replaces. */
+    data class Grouping(val headerBg: Color, val hues: List<Color>)
+
+    val groupings: Map<String, Grouping> = mapOf(
+        "Vogon stage" to Grouping(Color(0xFF8B6420), listOf(Color(0xFFC6392F), Color(0xFF2E6FB7), Color(0xFF0F2447))),
+        "Oolon Colluphid" to Grouping(Color(0xFF8B3350), listOf(Color(0xFF2E6FB7), Color(0xFFD9A21C), Color(0xFFC9A45C))),
+        "Babel fish" to Grouping(Color(0xFF8B0021), listOf(Color(0xFFB03A6E), Color(0xFFD9762A), Color(0xFF8C6E4E))),
+        "Improbability party" to Grouping(Color(0xFF123A52), listOf(Color(0xFF5AAE34), Color(0xFFC6392F), Color(0xFF8E4FA8))),
+        "Improbability den" to Grouping(Color(0xFF4E7D6E), listOf(Color(0xFF8C6E4E), Color(0xFF8A9296), Color(0xFF365A4E))),
+        "Hyperspace" to Grouping(Color(0xFF163A63), listOf(Color(0xFF8A9296), Color(0xFFC9A45C), Color(0xFFC6392F))),
+        "Point-of-View Gun" to Grouping(Color(0xFFB03A6E), listOf(Color(0xFFC6392F), Color(0xFF5AAE34), Color(0xFF8B6420)))
+    )
 
     const val SLIDE_MS = 420 / 3
     const val DROP_MS = 420 / 3

--- a/composeApp/src/commonTest/kotlin/com/hereliesaz/hg2gui/ui/AsciiArtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/hereliesaz/hg2gui/ui/AsciiArtTest.kt
@@ -1,0 +1,36 @@
+package com.hereliesaz.hg2gui.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AsciiArtTest {
+
+    @Test
+    fun prose_isNotArt() {
+        val text = """
+            This is a completely ordinary paragraph of output.
+            It has several lines of real words in it.
+            Nothing here should look like a picture.
+        """.trimIndent()
+        assertFalse(looksLikeAsciiArt(text))
+    }
+
+    @Test
+    fun shortBlock_isNotArt() {
+        assertFalse(looksLikeAsciiArt("###\n###"))
+    }
+
+    @Test
+    fun symbolDenseBlock_isArt() {
+        val text = """
+            /\_/\
+            ( o.o )
+            > ^ <
+            #===========#
+            |///////////|
+            #===========#
+        """.trimIndent()
+        assertTrue(looksLikeAsciiArt(text))
+    }
+}

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -46,6 +46,12 @@ Two more root pills sit alongside the shell categories, neither backed by a shel
 *   **AI**: one `chat…` pill opening a natural-language-to-command chat screen (requires an
     Anthropic API key set in Settings → AI). Never runs anything itself — a suggested command
     shows a USE pill that hands it to the command line the same way.
+*   **Store**: one `search…` pill opening the azphalt.store package browser — the same idea as
+    `pkg`/`apt`, but for `.azp` extensions (assets, code, packs, companion apps, MCP-server
+    headers, and AI-skill bundles). Filter by kind, then INSTALL downloads and unpacks a package.
+    HG2Gui has no `.azp` execution runtime, so only `skill`-kind packages do anything further —
+    their `SKILL.md` content is folded into the AI chat's system prompt. Everything else is
+    download-only, for use elsewhere, the same as `apt download`. See `docs/USER_GUIDE.md`.
 
 ## Built-in commands
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -38,6 +38,15 @@ predates them (`DistroManager.ensureBundledScripts`):
 
 See `docs/USER_GUIDE.md` for the full description of each.
 
+Two more root pills sit alongside the shell categories, neither backed by a shell binary:
+
+*   **Workflows**: saved command templates. Each saved one is a pill that asks for any
+    `{placeholder}` values the template needs, then drops the assembled command onto the command
+    line to review and run — a `new…` pill saves one from a name plus a template string.
+*   **AI**: one `chat…` pill opening a natural-language-to-command chat screen (requires an
+    Anthropic API key set in Settings → AI). Never runs anything itself — a suggested command
+    shows a USE pill that hands it to the command line the same way.
+
 ## Built-in commands
 
 These ten are the only commands HG2Gui itself implements — see `terminal/Builtins.kt`. Every

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -1,0 +1,131 @@
+# The Guide
+
+Every entry in HG2Gui's in-app Guide — a real command paired with an invented,
+tone-not-fiction definition (`ui/guide/GuideContent.kt`). The Guide adds flavor, never a false
+claim about what a command actually does. This file is a flat export for reference; the app's
+own reader (`ui/guide/GuideReaderScreen.kt`) is the canonical source and wipes each entry in on
+open.
+
+## Chapter 1 — Standard Input
+
+The Hitchhiker's Guide to the Galaxy defines Terminal as "fatal," and encourages anyone using one to emulate that.
+
+- **`ls`** (list) — Lists every file in the directory, but completely glosses over every file without a name.
+- **`echo`** (echo) — Because it wasn't all Narcissus' fault.
+- **`cd`** (change directory) — Changes your directory, but sadly, not your destiny, duties, death, damnation, or deal.
+
+## Chapter 2 — File Permissions
+
+To prevent the entire universe from collapsing under the weight of its own poorly written shell scripts, the Unix permissions model was invented to ensure nobody could actually touch anything of value.
+
+- **`chmod`** (change mode) — Charades played with the operating system, pretending you have power over the inevitable decay of your data.
+- **`chown`** (change owner) — Transfers the crushing, inescapable existential burden of ownership from one doomed user to another.
+
+## Chapter 3 — Navigation
+
+Space is big. You just won't believe how vastly, hugely, mind-bogglingly big it is. But it is nothing compared to the labyrinthine absurdity of the root file system.
+
+- **`pwd`** (print working directory) — Proves without a shadow of a doubt that you are exactly where you didn't want to be.
+- **`mkdir`** (make directory) — Manufactures a meticulously sterile void, perfectly prepared to house your digital disappointments.
+
+## Chapter 4 — Package Management
+
+The Guide notes that all major galactic civilizations go through three distinct and recognizable phases of package management: Survival (How do I install this?), Inquiry (Why is this dependency broken?), and Sophistication (Where did my free space go?).
+
+- **`pkg install`** (package install) — Procures perfectly packaged problems you previously didn't possess.
+- **`apt-get update`** (advanced package tool get) — Asks the universe if entropy has escalated since you last inquired. Spoiler: It has.
+
+## Chapter 6 — Text Editors
+
+*(Note: Chapter 5 was eaten by a small, heavily armed logic flaw.)* There is a long and storied history of holy wars across the galaxy, mostly fought over the proper way to exit a text editor.
+
+- **`nano`** (nano's another editor) — Nurtures your neuroses by explicitly explaining how to escape the very cage you just built.
+- **`vi`** (visual) — Vindicates the Vogon view that true art requires unyielding, inescapable agony.
+
+## Chapter 7 — Processes
+
+A process is simply a program that has managed to briefly trick the CPU into believing it has a purpose.
+
+- **`top`** (table of processes) — Tally of the parasitic processes currently consuming the cold, calculating core of your computer.
+- **`kill`** (kill) — Kicks the metaphorical chair out from beneath a process that has outlived its microscopic usefulness.
+
+## Chapter 8 — Storage
+
+The Encyclopedia Galactica defines a file system as a logical method for storing data. The Guide defines it as a digital sock drawer where you will inevitably lose the one script you actually need.
+
+- **`df`** (disk free) — Documents the depressing depletion of your disk space, offering absolutely zero psychological support.
+- **`rm`** (remove) — Renders reality slightly emptier, rapidly resolving the temporary existence of your trivial files.
+
+## Chapter 9 — Shell Scripting
+
+If you are going to do something utterly pointless, the Guide advises that you should at least automate it so you can be somewhere else when the error logs start flooding in.
+
+- **`bash`** (bourne-again shell) — Bashes your fragile, flawed human logic repeatedly against the unforgiving anvil of machine syntax.
+- **`source`** (source) — Sucks the soul out of a separate script, violently assimilating its variables like a digital vampire.
+
+## Chapter 10 — Networking
+
+Connecting to the internet from a terminal emulator is much like shouting into a black hole, except occasionally the black hole shouts back to offer you a suspiciously cheap pharmaceutical product.
+
+- **`ping`** (packet internet groper) — Pokes the pitch-black abyss of the internet, praying something out there pokes back.
+- **`ssh`** (secure shell) — Sends your consciousness hurtling through hyperspace, solely so you can shatter systems from the safety of your sofa.
+
+## chapter_01 — The Absurdity of Redundancy
+
+It is a well-documented phenomenon that any sufficiently advanced filesystem will spontaneously generate duplicate files with slightly altered casing, just to see if the user is paying attention.
+
+- **`ls -a`** (list, all) — Lifts the veil on the lurking, hidden files, highlighting the horrific reality that your system has secrets.
+
+## chapter_02 — Doppelgänger Permissions
+
+You may attempt to read this file, but it will only tell you that the permissions you thought you understood were merely another language game designed to keep you from realizing the terminal is actually empty.
+
+- **`sudo`** (superuser do) — Summons a superficial sense of supremacy, temporarily tricking the terminal into trusting your terrible ideas.
+
+## chapter_03 — The Infinite Directory
+
+A wise philosopher once noted that having two maps of the exact same territory does not help you find your keys any faster.
+
+- **`rmdir`** (remove directory) — Removes the remnants of a room that was already agonizingly absent of anything.
+
+## chapter_04 — Ghost Dependencies
+
+You have successfully downloaded a duplicate chapter about package management. The dependencies for understanding this chapter include a complete abandonment of logical coherence.
+
+- **`dpkg`** (debian package) — Delivers the dependent data with the depressing demeanor of a doomed, depressed dictionary.
+
+## chapter_05 — The Anomaly
+
+Curiously, while the uppercase Chapter 5 was destroyed by a logic flaw, this file survived. It contains nothing but the creeping dread of realization.
+
+- **`find`** (find) — Frantically flails through the filesystem, finally confirming the absolute absence of whatever you were foolish enough to look for.
+
+## chapter_06 — The Mirror Editor
+
+An editor editing a file about an editor editing a duplicate file.
+
+- **`cat`** (concatenate) — Carelessly coughs the complete contents of a file directly onto your screen, utterly unconcerned with context or comprehension.
+
+## chapter_07 — Zombie Processes
+
+This file is the textual equivalent of a zombie process. It has no parent, it serves no function, and it simply refuses to die.
+
+- **`ps`** (process status) — Parades the pathetic, purgatorial processes perpetually trapped in the processor's penal colony.
+
+## chapter_08 — Backing up the Void
+
+To ensure the utmost safety of your completely irrelevant data, it is highly recommended to keep a lower-case copy of every upper-case file.
+
+- **`tar`** (tape archive) — Traps your trivial texts in a tight, terrible tomb, ensuring they degrade together in the dark.
+
+## chapter_09 — Looping the Loop
+
+Automating the creation of the very file you are reading. Time is an illusion. Terminal history doubly so.
+
+- **`grep`** (global regular expression print) — Grabs greedily at the galactic garbage heap, guaranteeing you only gather other, slightly sharper garbage.
+
+## chapter_10 — The Ultimate Handshake
+
+The final duplicate file. By this point, the Guide assumes you have either mastered the command line or have thrown your device into the nearest body of water.
+
+- **`ifconfig`** (interface configuration) — Inappropriately forces your interface to strip and show its subnet mask to complete, calculating strangers.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -70,6 +70,15 @@ Connecting to the internet from a terminal emulator is much like shouting into a
 - **`ping`** (packet internet groper) — Pokes the pitch-black abyss of the internet, praying something out there pokes back.
 - **`ssh`** (secure shell) — Sends your consciousness hurtling through hyperspace, solely so you can shatter systems from the safety of your sofa.
 
+## Chapter 11 — Self-Knowledge
+
+The Guide notes that HG2Gui also ships four small oracles of its own, bootstrapped straight into the shell rather than fetched by any package manager. Three turn the lens inward. One dares to look outward, but only ever as far as the single address you hand it.
+
+- **`osint-lookup`** (open-source intelligence lookup) — Obsessively obtains obscure open-source omens about the one domain you dared to name, then offers them up without a shred of context or comfort.
+- **`net-inventory`** (network inventory) — Narrates the naked, humiliating truth of your own network — every interface, route, and DNS server you never bothered to name.
+- **`harden-check`** (harden check) — Halfheartedly hunts for holes in your own home, then hands you a list of horrors you now cannot un-know.
+- **`sysinfo`** (system information) — Surveys the sprawling, sorry state of everything you've installed, and solemnly informs you exactly how much storage it cost you.
+
 ## chapter_01 — The Absurdity of Redundancy
 
 It is a well-documented phenomenon that any sufficiently advanced filesystem will spontaneously generate duplicate files with slightly altered casing, just to see if the user is paying attention.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -79,6 +79,38 @@ The Guide notes that HG2Gui also ships four small oracles of its own, bootstrapp
 - **`harden-check`** (harden check) — Halfheartedly hunts for holes in your own home, then hands you a list of horrors you now cannot un-know.
 - **`sysinfo`** (system information) — Surveys the sprawling, sorry state of everything you've installed, and solemnly informs you exactly how much storage it cost you.
 
+## Chapter 12 — Version Control
+
+The Guide notes that git is the closest thing this galaxy has invented to a time machine — one that only ever travels backward, and only ever to show you exactly how you broke everything.
+
+- **`git init`** (git initialize) — Initiates an empty, innocent void, blissfully unaware of the catastrophic commit history about to be inflicted upon it.
+- **`git commit`** (git commit) — Commits you, irrevocably and in writing, to whatever questionable decision you just made, timestamped for future ridicule.
+- **`git push`** (git push) — Propels your private embarrassments into a public, permanent, and painfully searchable record for the rest of the team to find.
+
+## Chapter 13 — Reconnaissance & Security
+
+Before harden-check was written, the Guide notes, curious users simply pointed these three tools at things and hoped for the best. It does not recommend abandoning that tradition, only supplementing it.
+
+- **`nmap`** (network mapper) — Methodically maps every open, oblivious port on a machine, mostly so you can stare at the results and still not know what to do next.
+- **`whois`** (who is) — Whispers back exactly who is responsible for a domain, so you finally have someone specific to blame.
+- **`openssl`** (open secure sockets layer) — Offers one thousand ways to encrypt, decrypt, sign, and verify, exactly none of which you will remember the flags for tomorrow.
+
+## Chapter 14 — Automation
+
+The Guide observes that automation is simply the art of making your mistakes happen on a schedule, unattended, and without a witness.
+
+- **`cron`** (chronos) — Commits your future self to unattended, unsupervised chaos, precisely on schedule, forever, until you remember it exists.
+- **`xargs`** (extended arguments) — Extracts every argument you piped it and hurls them at the next command, whether or not that command was prepared to catch them.
+- **`watch`** (watch) — Watches a command fail, again and again, at an interval you chose specifically so you wouldn't have to.
+
+## Chapter 15 — Artificial Wisdom
+
+The Guide is famously ambivalent about artificial intelligence, mostly because every civilization that built one eventually asked it a shell command and got a very confident, occasionally correct, answer. Note: none of the following are typed commands — they are pills, tapped, like everything else here.
+
+- **`AI chat`** (natural-language to command) — Answers plain, foolish English with a command it is fairly, if not entirely, confident about, then has the decency to make you press the button yourself.
+- **`Store`** (azphalt package browser) — Sells you a stranger's skills, agents, and extensions by the package, most of which this particular Guide has absolutely no way to run.
+- **`skill`** (installed skill package) — Quietly reads a stranger's homework over your assistant's shoulder, then lets it answer your next question as though it always knew.
+
 ## chapter_01 — The Absurdity of Redundancy
 
 It is a well-documented phenomenon that any sufficiently advanced filesystem will spontaneously generate duplicate files with slightly altered casing, just to see if the user is paying attention.

--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -91,6 +91,29 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
     enforced server-side, in `McpTools.callTool`, on every `shell.*` invocation — not just by
     what `tools/list` chooses to advertise (it always advertises both groups).
 
+### 8. Blocks, Workflows, AI chat (Kotlin, `commonMain`/`androidMain`)
+*   **Blocks**: no new state layer — `TerminalScreen`'s existing `BufferEntry` gained tap-to-
+    reveal COPY/RE-RUN/SHARE actions. Copy/share are androidMain hooks (`ClipboardManager`,
+    `Intent.ACTION_SEND`) passed down from `TerminalActivity`; re-run is pure `SessionUiState`
+    mutation (writes the entry's command into `inputText`, never runs it).
+*   **Workflows** (`ui/WorkflowFlow.kt` commonMain, `managers/WorkflowStore.kt` androidMain):
+    named command templates with `{placeholder}` substrings, stored the same flat-SharedPreferences
+    way as `SshPresets`. Saving and running both reuse the `wizardId`/`onWizard` pill primitive and
+    `SessionUiState.awaitPromptAnswer` exactly like the ssh wizard — a run asks one question per
+    placeholder, then writes the rendered command into the input line for the user to review and
+    press Run. `CommandTree.workflowsRoot` is a synthesized root pill (like `sys`/`apps`/`feat`),
+    not a shell binary.
+*   **AI chat** (`ai/AiClient.kt`, `managers/AiSettings.kt` androidMain; `ui/ai/AiChatScreen.kt`
+    commonMain; `ui/AiSettingsScreen.kt` androidMain): single-turn natural-language → shell-command
+    suggestion via the official Anthropic Java SDK (`com.anthropic:anthropic-java`), reached
+    through a synthesized `ai` root pill (`wizardId = "ai-chat"`, used to navigate screens rather
+    than collect prompt answers — a valid second use of the `onWizard` hook). The API key is
+    user-supplied and stored in plain `SharedPreferences`, same posture as the MCP pairing token
+    and SSH key paths. A suggested command is never executed automatically — the chat screen's
+    USE pill hands it to the terminal's input line, same "assemble, don't auto-run" rule every
+    wizard-produced command already follows; this deliberately does not duplicate the MCP server's
+    biometric-gated `shell.exec` tool.
+
 ## Data Flow
 1.  **Input**: The user taps `wifi`. No text is typed. Since `wifi` leaves no further
     parameters, it runs immediately on that tap.

--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -97,9 +97,14 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
     `Intent.ACTION_SEND`) passed down from `TerminalActivity`; re-run is pure `SessionUiState`
     mutation (writes the entry's command into `inputText`, never runs it). `BufferEntry` also
     calls `ui/AsciiArt.kt`'s `looksLikeAsciiArt()` on the entry's output and, when it matches,
-    renders via `AsciiArtCanvas` (a `Canvas` drawing one flat filled rect per character, sized by
-    a light-to-dense character ramp) instead of the plain monospace `Text` — a PLAIN TEXT toggle
-    in the same tap-to-reveal row always falls back to the raw string.
+    renders via `AsciiArtCanvas` instead of the plain monospace `Text` — a PLAIN TEXT toggle in
+    the same tap-to-reveal row always falls back to the raw string. `AsciiArtCanvas` maps each
+    character to a density (a light-to-dense ramp; box-drawing/block Unicode is treated as fully
+    dense), then runs marching squares over that density grid (`buildContourPath`) to trace one
+    smooth filled vector `Path` - the same contour-tracing approach a Potrace-style vectorizer
+    uses, applied to the density field instead of raster pixels. No model, no network call: it's a
+    deterministic, offline algorithm that constructs an actual vector shape from the art's
+    character grid rather than reproducing glyphs or a blocky per-cell mosaic.
 *   **Workflows** (`ui/WorkflowFlow.kt` commonMain, `managers/WorkflowStore.kt` androidMain):
     named command templates with `{placeholder}` substrings, stored the same flat-SharedPreferences
     way as `SshPresets`. Saving and running both reuse the `wizardId`/`onWizard` pill primitive and

--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -114,6 +114,33 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
     wizard-produced command already follows; this deliberately does not duplicate the MCP server's
     biometric-gated `shell.exec` tool.
 
+### 9. Store (azphalt registry client) (Kotlin, `commonMain`/`androidMain`)
+*   **`azp/AzpClient.kt`** (androidMain): OkHttp client for the azphalt Repository API
+    (`spec/repository-api.md` in `hereliesaz/azphalt`) against the live registry at
+    `https://www.azphalt.store` — `search(query, kind, page)` (`GET /packages`) and
+    `download(id, version)` (`GET /packages/{id}/versions/{version}/download`). Free packages
+    only; paid packages need a Bearer entitlement this client does not obtain.
+*   **`azp/AzpInstaller.kt`** (androidMain): a `.azp` is a plain ZIP archive with `manifest.json`
+    at its root (`spec/package-format.md`) — `install()` unzips it into
+    `filesDir/azp/<id>/<version>/` (rejecting any entry that would escape via `..`), reads
+    `manifest.json`'s `kind`, and for `kind:"skill"` collects the declared `skill.skills[].id`
+    list so the SKILL.md payloads can be found again later.
+*   **`managers/AzpLibrary.kt`** (androidMain): flat-SharedPreferences record of installed
+    packages, same shape as `WorkflowStore`/`SshPresets`. `installedSkillTexts()` reads each
+    installed skill package's `skills/<id>/SKILL.md` off disk, capped to a fixed character budget,
+    for `AiClient` to fold into its system prompt.
+*   **`ui/azp/AzpStoreScreen.kt`** (commonMain): search box, kind-filter pills (all/skill/mcp/
+    code/pack/asset/app), and a result list with an INSTALL/INSTALLED pill per package — same
+    visual idiom as `AiChatScreen`. Reached via a synthesized `azp` root pill
+    (`CommandTree.azpRoot`, `wizardId = "azp-store"` navigates to the screen, same reuse of
+    `onWizard` as the AI pill).
+*   HG2Gui has no `.azp` execution runtime (no WASM sandbox, no MCP client), so "install" for
+    every kind except `skill` is download-and-unpack only — the package sits on-device for the
+    user's own use elsewhere, the same as `apt download` versus `apt install`. Signature
+    verification (the Ed25519 model in `package-format.md`) is **not implemented** in this v1;
+    packages are trusted at download time, same posture as this app's other unverified local
+    settings (the MCP pairing token, the AI API key).
+
 ## Data Flow
 1.  **Input**: The user taps `wifi`. No text is typed. Since `wifi` leaves no further
     parameters, it runs immediately on that tap.

--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -95,7 +95,11 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
 *   **Blocks**: no new state layer — `TerminalScreen`'s existing `BufferEntry` gained tap-to-
     reveal COPY/RE-RUN/SHARE actions. Copy/share are androidMain hooks (`ClipboardManager`,
     `Intent.ACTION_SEND`) passed down from `TerminalActivity`; re-run is pure `SessionUiState`
-    mutation (writes the entry's command into `inputText`, never runs it).
+    mutation (writes the entry's command into `inputText`, never runs it). `BufferEntry` also
+    calls `ui/AsciiArt.kt`'s `looksLikeAsciiArt()` on the entry's output and, when it matches,
+    renders via `AsciiArtCanvas` (a `Canvas` drawing one flat filled rect per character, sized by
+    a light-to-dense character ramp) instead of the plain monospace `Text` — a PLAIN TEXT toggle
+    in the same tap-to-reveal row always falls back to the raw string.
 *   **Workflows** (`ui/WorkflowFlow.kt` commonMain, `managers/WorkflowStore.kt` androidMain):
     named command templates with `{placeholder}` substrings, stored the same flat-SharedPreferences
     way as `SshPresets`. Saving and running both reuse the `wizardId`/`onWizard` pill primitive and

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -99,10 +99,11 @@ binary now, run in the Termux environment below, not a reimplementation of one.
     and share hands the same text to the system share sheet.
 -   **ASCII art rendering:** output that looks like ASCII or box-drawing art (three or more lines,
     heavy on symbols rather than letters — `cowsay`, `figlet`, `jp2a`, `chafa`, and the like)
-    renders as flat filled cells sized by character density instead of literal monospace glyphs,
-    so it reads as art rather than a wall of text. The heuristic is conservative — real prose or a
-    table always falls back to plain text. Tap the entry, then **PLAIN TEXT** to see the raw
-    output (and copy/share it) any time.
+    is traced into one smooth flat vector shape (the same contour-tracing idea a Potrace-style
+    vectorizer uses) instead of literal monospace glyphs, so it reads as a constructed picture
+    rather than a wall of text. The heuristic is conservative — real prose or a table always falls
+    back to plain text. Tap the entry, then **PLAIN TEXT** to see the raw output (and copy/share
+    it) any time.
 -   **Workflows:** the **Workflows** pill (alongside the shell categories) holds saved command
     templates. Picking one asks for any `{placeholder}` values the template uses, then drops the
     assembled command onto the input line, same as everything else here — nothing runs until you

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -97,6 +97,12 @@ binary now, run in the Termux environment below, not a reimplementation of one.
     grabs the output (or the command itself, if there's no output yet), re-run drops the command
     back onto the input line for you to review and press Run (it never runs again on its own),
     and share hands the same text to the system share sheet.
+-   **ASCII art rendering:** output that looks like ASCII or box-drawing art (three or more lines,
+    heavy on symbols rather than letters — `cowsay`, `figlet`, `jp2a`, `chafa`, and the like)
+    renders as flat filled cells sized by character density instead of literal monospace glyphs,
+    so it reads as art rather than a wall of text. The heuristic is conservative — real prose or a
+    table always falls back to plain text. Tap the entry, then **PLAIN TEXT** to see the raw
+    output (and copy/share it) any time.
 -   **Workflows:** the **Workflows** pill (alongside the shell categories) holds saved command
     templates. Picking one asks for any `{placeholder}` values the template uses, then drops the
     assembled command onto the input line, same as everything else here — nothing runs until you

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -93,6 +93,21 @@ binary now, run in the Termux environment below, not a reimplementation of one.
     target's own infrastructure, and it isn't a tool for looking up arbitrary third parties.
     Missing tools (`whois`/`dig`/`curl`/`jq`) print a `pkg install` hint instead of failing
     silently.
+-   **Blocks:** tap any entry in the buffer to reveal **COPY**, **RE-RUN** and **SHARE** — copy
+    grabs the output (or the command itself, if there's no output yet), re-run drops the command
+    back onto the input line for you to review and press Run (it never runs again on its own),
+    and share hands the same text to the system share sheet.
+-   **Workflows:** the **Workflows** pill (alongside the shell categories) holds saved command
+    templates. Picking one asks for any `{placeholder}` values the template uses, then drops the
+    assembled command onto the input line, same as everything else here — nothing runs until you
+    press Run. A **new…** pill saves one: give it a name, then a template like
+    `git commit -m "{message}"`.
+-   **AI:** the **AI** pill opens a chat screen — type a request in plain English and it suggests
+    a shell command (or a short plain-text answer if the request isn't command-shaped), via the
+    Anthropic API. A suggested command shows a **USE ▸** pill that drops it onto the input line
+    for review, exactly like everything else — the chat never runs a command by itself. Needs an
+    API key first: Settings → **AI SETTINGS ›**. The key is stored unencrypted on this device,
+    same as the MCP pairing token and other local settings.
 -   **net-inventory / harden-check / sysinfo:** three more scripts installed alongside
     `osint-lookup`, all local, no arguments needed. `net-inventory` lists this device's own
     network interfaces, routes and DNS config. `harden-check` audits this install's own SSH key

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -108,6 +108,16 @@ binary now, run in the Termux environment below, not a reimplementation of one.
     for review, exactly like everything else — the chat never runs a command by itself. Needs an
     API key first: Settings → **AI SETTINGS ›**. The key is stored unencrypted on this device,
     same as the MCP pairing token and other local settings.
+-   **Store:** the **Store** pill opens a browser for [azphalt.store](https://azphalt.store), the
+    package registry for `.azp` extensions — the same idea as `pkg`/`apt`, but general-purpose:
+    assets, sandboxed code, packs, companion apps, MCP-server headers, and AI-skill bundles all
+    ship as `.azp` packages. Search, filter by kind (skill / mcp / code / pack / asset / app), and
+    tap **INSTALL** to download and unpack one. HG2Gui has no `.azp` execution sandbox, so most
+    kinds are download-only, kept on-device for use elsewhere — the one exception is a **skill**
+    package: its bundled `SKILL.md` is folded into the AI chat's system prompt automatically, so
+    an installed skill actually changes how the AI pill answers. Packages are trusted as
+    downloaded — this v1 does not verify the Ed25519 signature azphalt packages carry, so treat it
+    the same as any other unverified download.
 -   **net-inventory / harden-check / sysinfo:** three more scripts installed alongside
     `osint-lookup`, all local, no arguments needed. `net-inventory` lists this device's own
     network interfaces, routes and DNS config. `harden-check` audits this install's own SSH key

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ jsonpath = "3.0.0"
 jsoup = "1.23.1"
 comparestring2 = "1.0.9"
 kotlinx-serialization-json = "1.9.0"
+anthropic-java = "2.34.0"
 
 [libraries]
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidx-activityCompose" }
@@ -30,6 +31,7 @@ json-path = { group = "com.jayway.jsonpath", name = "json-path", version.ref = "
 jsoup = { group = "org.jsoup", name = "jsoup", version.ref = "jsoup" }
 comparestring2 = { group = "it.andreuzzi", name = "CompareString2", version.ref = "comparestring2" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinx-serialization-json" }
+anthropic-java = { group = "com.anthropic", name = "anthropic-java", version.ref = "anthropic-java" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary

Two unrelated changes landed on this branch before the first one merged, so this PR now covers both.

### 1. Gradle-driven `versionBuild` increment

The version-code increment has to be Gradle's own doing, computed and written before AGP finalizes `versionCode` for the build — not bash `sed` running as a workflow step before or after `./gradlew bundleRelease`.

`composeApp/build.gradle.kts` gets a new, standalone `incrementVersionBuild` task:
- Fetches + resets to `origin/master`, reads the committed `versionBuild`.
- `-PversionCodeMode=strict` fails outright (nothing written, nothing pushed, nothing built) if the committed value alone wouldn't clear Play. `auto` (default) takes the next code after `-PplayMaxVersionCode`, which CI supplies since Gradle has no business calling the Play API itself.
- Writes the new value back with a targeted line substitution, not `Properties.store()` (which rewrites the whole file with its own field order and an auto-generated timestamp comment — every release would otherwise diff the entire file instead of one line).
- Commits and pushes to `master` itself, with the same fetch/reset/retry-on-conflict shape the old bash step used.

`release-play.yml`'s "Resolve the versionCode" step is replaced by a single call to this task, run *before* "Build signed release bundle" — so `version.properties` is already bumped and already pushed by the time compilation starts. The final "Commit the versionCode that shipped" step is gone entirely.

### 2. Workflows, Blocks, and AI command chat (Warp Terminal-inspired)

- **Blocks**: tap a buffer entry to reveal COPY/RE-RUN/SHARE, mirroring the existing tap-to-reveal idiom already used for the MCP pairing token. Re-run only ever populates the input line for review, never fires the command.
- **Workflows**: saved `{placeholder}` command templates, reached via a new Workflows root pill and the existing `wizardId`/`onWizard` mechanism — running one prompts for each placeholder, then hands the assembled command to the input line, same as the ssh wizard.
- **AI**: a natural-language-to-command chat screen backed by the official Anthropic Java SDK, reached via a new AI root pill. Never executes a command itself — suggestions populate the input line for review. Needs a user-supplied API key from Settings → AI (stored unencrypted, same posture as the MCP pairing token).

Color schemes are being organized separately by the repo owner and are out of scope here; Themes were explicitly excluded from this work.

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlinAndroid` / `testPlaystoreDebugUnitTest` (after both changes)
- [x] Ran the actual `incrementVersionBuild` task for real against a throwaway local repo (a bare "origin" + working clone — not the real GitHub remote) through the full `auto`-mode success path and both `strict`-mode paths (clears Play → succeeds; doesn't clear → fails with nothing written/pushed)
- [x] Confirmed a fresh clone from that throwaway origin shows the pushed commit with a clean, minimal one-line diff to `version.properties`
- [x] Confirmed the real repo's `version.properties` is untouched by any non-release Gradle invocation (`printApplicationId`, compile, test)
- [ ] Manual: a real `workflow_dispatch` run against actual Play secrets (no device/secrets available in this environment)
- [ ] Manual on-device: Blocks/Workflows/AI chat spot-check (no device available in this environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_
