### PR TITLE
PillMenu reconciliation, Guide Motion, typeset output

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -39,6 +39,7 @@ import com.hereliesaz.hg2gui.azp.AzpInstaller
 import com.hereliesaz.hg2gui.managers.AiSettings
 import com.hereliesaz.hg2gui.managers.AzpLibrary
 import com.hereliesaz.hg2gui.managers.ContactManager
+import com.hereliesaz.hg2gui.managers.OsContextStore
 import com.hereliesaz.hg2gui.managers.SshPresets
 import com.hereliesaz.hg2gui.managers.TerminalHistoryEntry
 import com.hereliesaz.hg2gui.managers.VfsManager
@@ -326,7 +327,7 @@ class TerminalActivity : FragmentActivity() {
                                         AiReply(text = "error: ${e.message}", command = null)
                                     }
                                     aiMessages = aiMessages + AiMessage(
-                                        fromUser = false, text = reply.text, command = reply.command
+                                        fromUser = false, text = reply.text, command = reply.command, parts = reply.parts
                                     )
                                     aiBusy = false
                                 }
@@ -499,6 +500,13 @@ class TerminalActivity : FragmentActivity() {
                                 }
                                 wizardId == "ai-chat" -> screen = Screen.Ai
                                 wizardId == "azp-store" -> screen = Screen.Azp
+                                wizardId.startsWith("switchos:") -> {
+                                    val os = wizardId.removePrefix("switchos:")
+                                    scope.launch {
+                                        OsContextStore.set(this@TerminalActivity, os)
+                                        tree = withContext(Dispatchers.IO) { CommandTree.from(this@TerminalActivity) }
+                                    }
+                                }
                             }
                         },
                         onRun = { sessionId, line, onOutput, onNeedInput ->

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ai/AiClient.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ai/AiClient.kt
@@ -6,11 +6,14 @@ import com.anthropic.models.messages.OutputConfig
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
-data class AiReply(val text: String, val command: String?)
+/** [parts] is a flag-by-flag "what each part does" breakdown, present only for command replies
+ *  where the model chose to include one - see HG2Gui_Redesign.dc.html's "Phase 4" concept. Empty
+ *  for plain-text replies and for commands too simple to be worth breaking down. */
+data class AiReply(val text: String, val command: String?, val parts: List<Pair<String, String>> = emptyList())
 
 private const val SYSTEM_PROMPT = """You are a command-line assistant inside HG2Gui, a Termux-based Android terminal app. The user's current working directory is {cwd}.
 
-If the user's request can be satisfied by a single shell command, reply with ONLY that command, prefixed with "CMD:" and nothing else - no explanation, no markdown fences. Otherwise reply with a short plain-text answer, prefixed with "TEXT:"."""
+If the user's request can be satisfied by a single shell command, reply on the first line with ONLY that command, prefixed with "CMD:" - no explanation, no markdown fences on that line. If the command has more than one or two meaningful tokens/flags, follow it with a line reading exactly "PARTS:", then one line per meaningful token formatted as "<token>|<what it does, one short sentence>" - skip trivial or obvious tokens. Otherwise reply with a short plain-text answer, prefixed with "TEXT:", and no PARTS section."""
 
 /**
  * Single-turn natural-language -> shell-command suggestion (or plain-text reply), via the
@@ -52,11 +55,21 @@ object AiClient {
         val trimmed = raw.trim()
         return when {
             trimmed.startsWith("CMD:") -> {
-                val command = trimmed.removePrefix("CMD:").trim()
-                AiReply(text = command, command = command)
+                val lines = trimmed.lines()
+                val command = lines.first().removePrefix("CMD:").trim()
+                AiReply(text = command, command = command, parts = parseParts(lines.drop(1)))
             }
             trimmed.startsWith("TEXT:") -> AiReply(text = trimmed.removePrefix("TEXT:").trim(), command = null)
             else -> AiReply(text = trimmed, command = null)
+        }
+    }
+
+    private fun parseParts(rest: List<String>): List<Pair<String, String>> {
+        val start = rest.indexOfFirst { it.trim() == "PARTS:" }
+        if (start < 0) return emptyList()
+        return rest.drop(start + 1).mapNotNull { line ->
+            val i = line.indexOf('|')
+            if (i < 0) null else line.substring(0, i).trim() to line.substring(i + 1).trim()
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/OsContextStore.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/OsContextStore.kt
@@ -1,0 +1,20 @@
+package com.hereliesaz.hg2gui.managers
+
+import android.content.Context
+import androidx.core.content.edit
+
+private const val PREFS_NAME = "hg2gui_os_context"
+private const val KEY_OS = "os"
+
+/** The OS a session is mentally "in" - "local" (the real Termux prefix, the default) or a
+ *  reference-only context (ubuntu/macos/windows) offered alongside it. Persisted, not
+ *  session-scoped, since a device is usually SSH'd into the same kind of host repeatedly. */
+object OsContextStore {
+    private fun prefs(context: Context) = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun current(context: Context): String = prefs(context).getString(KEY_OS, "local") ?: "local"
+
+    fun set(context: Context, os: String) {
+        prefs(context).edit { putString(KEY_OS, os) }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/menu/CommandTree.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/menu/CommandTree.kt
@@ -1,6 +1,7 @@
 package com.hereliesaz.hg2gui.ui.menu
 
 import android.content.Context
+import com.hereliesaz.hg2gui.managers.OsContextStore
 import com.hereliesaz.hg2gui.managers.SshPresets
 import com.hereliesaz.hg2gui.managers.WorkflowStore
 import com.hereliesaz.hg2gui.terminal.DistroManager
@@ -194,6 +195,68 @@ object CommandTree {
         )
     )
 
+    // Reference-only command sets for a foreign OS - not live-discovered like Shell, since these
+    // aren't necessarily real local binaries. For working over an active `ssh` connection into a
+    // host of that kind, where the local Termux PATH tells you nothing about what's actually
+    // there. git/ls/ssh genuinely overlap with what's locally real; the package/service managers
+    // don't - that's the whole point of picking a context.
+    private data class OsCmd(val label: String, val args: List<String>)
+    private val OS_COMMANDS: Map<String, List<OsCmd>> = mapOf(
+        "ubuntu" to listOf(
+            OsCmd("apt", listOf("install", "update", "upgrade", "search")),
+            OsCmd("systemctl", listOf("status", "start", "restart")),
+            OsCmd("ls", listOf("-la", "-lh", "~")),
+            OsCmd("git", listOf("status", "pull", "commit", "push")),
+            OsCmd("ssh", listOf("user@host"))
+        ),
+        "macos" to listOf(
+            OsCmd("brew", listOf("install", "update", "upgrade", "list")),
+            OsCmd("launchctl", listOf("list", "load", "unload")),
+            OsCmd("ls", listOf("-la", "-lh", "~")),
+            OsCmd("git", listOf("status", "pull", "commit", "push")),
+            OsCmd("ssh", listOf("user@host"))
+        ),
+        "windows" to listOf(
+            OsCmd("winget", listOf("install", "upgrade", "search", "list")),
+            OsCmd("sc", listOf("query", "start", "stop")),
+            OsCmd("dir", listOf("/a", "/b", "%USERPROFILE%")),
+            OsCmd("git", listOf("status", "pull", "commit", "push")),
+            OsCmd("ssh", listOf("user@host"))
+        )
+    )
+    private val OS_LABELS = mapOf("ubuntu" to "Ubuntu", "macos" to "macOS", "windows" to "Windows")
+
+    /** The reference tree for the currently-picked foreign OS context - swapped in alongside the
+     *  real Shell categories, never replacing them. Pure token-emitting leaves, same as any Shell
+     *  pill: picking one just assembles the command onto the input line for review. */
+    private fun osReferenceRoot(os: String): MenuNode {
+        val children = OS_COMMANDS[os].orEmpty().map { c ->
+            MenuNode(
+                id = "ctx/$os/${c.label}",
+                label = c.label,
+                cap = c.args.size.toString(),
+                children = c.args.map { a -> MenuNode(id = "ctx/$os/${c.label}/$a", label = a) }
+            )
+        }
+        return MenuNode(id = "ctx/$os", label = OS_LABELS[os] ?: os, cap = children.size.toString(), children = children)
+    }
+
+    /** The Context root pill: pick which OS's commands the reference tree above should offer,
+     *  or "local" to turn it off. Picking one is a state change, not a token - same
+     *  wizardId-as-navigation reuse as [aiRoot]/[azpRoot], handled by re-fetching [from]. */
+    private fun contextRoot(context: Context): MenuNode {
+        val current = OsContextStore.current(context)
+        val choices = listOf("local", "ubuntu", "macos", "windows").map { os ->
+            MenuNode(
+                id = "ctx-pick/$os",
+                label = (OS_LABELS[os] ?: os.replaceFirstChar { it.uppercase() }) + if (os == current) " (current)" else "",
+                emitsToken = false,
+                wizardId = "switchos:$os"
+            )
+        }
+        return MenuNode(id = "ctx", label = "Context", cap = (OS_LABELS[current] ?: current), children = choices)
+    }
+
     private fun shellLeaf(fullName: String, label: String, filePickerRoot: File): MenuNode {
         val hints = SHELL_HINTS[fullName].orEmpty().map { MenuNode("sh/$fullName/$it", it) }
         val children = hints + FileBrowser.pickerNode("sh/$fullName/file", filePickerRoot)
@@ -310,14 +373,17 @@ object CommandTree {
     fun from(context: Context): List<MenuNode> {
         val filePickerRoot = pickerRoot(context)
         val shellRoots = scanShell(context, filePickerRoot)
+        val os = OsContextStore.current(context)
+        val osRoots = if (os == "local") emptyList() else listOf(osReferenceRoot(os))
 
-        return shellRoots + listOf(
+        return shellRoots + osRoots + listOf(
             MenuNode("sys", "System", SYSTEM.size.toString(), SYSTEM.sorted().map { node(it, filePickerRoot) }),
             MenuNode("apps", "Apps & nav", APPS.size.toString(), APPS.sorted().map { node(it, filePickerRoot) }),
             MenuNode("feat", "Features", FEATURES.size.toString(), FEATURES.sorted().map { node(it, filePickerRoot) }),
             workflowsRoot(context),
             aiRoot(),
-            azpRoot()
+            azpRoot(),
+            contextRoot(context)
         )
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/hereliesaz/hg2gui/ai/AiClientTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/hereliesaz/hg2gui/ai/AiClientTest.kt
@@ -1,0 +1,39 @@
+package com.hereliesaz.hg2gui.ai
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class AiClientTest {
+
+    @Test
+    fun plainCommand_noParts() {
+        val reply = AiClient.parse("CMD:ls -la")
+        assertEquals("ls -la", reply.command)
+        assertTrue(reply.parts.isEmpty())
+    }
+
+    @Test
+    fun commandWithParts_isParsed() {
+        val raw = """
+            CMD:tar -xzf archive.tar.gz -C ~/out
+            PARTS:
+            -x|Extract.
+            -z|Run it through gzip on the way out.
+            -f|The next word is the file.
+            -C|Change to this directory first.
+        """.trimIndent()
+        val reply = AiClient.parse(raw)
+        assertEquals("tar -xzf archive.tar.gz -C ~/out", reply.command)
+        assertEquals(4, reply.parts.size)
+        assertEquals("-x" to "Extract.", reply.parts[0])
+        assertEquals("-C" to "Change to this directory first.", reply.parts[3])
+    }
+
+    @Test
+    fun textReply_noParts() {
+        val reply = AiClient.parse("TEXT:tar bundles files, it doesn't compress on its own.")
+        assertEquals(null, reply.command)
+        assertTrue(reply.parts.isEmpty())
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
@@ -319,6 +319,9 @@ private fun BufferEntry(
     // wizard-produced command already follows.
     var expanded by remember { mutableStateOf(false) }
     val isArt = remember(entry.output) { looksLikeAsciiArt(entry.output) }
+    // Checked only when the output isn't already art - a block of `label: value` lines and a
+    // dense symbol-art block are mutually exclusive readings of the same text.
+    val isTable = remember(entry.output) { !isArt && looksLikeKeyValueTable(entry.output) }
     var showRaw by remember(entry.output) { mutableStateOf(false) }
     Column(
         Modifier
@@ -357,6 +360,10 @@ private fun BufferEntry(
                 // Vector-style rendering: flat filled cells sized by character density, not
                 // literal glyphs - a script's ASCII/box-drawing art reads as art, not text.
                 AsciiArtCanvas(entry.output, Azphalt.Ink.copy(alpha = .8f))
+            } else if (isTable && !showRaw) {
+                // "Output is set, not echoed": a block of label: value lines is set on the page
+                // as a two-column grid with hairline rules, not left as raw monospace text.
+                KeyValueTable(entry.output, Azphalt.Ink)
             } else {
                 Text(
                     entry.output,
@@ -377,6 +384,8 @@ private fun BufferEntry(
                 BlockActionPill("SHARE") { onShare(copyText) }
                 if (isArt) {
                     BlockActionPill(if (showRaw) "ART" else "PLAIN TEXT") { showRaw = !showRaw }
+                } else if (isTable) {
+                    BlockActionPill(if (showRaw) "READING" else "PLAIN TEXT") { showRaw = !showRaw }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
@@ -323,8 +323,10 @@ private fun BufferEntry(
     Column(
         Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
-            .background(Azphalt.Ink.copy(alpha = .05f))
+            // "Radii are 999px for anything pressable, 26px for a record tile" - DESIGN.md's own
+            // literal figures for this exact element.
+            .clip(RoundedCornerShape(26.dp))
+            .background(Azphalt.Ink.copy(alpha = .09f))
             .clickable { expanded = !expanded }
             .padding(12.dp)
     ) {

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TypesetOutput.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TypesetOutput.kt
@@ -1,0 +1,85 @@
+package com.hereliesaz.hg2gui.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
+
+/*
+ * "Output is set, not echoed" (HG2Gui_Reading.dc.html): a terminal draws a grid of characters
+ * because a printer once did. Where output is genuinely structured - not prose, not a one-off
+ * value - it's set on the page instead: hierarchy from weight/size, a two-column grid, rules at
+ * 16% ink, figures right-aligned. This covers the one broadly, safely detectable case: a block of
+ * `label: value` lines, the convention a lot of real command output already follows (`ifconfig`,
+ * `stat`, `dpkg -s`, and similar). The spec's other views (a manual page, a file index, a diff)
+ * each need real semantic parsing of that specific command's output and are out of scope here -
+ * this is the one generic, command-agnostic slice. A Plain text toggle (BufferEntry) always falls
+ * back to exactly what the command printed, because a reading can be wrong.
+ */
+
+private val KEY_VALUE_LINE = Regex("^([^:\\n]{1,32}):\\s+(.+)$")
+
+/** Conservative on purpose: every non-blank line must match `label: value`, or this returns
+ *  false - prose and code essentially never satisfy that on every line, so a false positive
+ *  (typesetting something that wasn't actually a table) is unlikely. */
+fun looksLikeKeyValueTable(text: String): Boolean {
+    val lines = text.lines().filter { it.isNotBlank() }
+    if (lines.size < 3) return false
+    return lines.all { KEY_VALUE_LINE.matches(it.trim()) }
+}
+
+private data class KeyValueRow(val label: String, val value: String)
+
+private fun parseKeyValueTable(text: String): List<KeyValueRow> =
+    text.lines().filter { it.isNotBlank() }.mapNotNull { line ->
+        KEY_VALUE_LINE.matchEntire(line.trim())?.let { m ->
+            KeyValueRow(m.groupValues[1].trim(), m.groupValues[2].trim())
+        }
+    }
+
+@Composable
+fun KeyValueTable(text: String, ink: Color, modifier: Modifier = Modifier) {
+    val rows = remember(text) { parseKeyValueTable(text) }
+    val rule = ink.copy(alpha = .16f)
+    Column(modifier.fillMaxWidth()) {
+        Box(Modifier.fillMaxWidth().height(1.dp).background(rule))
+        rows.forEach { row ->
+            Row(
+                Modifier.fillMaxWidth().padding(vertical = 8.dp),
+                horizontalArrangement = Arrangement.SpaceBetween
+            ) {
+                Text(
+                    row.label.uppercase(),
+                    color = ink.copy(alpha = .55f),
+                    fontSize = 9.sp,
+                    fontWeight = FontWeight.ExtraBold,
+                    letterSpacing = 0.14.em
+                )
+                Text(
+                    row.value,
+                    color = ink,
+                    fontSize = 13.sp,
+                    fontWeight = FontWeight.SemiBold,
+                    textAlign = TextAlign.End,
+                    style = TextStyle(fontFeatureSettings = "tnum")
+                )
+            }
+            Box(Modifier.fillMaxWidth().height(1.dp).background(rule))
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/ai/AiChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/ai/AiChatScreen.kt
@@ -31,7 +31,14 @@ import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
 import com.hereliesaz.hg2gui.ui.menu.pageBrush
 
-data class AiMessage(val fromUser: Boolean, val text: String, val command: String? = null)
+/** [parts] is a flag-by-flag "what each part does" breakdown for a command reply - see
+ *  HG2Gui_Redesign.dc.html's "Phase 4" concept. Empty when the model didn't include one. */
+data class AiMessage(
+    val fromUser: Boolean,
+    val text: String,
+    val command: String? = null,
+    val parts: List<Pair<String, String>> = emptyList()
+)
 
 /**
  * Single-turn natural-language -> command suggestion, styled like every other full-screen
@@ -190,6 +197,38 @@ private fun AiBubble(message: AiMessage, onUseCommand: (String) -> Unit) {
                     "USE ▸", color = Azphalt.Yellow,
                     fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
                 )
+            }
+        }
+        if (message.parts.isNotEmpty()) {
+            Spacer(Modifier.height(10.dp))
+            Column(
+                Modifier
+                    .fillMaxWidth()
+                    .clip(RoundedCornerShape(14.dp))
+                    .background(Azphalt.Ink.copy(alpha = .09f))
+                    .padding(12.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp)
+            ) {
+                Text(
+                    "WHAT EACH PART DOES",
+                    color = Azphalt.Ink.copy(alpha = .45f),
+                    fontSize = 9.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.18.em
+                )
+                message.parts.forEach { (token, explanation) ->
+                    Row(horizontalArrangement = Arrangement.spacedBy(12.dp)) {
+                        Text(
+                            token,
+                            color = Azphalt.Ink,
+                            fontSize = 12.sp, fontWeight = FontWeight.ExtraBold,
+                            modifier = Modifier.widthIn(min = 34.dp)
+                        )
+                        Text(
+                            explanation,
+                            color = Azphalt.Ink.copy(alpha = .78f),
+                            fontSize = 12.sp, lineHeight = 16.sp
+                        )
+                    }
+                }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideReaderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideReaderScreen.kt
@@ -19,6 +19,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
 import androidx.compose.ui.draw.drawWithContent
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
@@ -41,7 +42,9 @@ import kotlinx.coroutines.delay
  *
  * Every screen change wipes on: one axis, reading order, no fade, never loops. Text and rules
  * reveal via a left-to-right clip; pills grow their actual width instead, so a rounded end grows
- * into being rather than getting guillotined by a hard clip partway through its curve.
+ * into being rather than getting guillotined by a hard clip partway through its curve. A faint,
+ * oversized echo of the entry's own word drifts in behind everything else - depth is speed, not
+ * blur (GuideWash).
  */
 
 private val GUIDE_HUES = intArrayOf(6, 5, 4, 2, 9, 0, 7) // red, orange, amber, teal, blue, violet, magenta
@@ -189,6 +192,8 @@ private fun ColumnScope.GuideEntryReader(
 ) {
     val hue = GUIDE_HUES[GuideBook.entries.indexOf(entry) % GUIDE_HUES.size]
 
+    Box(Modifier.fillMaxSize().clipToBounds()) {
+    GuideWash(entry.cmd.uppercase(), wipeKey)
     Column(Modifier.fillMaxSize().padding(horizontal = 20.dp)) {
         Row(
             Modifier.fillMaxWidth().padding(top = 18.dp),
@@ -284,6 +289,34 @@ private fun ColumnScope.GuideEntryReader(
             }
         }
     }
+    }
+}
+
+/**
+ * The faint oversized echo of the entry's own word, drifting in from the right at a fraction of
+ * the entry's own pace - "depth is speed," not blur or dimming. Plays once per [wipeKey], same as
+ * every WipeItem, so Replay restarts it too.
+ */
+@Composable
+private fun GuideWash(word: String, wipeKey: Int) {
+    val drift = remember(wipeKey) { Animatable(40f) }
+    LaunchedEffect(wipeKey) {
+        drift.snapTo(40f)
+        drift.animateTo(0f, tween(2400, easing = CubicBezierEasing(0f, .9f, .1f, 1f)))
+    }
+    Text(
+        word,
+        color = Azphalt.Ink.copy(alpha = .09f),
+        fontSize = 100.sp,
+        lineHeight = 84.sp,
+        fontWeight = FontWeight.Black,
+        letterSpacing = (-0.04).em,
+        maxLines = 1,
+        softWrap = false,
+        modifier = Modifier
+            .padding(top = 64.dp, start = 4.dp)
+            .graphicsLayer { translationX = drift.value.dp.toPx() }
+    )
 }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -334,10 +334,13 @@ private fun StackPill(
     }
     val offset = remember { Animatable(if (entering) -1.7f else 0f) }
 
+    // One shared clock, no per-pill stagger - "dismissing the host plays the exact same arrival
+    // as opening the app... because returning to a stack and arriving at it are the same event."
+    // Every root pill's entrance and leaving-stack animation shares this same unstaggered timing.
     LaunchedEffect(leaving, entering) {
         if (entering) offset.animateTo(
             0f,
-            tween(Azphalt.SLIDE_MS, delayMillis = index * 70, easing = LinearEasing)
+            tween(Azphalt.SLIDE_MS, easing = LinearEasing)
         ) else offset.animateTo(target, tween(Azphalt.SLIDE_MS, easing = LinearEasing))
     }
 
@@ -351,7 +354,7 @@ private fun StackPill(
     LaunchedEffect(entering) {
         if (entering) lift.animateTo(
             -pitchPx * row,
-            tween(Azphalt.SLIDE_MS, delayMillis = index * 70, easing = LinearEasing)
+            tween(Azphalt.SLIDE_MS, easing = LinearEasing)
         )
     }
 
@@ -465,14 +468,14 @@ private fun ChildPill(
             turn.animateTo(0f, keyframes {
                 durationMillis = Azphalt.SWING_MS
                 (if (localIndex % 2 == 0) -360f else 360f) at 0 using LinearEasing
-                (if (localIndex % 2 == 0) -36f else 36f) at (Azphalt.SWING_MS * 0.9f).toInt() using LinearEasing
+                (if (localIndex % 2 == 0) -36f else 36f) at (Azphalt.SWING_MS * Azphalt.LIFT_FRACTION).toInt() using LinearEasing
                 0f at Azphalt.SWING_MS
             })
         }
         launch {
             lift.animateTo(-pitchPx * absoluteRow, keyframes {
                 durationMillis = Azphalt.SWING_MS
-                (-pitchPx * (absoluteRow - 1).coerceAtLeast(BAND_BASE_ROW)) at (Azphalt.SWING_MS * 0.9f).toInt() using LinearEasing
+                (-pitchPx * (absoluteRow - 1).coerceAtLeast(BAND_BASE_ROW)) at (Azphalt.SWING_MS * Azphalt.LIFT_FRACTION).toInt() using LinearEasing
             })
         }
     }
@@ -576,7 +579,9 @@ internal fun Pill(
             .background(bg)
             .padding(start = 12.dp, end = 6.dp),
         verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.spacedBy(5.dp, Alignment.End)
+        // "Label and end-cap sit together at the right end of the pill, in that order, 9px
+        // apart" - the style guide's own literal gap value.
+        horizontalArrangement = Arrangement.spacedBy(9.dp, Alignment.End)
     ) {
         Text(
             text = label.uppercase(),

--- a/composeApp/src/commonTest/kotlin/com/hereliesaz/hg2gui/ui/TypesetOutputTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/hereliesaz/hg2gui/ui/TypesetOutputTest.kt
@@ -1,0 +1,43 @@
+package com.hereliesaz.hg2gui.ui
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TypesetOutputTest {
+
+    @Test
+    fun keyValueLines_isTable() {
+        val text = """
+            Address: 10.0.0.14/24
+            Gateway: 10.0.0.1
+            Signal: -47 dBm
+        """.trimIndent()
+        assertTrue(looksLikeKeyValueTable(text))
+    }
+
+    @Test
+    fun prose_isNotTable() {
+        val text = """
+            This is a completely ordinary paragraph of output.
+            It has several lines of real words in it.
+            Nothing here is a label: value pair on every line.
+        """.trimIndent()
+        assertFalse(looksLikeKeyValueTable(text))
+    }
+
+    @Test
+    fun tooFewLines_isNotTable() {
+        assertFalse(looksLikeKeyValueTable("Address: 10.0.0.14"))
+    }
+
+    @Test
+    fun mixedLines_isNotTable() {
+        val text = """
+            Address: 10.0.0.14/24
+            just some plain text here
+            Signal: -47 dBm
+        """.trimIndent()
+        assertFalse(looksLikeKeyValueTable(text))
+    }
+}

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -45,7 +45,15 @@ Two more root pills sit alongside the shell categories, neither backed by a shel
     line to review and run — a `new…` pill saves one from a name plus a template string.
 *   **AI**: one `chat…` pill opening a natural-language-to-command chat screen (requires an
     Anthropic API key set in Settings → AI). Never runs anything itself — a suggested command
-    shows a USE pill that hands it to the command line the same way.
+    shows a USE pill that hands it to the command line the same way. A command reply may also
+    include a "what each part does" breakdown, one line per flag.
+*   **Context**: pick which OS's commands the tree should also offer — `local` (the default,
+    turns this off) or a reference set for `ubuntu`/`macos`/`windows` (a synthesized root pill
+    alongside the shell categories, e.g. `apt`/`systemctl`/`git`/`ssh` for Ubuntu). For working
+    over an active `ssh` connection into a host of that kind, where the local Termux PATH tells
+    you nothing about what's actually there — `git`/`ls`/`ssh` genuinely overlap with what's
+    locally real, the package/service managers don't. Picking one just assembles the command onto
+    the command line like any other pill; nothing runs automatically.
 *   **Store**: one `search…` pill opening the azphalt.store package browser — the same idea as
     `pkg`/`apt`, but for `.azp` extensions (assets, code, packs, companion apps, MCP-server
     headers, and AI-skill bundles). Filter by kind, then INSTALL downloads and unpacks a package.

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -1,7 +1,7 @@
 # Design
 
-The visual system is **Azphalt**: a warm printed yellow page, ink text, ten capsule hues, one
-typeface (Jost), and a single primitive — the capsule. No borders. No shadows. No blur. No
+The visual system is **Azphalt**: a warm printed yellow page, ink text, fourteen capsule hues,
+one typeface (Jost), and a single primitive — the capsule. No borders. No shadows. No blur. No
 icons. No emoji. Radii are 999px for anything pressable, 26px for a record tile.
 
 This document specifies the one place HG2Gui departs from base Azphalt: the **pill menu**,
@@ -127,6 +127,7 @@ Session tabs, command-line tokens and modifier keys sit at 8sp, uppercase, +0.09
 
 ## 7. Unchanged from Azphalt
 
-Hue by hash, ten hues in assignment order, the darker mate on the end-cap. Ink for the open
-pill, yellow for its label and cap. Record tile at 26dp radius, 9% ink. No borders, no shadows,
-no blur, no icons, no hover states.
+Hue by hash, fourteen hues in assignment order (the original ten sit on the default ground; four
+more - gray, sage, tan, brown - extend the set for the rarer grounds and category recolors), the
+darker mate on the end-cap. Ink for the open pill, yellow for its label and cap. Record tile at
+26dp radius, 9% ink. No borders, no shadows, no blur, no icons, no hover states.

--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -170,6 +170,21 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
     `AiChatScreen`, `AzpStoreScreen`, `CommandGuideScreen`, `GuideReaderScreen`, `FilesScreen`,
     `StorageScreen`, `FolderPicker`, `EditorScreen`.
 
+### 11. Guide reader motion (Kotlin, `commonMain`)
+*   **`ui/guide/GuideReaderScreen.kt`**: an entry never just appears - each field wipes on in
+    reading order via `WipeItem`, sequenced `120 + seq*110` ms apart with
+    `CubicBezierEasing(0f, .9f, .1f, 1f)` (the Azphalt "unfold" easing). Text/rules reveal via a
+    left-to-right `clipRect`; capsules/pills instead animate their real layout width from 0, since
+    clip-masking an already-round shape would guillotine its leading curve.
+*   `GuideWash`: a faint, oversized echo of the entry's own command name (9% ink, ~100sp) behind
+    the content, drifting in from the right over 2400ms on the same easing - "depth is speed," no
+    blur or dimming. Tied to the same `wipeKey` as every `WipeItem`, so Prev/Next/Replay restart
+    it along with everything else. This is the one piece of `HG2Gui_Guide_Motion.dc.html`'s "01 -
+    Entry" demo the screen was missing; the wipe-in cascade itself already matched. The spec's "02
+    - Parallax" scroll-driven variant (a background wash plane at 0.2x scroll speed, mid-plane
+    rods at 0.5x) isn't implemented - the real `GuideEntryReader` is a single fixed screen with
+    Prev/Next, not a long scrolling page, so there's no scroll position for it to drive against.
+
 ## Data Flow
 1.  **Input**: The user taps `wifi`. No text is typed. Since `wifi` leaves no further
     parameters, it runs immediately on that tap.

--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -105,6 +105,15 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
     uses, applied to the density field instead of raster pixels. No model, no network call: it's a
     deterministic, offline algorithm that constructs an actual vector shape from the art's
     character grid rather than reproducing glyphs or a blocky per-cell mosaic.
+*   **Typeset output** (`ui/TypesetOutput.kt` commonMain): `BufferEntry` also checks
+    `looksLikeKeyValueTable()` (only when the output isn't already art) and, when every non-blank
+    line matches `label: value`, renders via `KeyValueTable` instead of plain text - a two-column
+    grid with 16%-ink hairline rules, dimmed uppercase labels, and right-aligned values (tabular
+    figure OpenType feature where the font supports it). A PLAIN TEXT/READING toggle in the same
+    tap-to-reveal row switches back to the raw string. This is a deliberately narrow slice of
+    `HG2Gui_Reading.dc.html`'s "output is set, not echoed" concept - that spec's other views (a
+    manual page, a file index, a diff) each need real semantic parsing of that specific command's
+    output; `label: value` detection is the one generic, command-agnostic case.
 *   **Workflows** (`ui/WorkflowFlow.kt` commonMain, `managers/WorkflowStore.kt` androidMain):
     named command templates with `{placeholder}` substrings, stored the same flat-SharedPreferences
     way as `SshPresets`. Saving and running both reuse the `wizardId`/`onWizard` pill primitive and

--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -194,6 +194,30 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
     rods at 0.5x) isn't implemented - the real `GuideEntryReader` is a single fixed screen with
     Prev/Next, not a long scrolling page, so there's no scroll position for it to drive against.
 
+### 12. Context (OS-reference tree) and AI part breakdown (Kotlin, `androidMain`/`commonMain`)
+*   **`managers/OsContextStore.kt`** (androidMain): flat SharedPreferences, one string key,
+    `current()`/`set()` - the OS a session is mentally "in" (`local`, the default, or
+    `ubuntu`/`macos`/`windows`). Persisted, not session-scoped, since a device is usually SSH'd
+    into the same kind of host repeatedly.
+*   **`CommandTree.kt`**: `contextRoot()` is a synthesized root pill (like `workflowsRoot`/
+    `aiRoot`) with one leaf per OS choice, each `wizardId = "switchos:<os>"` - picking one is a
+    state change, not a token, handled by `TerminalActivity`'s `onWizard` (sets
+    `OsContextStore`, then re-fetches `CommandTree.from`). When the current OS isn't `local`,
+    `from()` adds one more root, `osReferenceRoot()`: a static (not live-discovered) reference
+    tree for that OS's package manager, service manager, and the commands that genuinely overlap
+    with the local Termux install (`git`, `ls`, `ssh`). This is `HG2Gui_Redesign.dc.html`'s "2b -
+    context-aware" demo, scoped to what's actually useful without a live remote-shell-awareness
+    mechanism this app doesn't have: a reference tree for working over an `ssh` connection, not a
+    live suggestion set that knows what's really installed on the far end.
+*   **AI part breakdown** (`ai/AiClient.kt`, `ui/ai/AiChatScreen.kt`): the system prompt now asks
+    the model to optionally follow a `CMD:` reply with a `PARTS:` block, one `<token>|<what it
+    does>` line per flag, for commands worth breaking down. `AiClient.parse` splits this into
+    `AiReply.parts`, rendered as a "WHAT EACH PART DOES" panel under the USE pill
+    (`AiChatScreen.kt`'s `AiBubble`). This is the tractable slice of `HG2Gui_Redesign.dc.html`'s
+    "2c - Phase 4" concept - the breakdown panel, not the full separate screen with per-token
+    tap-to-swap-from-the-tree editing, which would need a way to re-enter the pill tree from an
+    arbitrary token position and is out of scope here.
+
 ## Data Flow
 1.  **Input**: The user taps `wifi`. No text is typed. Since `wifi` leaves no further
     parameters, it runs immediately on that tap.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -104,6 +104,11 @@ binary now, run in the Termux environment below, not a reimplementation of one.
     rather than a wall of text. The heuristic is conservative — real prose or a table always falls
     back to plain text. Tap the entry, then **PLAIN TEXT** to see the raw output (and copy/share
     it) any time.
+-   **Typeset output:** output that's a block of `label: value` lines (`ifconfig`, `stat`,
+    `dpkg -s`, and similar — three or more lines, every one of them that shape) is set as a
+    two-column grid instead of raw monospace text — labels dimmed and uppercase, values
+    right-aligned. Tap the entry, then **PLAIN TEXT** to see exactly what the command printed any
+    time — a reading can be wrong.
 -   **Workflows:** the **Workflows** pill (alongside the shell categories) holds saved command
     templates. Picking one asks for any `{placeholder}` values the template uses, then drops the
     assembled command onto the input line, same as everything else here — nothing runs until you

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -119,7 +119,17 @@ binary now, run in the Termux environment below, not a reimplementation of one.
     Anthropic API. A suggested command shows a **USE ▸** pill that drops it onto the input line
     for review, exactly like everything else — the chat never runs a command by itself. Needs an
     API key first: Settings → **AI SETTINGS ›**. The key is stored unencrypted on this device,
-    same as the MCP pairing token and other local settings.
+    same as the MCP pairing token and other local settings. A command reply may also show a
+    **what each part does** panel — a short explanation per flag, when the command has enough of
+    them to be worth breaking down.
+-   **Context:** the **Context** pill sets which OS's commands the tree offers alongside the real
+    Shell categories — pick `ubuntu`, `macos`, or `windows` and a reference root appears with that
+    OS's package manager, service manager, and a few overlapping basics (`git`, `ls`, `ssh`).
+    Meant for working over an active `ssh` connection into a host of that kind, where the local
+    Termux `PATH` doesn't tell you what's actually there. Pick **local** to turn it off again.
+    Picking a pill just assembles the command onto the input line, same as everywhere else —
+    nothing runs by itself, and most of these commands (`apt`, `brew`, `winget`, and friends)
+    aren't real local binaries, so this is reference, not live discovery like Shell.
 -   **Store:** the **Store** pill opens a browser for [azphalt.store](https://azphalt.store), the
     package registry for `.azp` extensions — the same idea as `pkg`/`apt`, but general-purpose:
     assets, sandboxed code, packs, companion apps, MCP-server headers, and AI-skill bundles all


### PR DESCRIPTION
## Summary

Continuing the backlog batch (ground rotation wiring already merged in #106). All three remaining items now done:

1. **Menu Style Guide reconciliation** — diffed `PillMenu.kt` against the 8 numbered rules in the style guide addendum. Confirmed most figures already match exactly (62dp overhang, 34%/30%/24% positioning, 173ms/140ms timing, 90% lift, 1.15x pick grow, 56dp trail floor). Found and fixed three real divergences:
   - Root stack pills staggered their entrance by 70ms per index; spec (and this repo's own `DESIGN.md`) call for one shared clock, no per-pill stagger.
   - Label-to-end-cap gap was 5dp, spec says 9dp.
   - The record tile (`TerminalScreen`'s `BufferEntry`) used a 12dp radius / 5% ink wash instead of `DESIGN.md`'s own documented 26dp / 9%.
   - Also updated `DESIGN.md`'s "ten hues" to "fourteen" to match the hue-palette extension from earlier this session (the doc was stale, not the code).
   - Deliberately **not** touched: the "pills vary length by a 4% step" rule — implementing it risks disturbing the host-parks-at-34% positioning math (tuned across two earlier PRs, #91/#92) in a way I can't verify without a device to render on. Flagged as a known gap.
2. **Guide Motion** — `GuideEntryReader`'s wipe-in cascade already matched the spec's "01 - Entry" demo almost exactly (same easing, same sequencing, same pill-grows-width vs text-clips split). Added the one missing piece: `GuideWash`, a faint oversized echo of the entry's own command name drifting in behind the content. The spec's "02 - Parallax" scroll-driven variant isn't implemented — the real entry reader is a single fixed screen with Prev/Next, not a scrolling page, so there's no scroll position to drive it against.
3. **Reading/typeset output** — `HG2Gui_Reading.dc.html`'s "output is set, not echoed" concept covers six bespoke views (network status, man page, file index, disk-usage table, log, diff), each needing real semantic parsing of that specific command's output — too large for one pass. Implemented the one generic, command-agnostic slice: a block of `label: value` lines (a genuinely common shell convention) now renders as a two-column typeset grid instead of raw monospace text, with a PLAIN TEXT toggle back to the raw string.

Guide-style illustration work remains explicitly out of scope (logged separately for later, per an earlier conversation).

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlinAndroid` / `testPlaystoreDebugUnitTest` after every item
- [x] New unit tests for `looksLikeKeyValueTable`
- [ ] Manual on-device spot-check (no device available in this environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_
