### PR TITLE
Ground rotation wiring, menu style reconciliation, Guide Motion, typeset output

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -430,6 +430,10 @@ class TerminalActivity : FragmentActivity() {
                         activeSessionId = activeSessionId,
                         onSessionPick = { activeSessionId = it },
                         onNewSession = {
+                            // A deliberate tap, never mid-gesture - the one place this session
+                            // rerolls the ground (capped at Azphalt.MAX_GROUND_REROLLS regardless
+                            // of how many new tabs get opened).
+                            Azphalt.rerollGround()
                             scope.launch {
                                 val newEngine = withContext(Dispatchers.Default) {
                                     TerminalEngine(this@TerminalActivity)

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/AiSettingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/AiSettingsScreen.kt
@@ -29,10 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
-
-private val PageYellow = Brush.linearGradient(
-    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
-)
+import com.hereliesaz.hg2gui.ui.menu.pageBrush
 
 /**
  * A single masked API-key field + Save, same tap-to-reveal idiom McpServerScreen uses for its
@@ -52,7 +49,7 @@ fun AiSettingsScreen(
     Column(
         Modifier
             .fillMaxSize()
-            .background(PageYellow)
+            .background(Azphalt.currentGround.pageBrush())
             .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
     ) {
         Row(

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/McpServerScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/McpServerScreen.kt
@@ -21,10 +21,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
-
-private val PageYellow = Brush.linearGradient(
-    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
-)
+import com.hereliesaz.hg2gui.ui.menu.pageBrush
 
 /**
  * Server on/off, the shell-exec toggle (biometric-gated on enable - the actual BiometricPrompt
@@ -51,7 +48,7 @@ fun McpServerScreen(
     Column(
         Modifier
             .fillMaxSize()
-            .background(PageYellow)
+            .background(Azphalt.currentGround.pageBrush())
             .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
     ) {
         Row(

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/SettingsScreen.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/SettingsScreen.kt
@@ -16,10 +16,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
-
-private val PageYellow = Brush.linearGradient(
-    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
-)
+import com.hereliesaz.hg2gui.ui.menu.pageBrush
 
 /** Bounds match the range the reporter cared about testing: half size to double. */
 const val FONT_SCALE_MIN_PERCENT = 50
@@ -39,7 +36,7 @@ fun SettingsScreen(
     Column(
         Modifier
             .fillMaxSize()
-            .background(PageYellow)
+            .background(Azphalt.currentGround.pageBrush())
             .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
     ) {
         Row(

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
@@ -35,13 +35,10 @@ import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.managers.TerminalHistoryEntry
 import com.hereliesaz.hg2gui.terminal.ShellAliases
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import com.hereliesaz.hg2gui.ui.menu.pageBrush
 import com.hereliesaz.hg2gui.ui.menu.MenuNode
 import com.hereliesaz.hg2gui.ui.menu.PillMenu
 import kotlinx.coroutines.launch
-
-private val PageYellow = Brush.linearGradient(
-    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
-)
 
 @Composable
 fun TerminalScreen(
@@ -157,7 +154,7 @@ fun TerminalScreen(
     Column(
         Modifier
             .fillMaxSize()
-            .background(PageYellow)
+            .background(Azphalt.currentGround.pageBrush())
             .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
     ) {
 

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/ai/AiChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/ai/AiChatScreen.kt
@@ -29,12 +29,9 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import com.hereliesaz.hg2gui.ui.menu.pageBrush
 
 data class AiMessage(val fromUser: Boolean, val text: String, val command: String? = null)
-
-private val PageYellow = Brush.linearGradient(
-    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
-)
 
 /**
  * Single-turn natural-language -> command suggestion, styled like every other full-screen
@@ -60,7 +57,7 @@ fun AiChatScreen(
     Column(
         Modifier
             .fillMaxSize()
-            .background(PageYellow)
+            .background(Azphalt.currentGround.pageBrush())
             .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
     ) {
         Row(

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
@@ -28,6 +28,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import com.hereliesaz.hg2gui.ui.menu.pageBrush
 
 /** A search result row, or an already-installed package - shared shape for the list. */
 data class AzpListing(
@@ -41,10 +42,6 @@ data class AzpListing(
 )
 
 private val KINDS = listOf("all", "skill", "mcp", "code", "pack", "asset", "app")
-
-private val PageYellow = Brush.linearGradient(
-    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
-)
 
 /**
  * Browses the azphalt registry (spec/repository-api.md) - the same `pkg`/`apt` idiom, but for
@@ -69,7 +66,7 @@ fun AzpStoreScreen(
     Column(
         Modifier
             .fillMaxSize()
-            .background(PageYellow)
+            .background(Azphalt.currentGround.pageBrush())
             .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
     ) {
         Row(

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/editor/EditorScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/editor/EditorScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import com.hereliesaz.hg2gui.ui.menu.pageBrush
 
 /*
  * A plain-text editor for files the shell has no pty to hand to a real one - nano is a real
@@ -31,10 +32,6 @@ import com.hereliesaz.hg2gui.ui.menu.Azphalt
  * embedded command line like the old vi-like editor had: Save and Back are real pills, same
  * page, same capsule primitive as the rest of Azphalt.
  */
-
-private val PageYellow = Brush.linearGradient(
-    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
-)
 
 @Composable
 fun EditorScreen(
@@ -47,7 +44,7 @@ fun EditorScreen(
     onBack: () -> Unit,
     modifier: Modifier = Modifier
 ) {
-    Column(modifier.fillMaxSize().background(PageYellow)) {
+    Column(modifier.fillMaxSize().background(Azphalt.currentGround.pageBrush())) {
         Row(
             Modifier.fillMaxWidth().padding(horizontal = 20.dp, vertical = 18.dp),
             horizontalArrangement = Arrangement.SpaceBetween,

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FilesScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FilesScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import com.hereliesaz.hg2gui.ui.menu.pageBrush
 import kotlinx.coroutines.launch
 
 /*
@@ -47,10 +48,6 @@ import kotlinx.coroutines.launch
  * its siblings squish into thin coloured rods beside it, its children living inside it as
  * smaller rectangles - two accordion levels deep, then a plain record of what's inside.
  */
-
-private val PageYellow = Brush.linearGradient(
-    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
-)
 
 private enum class SortMode(val label: String) { NAME("Name"), NEWEST("Newest") }
 private enum class FMScreen { Browse, Search, Storage, PickMove, PickCopy }
@@ -177,7 +174,7 @@ fun FilesScreen(
     Column(
         modifier
             .fillMaxSize()
-            .background(PageYellow)
+            .background(Azphalt.currentGround.pageBrush())
             .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
     ) {
         // --- Header --------------------------------------------------------------------

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FolderPicker.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FolderPicker.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import com.hereliesaz.hg2gui.ui.menu.pageBrush
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.launch
 
@@ -70,7 +71,7 @@ fun FolderPicker(
 
     val density = LocalDensity.current
 
-    Column(modifier.fillMaxSize().background(PageYellowBrush)) {
+    Column(modifier.fillMaxSize().background(Azphalt.currentGround.pageBrush())) {
         Row(
             Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
@@ -233,10 +234,6 @@ private suspend fun launchAll(vararg blocks: suspend () -> Unit) {
         blocks.forEach { block -> launch { block() } }
     }
 }
-
-private val PageYellowBrush = Brush.linearGradient(
-    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
-)
 
 @Composable
 private fun PickerChip(

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/StorageScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/StorageScreen.kt
@@ -22,16 +22,13 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import com.hereliesaz.hg2gui.ui.menu.pageBrush
 
 /*
  * Storage broken down by content type - real numbers from a recursive walk of the sandbox, not
  * a device-wide figure the app has no way to actually know. Two tabs: the breakdown, and the
  * worst offenders named.
  */
-
-private val PageYellow = Brush.linearGradient(
-    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
-)
 
 private val CATEGORY_HUES = mapOf(
     "Images" to 0, "Documents" to 2, "Code" to 9, "Archives" to 5, "Other" to 4
@@ -52,7 +49,7 @@ fun StorageScreen(
     Column(
         modifier
             .fillMaxSize()
-            .background(PageYellow)
+            .background(Azphalt.currentGround.pageBrush())
             .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
     ) {
         Row(

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/CommandGuideScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/CommandGuideScreen.kt
@@ -21,12 +21,9 @@ import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.Eyebrow
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import com.hereliesaz.hg2gui.ui.menu.pageBrush
 import com.hereliesaz.hg2gui.ui.menu.MenuNode
 import com.hereliesaz.hg2gui.ui.menu.PillMenu
-
-private val PageYellow = Brush.linearGradient(
-    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
-)
 
 /*
  * The guide is a read-through of the exact tree PillMenu itself runs on - picking a command
@@ -60,7 +57,7 @@ fun CommandGuideScreen(
     Column(
         modifier
             .fillMaxSize()
-            .background(PageYellow)
+            .background(Azphalt.currentGround.pageBrush())
             .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
     ) {
         Row(

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideReaderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideReaderScreen.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import com.hereliesaz.hg2gui.ui.menu.pageBrush
 import kotlinx.coroutines.delay
 
 /*
@@ -42,10 +43,6 @@ import kotlinx.coroutines.delay
  * reveal via a left-to-right clip; pills grow their actual width instead, so a rounded end grows
  * into being rather than getting guillotined by a hard clip partway through its curve.
  */
-
-private val PageYellow = Brush.linearGradient(
-    0f to Color(0xFFE8C81E), 0.5f to Color(0xFFD9B615), 1f to Color(0xFFE8C81E)
-)
 
 private val GUIDE_HUES = intArrayOf(6, 5, 4, 2, 9, 0, 7) // red, orange, amber, teal, blue, violet, magenta
 
@@ -64,7 +61,7 @@ fun GuideReaderScreen(
     Column(
         modifier
             .fillMaxSize()
-            .background(PageYellow)
+            .background(Azphalt.currentGround.pageBrush())
             .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
     ) {
         when (view) {

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
@@ -101,36 +102,25 @@ object Azphalt {
         return pool.last()
     }
 
-    /** Max grounds rerolls in one app session - "may reroll once, twice at most" per the style
-     *  guide, so a long session doesn't feel static without ever feeling arbitrary. */
+    /** Max ground rerolls in one app session - "may reroll once, twice at most" per the style
+     *  guide, so a long session doesn't feel static without ever feeling arbitrary. Process-wide
+     *  state (not `remember`-scoped) since EditorScreen runs in its own Activity
+     *  (EditorActivity) with its own composition - a per-composition roll would let the editor
+     *  disagree with the rest of the app about what ground is current. */
     const val MAX_GROUND_REROLLS = 2
 
-    /** Session-scoped ground selection, holding the current [Ground] and a reroll budget.
-     *  [reroll] is a no-op past [MAX_GROUND_REROLLS] - callers should only invoke it when no
-     *  pill gesture (drag, swing, cascade) is in flight, same as any other state mutation that
-     *  would fight an in-progress animation. */
-    class GroundState(initial: Ground) {
-        var current by mutableStateOf(initial)
-            private set
-        var rerollsUsed by mutableStateOf(0)
-            private set
+    var currentGround: Ground by mutableStateOf(randomGround())
+        private set
+    private var groundRerollsUsed = 0
 
-        val canReroll: Boolean get() = rerollsUsed < MAX_GROUND_REROLLS
+    val canRerollGround: Boolean get() = groundRerollsUsed < MAX_GROUND_REROLLS
 
-        fun reroll() {
-            if (!canReroll) return
-            current = randomGround(exclude = current)
-            rerollsUsed++
-        }
-    }
-
-    /** One ground roll per composition, persisted across recomposition (not process death) via
-     *  [remember] - a config change or process restart gets a fresh roll, same as any other
-     *  `remember`-scoped session state in this app. */
-    @Composable
-    fun rememberGroundState(): GroundState {
-        val initial = remember { randomGround() }
-        return remember { GroundState(initial) }
+    /** Call only when no pill gesture (drag, swing, cascade) is in flight - a no-op past
+     *  [MAX_GROUND_REROLLS]. */
+    fun rerollGround() {
+        if (!canRerollGround) return
+        currentGround = randomGround(exclude = currentGround)
+        groundRerollsUsed++
     }
 
     /** A coordinated multi-hue combo pulled from a single film scene, for a screen that needs
@@ -153,6 +143,11 @@ object Azphalt {
     const val SWING_MS = 520 / 3
     const val LIFT_FRACTION = 0.90f
 }
+
+/** The flat two-stop page gradient for this ground - page/foldDark/page, the same shape every
+ *  screen's local PageYellow constant used before a shared rotating ground existed. Top-level
+ *  (not nested in [Azphalt]) so it's callable as `Azphalt.currentGround.pageBrush()`. */
+fun Azphalt.Ground.pageBrush(): Brush = Brush.linearGradient(0f to page, 0.5f to foldDark, 1f to page)
 
 private val PILL_HEIGHT = 17.dp
 private val ROW_PITCH = 20.dp

--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -150,6 +150,26 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
     packages are trusted at download time, same posture as this app's other unverified local
     settings (the MCP pairing token, the AI API key).
 
+### 10. Ground rotation (Kotlin, `commonMain`)
+*   **`ui/menu/PillMenu.kt`**: `Azphalt.currentGround` is a process-wide `mutableStateOf(Ground)`
+    (not `remember`-scoped) so every screen agrees on the same background, including
+    `EditorScreen` - which runs in its own Activity (`EditorActivity`) with its own composition,
+    so a per-composition roll would let it disagree with the rest of the app. `Azphalt.grounds`
+    (Mustard weighted heavily as the primary, six others sharing the rest) and
+    `Azphalt.randomGround(exclude)` (weighted pick) predate this; `currentGround` just makes one
+    of those picks the shared, observable one.
+*   `Azphalt.rerollGround()` swaps to a new weighted pick (never repeating the current one),
+    capped at `Azphalt.MAX_GROUND_REROLLS` (2) per app process - "may reroll once, twice at most"
+    per the style guide. The one call site is `TerminalActivity`'s `onNewSession`: opening a new
+    session tab is a deliberate tap, never mid-gesture, so it's a safe moment to swap the
+    background without fighting an in-flight pill animation.
+*   Every screen that used to define its own local `PageYellow` gradient constant now calls the
+    top-level `Azphalt.Ground.pageBrush()` extension (`Brush.linearGradient(page, foldDark,
+    page)`, the same shape the old per-screen constants used) against `Azphalt.currentGround`
+    instead - `TerminalScreen`, `SettingsScreen`, `McpServerScreen`, `AiSettingsScreen`,
+    `AiChatScreen`, `AzpStoreScreen`, `CommandGuideScreen`, `GuideReaderScreen`, `FilesScreen`,
+    `StorageScreen`, `FolderPicker`, `EditorScreen`.
+
 ## Data Flow
 1.  **Input**: The user taps `wifi`. No text is typed. Since `wifi` leaves no further
     parameters, it runs immediately on that tap.


### PR DESCRIPTION
## Summary

Four backlog items from the design-system work, landing incrementally on this PR as each is finished:

1. **Ground rotation wiring** (done, this push) — `Azphalt.currentGround` is now a process-wide observable `Ground` instead of unused data-model-only state. Every screen's local `PageYellow` gradient constant is replaced by the shared `Azphalt.Ground.pageBrush()` extension against `currentGround`, including `EditorScreen` (a separate Activity/composition from `TerminalActivity`, so this had to be process-wide state, not `remember`-scoped). `Azphalt.rerollGround()` (capped at 2 per process) is called from `TerminalActivity`'s `onNewSession` — a deliberate tap, never mid-gesture.
2. Menu Style Guide reconciliation (in progress) — diff `PillMenu.kt` against the 8 numbered rules in the style guide addendum and fix any divergence.
3. Guide Motion (pending) — parallax wipe-in assembly for the Guide reader.
4. Reading/typeset output (pending) — structured, hierarchy-aware rendering for normal command output, with a Plain-text toggle.

Guide-style illustration work is explicitly out of scope for this batch (logged separately for later).

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlinAndroid` / `testPlaystoreDebugUnitTest` after item 1
- [ ] Same after each subsequent item
- [ ] Manual on-device spot-check (no device available in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Make Azphalt ground selection a process-wide observable state and wire it through all screens, with controlled rerolling on new terminal sessions.

Enhancements:
- Introduce a shared Azphalt.currentGround state with a capped reroll mechanism, replacing per-composition ground handling.
- Use a common Azphalt.Ground.pageBrush() gradient for page backgrounds across all major screens to keep visuals consistent and ground-aware.
- Trigger ground rerolling from TerminalActivity when opening new terminal sessions to vary the background without disrupting gestures.

Documentation:
- Extend the architecture documentation with a new section explaining the ground rotation model, its constraints, and how screens consume the shared page gradient.