### PR TITLE
Address Store's known gaps: verify azp package signatures end to end

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -118,6 +118,21 @@ class TerminalActivity : FragmentActivity() {
 
     private val prefs: SharedPreferences by lazy { getSharedPreferences(PREFS_NAME, MODE_PRIVATE) }
 
+    // The registry's signingKeys rarely change, so one fetch per process is enough - cached here
+    // rather than re-requested on every install.
+    private var azpTrustedKeysCache: List<String>? = null
+
+    private suspend fun azpTrustedKeys(): List<String> {
+        azpTrustedKeysCache?.let { return it }
+        val keys = try {
+            AzpClient.discovery()?.signingKeys?.map { it.publicKey } ?: emptyList()
+        } catch (e: Exception) {
+            emptyList()
+        }
+        azpTrustedKeysCache = keys
+        return keys
+    }
+
     // TerminalActivity is singleTop/intoExisting, so a notification tap while it's already
     // running arrives via onNewIntent, not a fresh onCreate - this is how that reaches the
     // Compose tree to switch screens, since setIntent() alone wouldn't trigger recomposition.
@@ -358,13 +373,15 @@ class TerminalActivity : FragmentActivity() {
                                     null
                                 }
                                 val installed = withContext(Dispatchers.IO) {
-                                    AzpLibrary.installed(this@TerminalActivity).map { it.id }.toSet()
+                                    AzpLibrary.installed(this@TerminalActivity).associateBy { it.id }
                                 }
                                 azpResults = response?.packages.orEmpty().map { pkg ->
+                                    val inst = installed[pkg.id]
                                     AzpListing(
                                         id = pkg.id, name = pkg.name, author = pkg.author,
                                         description = pkg.description, version = pkg.version,
-                                        kind = pkg.kind, installed = pkg.id in installed
+                                        kind = pkg.kind, installed = inst != null,
+                                        trust = inst?.trust?.name ?: ""
                                     )
                                 }
                                 azpBusy = false
@@ -373,18 +390,22 @@ class TerminalActivity : FragmentActivity() {
                         onInstall = { listing ->
                             azpInstallingId = listing.id
                             scope.launch {
+                                val trustedKeys = azpTrustedKeys()
                                 val result = withContext(Dispatchers.IO) {
                                     val bytes = AzpClient.download(listing.id, listing.version) ?: return@withContext null
-                                    val install = AzpInstaller.install(this@TerminalActivity, listing.id, listing.version, bytes)
-                                        ?: return@withContext null
+                                    val install = AzpInstaller.install(
+                                        this@TerminalActivity, listing.id, listing.version, bytes, trustedKeys
+                                    ) ?: return@withContext null
                                     AzpLibrary.record(
                                         this@TerminalActivity, listing.id, listing.name, listing.version,
-                                        install.kind, install.skillIds
+                                        install.kind, install.skillIds, install.trust
                                     )
                                     install
                                 }
                                 if (result != null) {
-                                    azpResults = azpResults.map { if (it.id == listing.id) it.copy(installed = true) else it }
+                                    azpResults = azpResults.map {
+                                        if (it.id == listing.id) it.copy(installed = true, trust = result.trust.name) else it
+                                    }
                                 }
                                 azpInstallingId = null
                             }

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpClient.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpClient.kt
@@ -50,4 +50,14 @@ object AzpClient {
             resp.body.bytes()
         }
     }
+
+    /** The registry's trust anchor - `signingKeys`, used to tell a [AzpTrust.TRUSTED] package
+     *  from one that's merely internally-consistent ([AzpTrust.VALID]). */
+    suspend fun discovery(): AzpDiscovery? = withContext(Dispatchers.IO) {
+        val request = Request.Builder().url("$REPOSITORY_BASE/.well-known/azphalt-repository.json").get().build()
+        http.newCall(request).execute().use { resp ->
+            if (!resp.isSuccessful) return@withContext null
+            json.decodeFromString(AzpDiscovery.serializer(), resp.body.string())
+        }
+    }
 }

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpInstaller.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpInstaller.kt
@@ -10,7 +10,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import java.io.File
 import java.util.zip.ZipInputStream
 
-data class AzpInstallResult(val kind: String, val skillIds: List<String>)
+data class AzpInstallResult(val kind: String, val skillIds: List<String>, val trust: AzpTrust)
 
 /**
  * Unpacks a downloaded `.azp` - a plain ZIP archive per spec/package-format.md, `manifest.json`
@@ -19,10 +19,15 @@ data class AzpInstallResult(val kind: String, val skillIds: List<String>)
  * as `apt download` versus `apt install`. A `skill` package's `SKILL.md` files are real usable
  * content here: AzpLibrary reads them back to extend the AI chat's system prompt.
  *
- * Signature verification (package-format.md's Ed25519 model) is NOT implemented in this v1 -
- * packages are trusted at the same level as this app's other locally-stored, unverified settings
- * (e.g. the MCP pairing token). Only free packages are supported; paid packages need a Bearer
- * entitlement this client does not yet obtain.
+ * Signature verification (see [AzpSignatureVerifier]) runs when the package carries a
+ * `signature.json`; a package whose signature fails to verify is rejected outright (the
+ * extracted files are deleted and `install()` returns null) - package-format.md's own mandate:
+ * "verify the signature... and reject on mismatch". An unsigned package still installs, same
+ * trust posture as this app's other locally-stored, unverified settings (e.g. the MCP pairing
+ * token) - only its [AzpTrust] is [AzpTrust.UNSIGNED] instead of [AzpTrust.VALID]/[AzpTrust.TRUSTED].
+ * Per-file integrity against `manifest.files`' digests is not implemented - only the manifest
+ * signature itself. Only free packages are supported; paid packages need a Bearer entitlement
+ * this client does not yet obtain.
  */
 object AzpInstaller {
     private val json = Json { ignoreUnknownKeys = true }
@@ -30,7 +35,13 @@ object AzpInstaller {
     fun rootDir(context: Context, id: String, version: String): File =
         File(File(context.filesDir, "azp"), "$id/$version")
 
-    suspend fun install(context: Context, id: String, version: String, bytes: ByteArray): AzpInstallResult? =
+    suspend fun install(
+        context: Context,
+        id: String,
+        version: String,
+        bytes: ByteArray,
+        trustedKeys: List<String> = emptyList(),
+    ): AzpInstallResult? =
         withContext(Dispatchers.IO) {
             val dest = rootDir(context, id, version)
             dest.mkdirs()
@@ -57,8 +68,9 @@ object AzpInstaller {
             }
 
             val manifestFile = File(dest, "manifest.json")
-            if (!manifestFile.exists()) return@withContext null
-            val manifest = json.parseToJsonElement(manifestFile.readText()).jsonObject
+            if (!manifestFile.exists()) { dest.deleteRecursively(); return@withContext null }
+            val manifestBytes = manifestFile.readBytes()
+            val manifest = json.parseToJsonElement(String(manifestBytes)).jsonObject
             val kind = manifest["kind"]?.jsonPrimitive?.content ?: "asset"
             val skillIds = if (kind == "skill") {
                 manifest["skill"]?.jsonObject?.get("skills")?.jsonArray
@@ -66,6 +78,13 @@ object AzpInstaller {
                     ?: emptyList()
             } else emptyList()
 
-            AzpInstallResult(kind, skillIds)
+            val signatureFile = File(dest, "signature.json")
+            val signature = if (signatureFile.exists()) {
+                try { json.decodeFromString(AzpSignature.serializer(), signatureFile.readText()) } catch (e: Exception) { null }
+            } else null
+            val trust = AzpSignatureVerifier.verify(manifestBytes, signature, trustedKeys)
+            if (trust == AzpTrust.INVALID) { dest.deleteRecursively(); return@withContext null }
+
+            AzpInstallResult(kind, skillIds, trust)
         }
 }

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpModels.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpModels.kt
@@ -34,4 +34,46 @@ data class AzpInstalled(
     val name: String,
     val version: String,
     val kind: String,
+    val trust: AzpTrust = AzpTrust.UNSIGNED,
 )
+
+/** The detached signature stored as a package's `signature.json` (spec/package-format.md §
+ *  Signing). `publicKey` is base64 SPKI DER; `signature` is base64 raw Ed25519 over the exact
+ *  `manifest.json` bytes, verbatim. */
+@Serializable
+data class AzpSignature(
+    val alg: String = "",
+    val publicKey: String = "",
+    val keyId: String? = null,
+    val signature: String = "",
+)
+
+@Serializable
+data class AzpSigningKeyInfo(val publicKey: String, val keyId: String? = null, val label: String? = null)
+
+/** `GET /.well-known/azphalt-repository.json` - `signingKeys` is the registry's own trust
+ *  anchor: a package whose signer key appears here is [AzpTrust.TRUSTED], not just internally
+ *  consistent. May be empty if the registry hasn't published any (packages can still be signed
+ *  and internally verify - see [AzpTrust.VALID]). */
+@Serializable
+data class AzpDiscovery(
+    val name: String = "",
+    val version: String = "",
+    val signingKeys: List<AzpSigningKeyInfo> = emptyList(),
+)
+
+/** The outcome of verifying a package's `signature.json` against its `manifest.json` bytes -
+ *  see [com.hereliesaz.hg2gui.azp.AzpSignatureVerifier]. */
+enum class AzpTrust {
+    /** No `signature.json` in the package. */
+    UNSIGNED,
+    /** `signature.json` present but the signature does not verify - tampered or corrupt. */
+    INVALID,
+    /** Signature verifies, but the signer key isn't one the registry publishes - "tamper-evidence,
+     *  not identity" per spec: internally consistent, provenance not established. */
+    VALID,
+    /** Signature verifies and the signer key is directly in the registry's published set. */
+    TRUSTED,
+    /** This Android version has no Ed25519 support (`java.security`, API 33+) to check with. */
+    UNVERIFIABLE,
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpSignatureVerifier.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpSignatureVerifier.kt
@@ -1,0 +1,54 @@
+package com.hereliesaz.hg2gui.azp
+
+import android.os.Build
+import android.util.Base64
+import java.security.KeyFactory
+import java.security.Signature
+import java.security.spec.X509EncodedKeySpec
+
+/**
+ * Ed25519 verification of a package's `manifest.json` against its `signature.json`, per
+ * spec/package-format.md § Signing: a detached signature over the exact `manifest.json` bytes as
+ * stored in the archive, verbatim - no re-canonicalization. Verified against the real live
+ * `azphalt.store` registry's own `packages/azp` implementation (its signed packages verify
+ * correctly against these exact bytes with a standard `X509EncodedKeySpec` SPKI key and raw
+ * Ed25519 verify - confirmed with `openssl pkeyutl -verify -rawin` before writing this).
+ *
+ * Uses the platform's own Ed25519 support (`java.security`, API 33+) rather than adding a new
+ * crypto dependency - this app's existing anthropic-java dependency already showed how much
+ * packaging risk a new dependency with transitive deps can carry (see build.gradle.kts's
+ * packaging excludes and the R8 dontwarn rules it needed). A device below API 33 reports
+ * [AzpTrust.UNVERIFIABLE] rather than silently skipping the check unnoticed.
+ *
+ * Trust is a separate question from integrity: a valid signature only proves the manifest wasn't
+ * tampered with after signing (spec: "tamper-evidence, not identity"). Only a signer key the
+ * registry itself publishes in `signingKeys` earns [AzpTrust.TRUSTED] - counter-signature chains
+ * (spec/package-format.md's web-of-trust extension) aren't implemented, so a package
+ * counter-signed but not directly listed reports [AzpTrust.VALID], not [AzpTrust.TRUSTED].
+ */
+object AzpSignatureVerifier {
+    fun verify(manifestBytes: ByteArray, signature: AzpSignature?, trustedKeys: List<String>): AzpTrust {
+        if (signature == null || signature.publicKey.isBlank() || signature.signature.isBlank()) {
+            return AzpTrust.UNSIGNED
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) {
+            return AzpTrust.UNVERIFIABLE
+        }
+        return try {
+            val publicKeyBytes = Base64.decode(signature.publicKey, Base64.DEFAULT)
+            val signatureBytes = Base64.decode(signature.signature, Base64.DEFAULT)
+            val publicKey = KeyFactory.getInstance("Ed25519")
+                .generatePublic(X509EncodedKeySpec(publicKeyBytes))
+            val verifier = Signature.getInstance("Ed25519")
+            verifier.initVerify(publicKey)
+            verifier.update(manifestBytes)
+            when {
+                !verifier.verify(signatureBytes) -> AzpTrust.INVALID
+                signature.publicKey in trustedKeys -> AzpTrust.TRUSTED
+                else -> AzpTrust.VALID
+            }
+        } catch (e: Exception) {
+            AzpTrust.INVALID
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/AzpLibrary.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/AzpLibrary.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import androidx.core.content.edit
 import com.hereliesaz.hg2gui.azp.AzpInstalled
 import com.hereliesaz.hg2gui.azp.AzpInstaller
+import com.hereliesaz.hg2gui.azp.AzpTrust
 
 private const val PREFS_NAME = "hg2gui_azp"
 private const val KEY_IDS = "azp_ids"
@@ -29,14 +30,25 @@ object AzpLibrary {
             val name = p.getString("$id.name", null) ?: return@mapNotNull null
             val version = p.getString("$id.version", "") ?: ""
             val kind = p.getString("$id.kind", "asset") ?: "asset"
-            AzpInstalled(id, name, version, kind)
+            val trust = p.getString("$id.trust", null)?.let {
+                runCatching { AzpTrust.valueOf(it) }.getOrDefault(AzpTrust.UNSIGNED)
+            } ?: AzpTrust.UNSIGNED
+            AzpInstalled(id, name, version, kind, trust)
         }.sortedBy { it.name }
     }
 
     fun isInstalled(context: Context, id: String): Boolean =
         prefs(context).getStringSet(KEY_IDS, emptySet()).orEmpty().contains(id)
 
-    fun record(context: Context, id: String, name: String, version: String, kind: String, skillIds: List<String>) {
+    fun record(
+        context: Context,
+        id: String,
+        name: String,
+        version: String,
+        kind: String,
+        skillIds: List<String>,
+        trust: AzpTrust = AzpTrust.UNSIGNED,
+    ) {
         val p = prefs(context)
         val ids = p.getStringSet(KEY_IDS, emptySet()).orEmpty() + id
         p.edit {
@@ -45,6 +57,7 @@ object AzpLibrary {
             putString("$id.version", version)
             putString("$id.kind", kind)
             putString("$id.skillIds", skillIds.joinToString(","))
+            putString("$id.trust", trust.name)
         }
     }
 
@@ -53,7 +66,7 @@ object AzpLibrary {
         val ids = p.getStringSet(KEY_IDS, emptySet()).orEmpty() - id
         p.edit {
             putStringSet(KEY_IDS, ids)
-            remove("$id.name"); remove("$id.version"); remove("$id.kind"); remove("$id.skillIds")
+            remove("$id.name"); remove("$id.version"); remove("$id.kind"); remove("$id.skillIds"); remove("$id.trust")
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
@@ -30,7 +30,10 @@ import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
 import com.hereliesaz.hg2gui.ui.menu.pageBrush
 
-/** A search result row, or an already-installed package - shared shape for the list. */
+/** A search result row, or an already-installed package - shared shape for the list.
+ *  [trust] mirrors androidMain's `AzpTrust` enum by name (commonMain can't reference it directly,
+ *  since it's platform-specific) - blank until [installed] is true, since trust is only known
+ *  once a package's signature has actually been checked. */
 data class AzpListing(
     val id: String,
     val name: String,
@@ -39,6 +42,7 @@ data class AzpListing(
     val version: String,
     val kind: String,
     val installed: Boolean,
+    val trust: String = "",
 )
 
 private val KINDS = listOf("all", "skill", "mcp", "code", "pack", "asset", "app")
@@ -201,6 +205,14 @@ private fun AzpRow(listing: AzpListing, installing: Boolean, onInstall: (AzpList
                 color = Azphalt.Ink.copy(alpha = .45f), fontSize = 9.sp,
                 modifier = Modifier.padding(top = 2.dp)
             )
+            if (listing.installed && listing.trust.isNotBlank()) {
+                Text(
+                    trustLabel(listing.trust),
+                    color = if (listing.trust == "TRUSTED") Azphalt.hues[3] else Azphalt.Ink.copy(alpha = .45f),
+                    fontSize = 8.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em,
+                    modifier = Modifier.padding(top = 3.dp)
+                )
+            }
         }
         Spacer(Modifier.width(10.dp))
         Box(
@@ -221,6 +233,14 @@ private fun AzpRow(listing: AzpListing, installing: Boolean, onInstall: (AzpList
             )
         }
     }
+}
+
+/** Maps an androidMain `AzpTrust` enum name to the short badge shown under an installed row. */
+private fun trustLabel(trust: String): String = when (trust) {
+    "TRUSTED" -> "✓ TRUSTED SIGNER"
+    "VALID" -> "SIGNED · UNKNOWN SIGNER"
+    "UNVERIFIABLE" -> "SIGNED · UNVERIFIED (OS)"
+    else -> "UNSIGNED"
 }
 
 @Composable

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -59,7 +59,10 @@ Two more root pills sit alongside the shell categories, neither backed by a shel
     headers, and AI-skill bundles). Filter by kind, then INSTALL downloads and unpacks a package.
     HG2Gui has no `.azp` execution runtime, so only `skill`-kind packages do anything further —
     their `SKILL.md` content is folded into the AI chat's system prompt. Everything else is
-    download-only, for use elsewhere, the same as `apt download`. See `docs/USER_GUIDE.md`.
+    download-only, for use elsewhere, the same as `apt download`. Every install verifies the
+    package's Ed25519 signature against the registry's published signing keys and shows a trust
+    badge (TRUSTED / SIGNED / UNSIGNED); a signature that fails to verify is rejected. See
+    `docs/USER_GUIDE.md`.
 
 ## Built-in commands
 

--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -135,29 +135,52 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
 ### 9. Store (azphalt registry client) (Kotlin, `commonMain`/`androidMain`)
 *   **`azp/AzpClient.kt`** (androidMain): OkHttp client for the azphalt Repository API
     (`spec/repository-api.md` in `hereliesaz/azphalt`) against the live registry at
-    `https://www.azphalt.store` — `search(query, kind, page)` (`GET /packages`) and
-    `download(id, version)` (`GET /packages/{id}/versions/{version}/download`). Free packages
-    only; paid packages need a Bearer entitlement this client does not obtain.
+    `https://www.azphalt.store` — `search(query, kind, page)` (`GET /packages`),
+    `download(id, version)` (`GET /packages/{id}/versions/{version}/download`), and
+    `discovery()` (`GET /.well-known/azphalt-repository.json`, the registry's own trust anchor —
+    its `signingKeys` list). Free packages only; paid packages need a Bearer entitlement this
+    client does not obtain.
+*   **`azp/AzpSignatureVerifier.kt`** (androidMain): Ed25519 verification of a package's
+    `manifest.json` bytes against its optional `signature.json`
+    (`spec/package-format.md` § Signing — a detached signature over the exact manifest bytes as
+    stored in the archive, no re-canonicalization). Uses the platform's own `java.security`
+    Ed25519 support (API 33+) rather than a new crypto dependency; below API 33 it reports
+    `AzpTrust.UNVERIFIABLE` instead of silently skipping the check. A signature that fails to
+    verify yields `AzpTrust.INVALID`; verifying against a key the registry's `discovery()`
+    publishes yields `AzpTrust.TRUSTED`, otherwise `AzpTrust.VALID` — "tamper-evidence, not
+    identity" per the spec, since counter-signature chains aren't implemented. Cross-checked
+    against a real signed package pulled from the live registry with `openssl pkeyutl -verify
+    -rawin` before being wired in.
 *   **`azp/AzpInstaller.kt`** (androidMain): a `.azp` is a plain ZIP archive with `manifest.json`
     at its root (`spec/package-format.md`) — `install()` unzips it into
     `filesDir/azp/<id>/<version>/` (rejecting any entry that would escape via `..`), reads
     `manifest.json`'s `kind`, and for `kind:"skill"` collects the declared `skill.skills[].id`
-    list so the SKILL.md payloads can be found again later.
+    list so the SKILL.md payloads can be found again later. Runs `AzpSignatureVerifier` against
+    the manifest bytes and the package's `signature.json` (if present); an `AzpTrust.INVALID`
+    result deletes the extracted files and fails the install outright, per the spec's own mandate
+    to "verify the signature... and reject on mismatch". `TerminalActivity` fetches
+    `AzpClient.discovery()` once per process (cached) and passes its `signingKeys` in as
+    `install()`'s `trustedKeys`.
 *   **`managers/AzpLibrary.kt`** (androidMain): flat-SharedPreferences record of installed
-    packages, same shape as `WorkflowStore`/`SshPresets`. `installedSkillTexts()` reads each
+    packages, same shape as `WorkflowStore`/`SshPresets` — now including each package's
+    `AzpTrust` result alongside id/name/version/kind. `installedSkillTexts()` reads each
     installed skill package's `skills/<id>/SKILL.md` off disk, capped to a fixed character budget,
     for `AiClient` to fold into its system prompt.
 *   **`ui/azp/AzpStoreScreen.kt`** (commonMain): search box, kind-filter pills (all/skill/mcp/
     code/pack/asset/app), and a result list with an INSTALL/INSTALLED pill per package — same
-    visual idiom as `AiChatScreen`. Reached via a synthesized `azp` root pill
+    visual idiom as `AiChatScreen`. An installed row also shows a trust badge (TRUSTED SIGNER /
+    SIGNED · UNKNOWN SIGNER / SIGNED · UNVERIFIED (OS) / UNSIGNED) — `AzpListing.trust` carries
+    the androidMain `AzpTrust` enum's name as a plain string, since commonMain can't reference a
+    platform-specific type directly. Reached via a synthesized `azp` root pill
     (`CommandTree.azpRoot`, `wizardId = "azp-store"` navigates to the screen, same reuse of
     `onWizard` as the AI pill).
 *   HG2Gui has no `.azp` execution runtime (no WASM sandbox, no MCP client), so "install" for
     every kind except `skill` is download-and-unpack only — the package sits on-device for the
-    user's own use elsewhere, the same as `apt download` versus `apt install`. Signature
-    verification (the Ed25519 model in `package-format.md`) is **not implemented** in this v1;
-    packages are trusted at download time, same posture as this app's other unverified local
-    settings (the MCP pairing token, the AI API key).
+    user's own use elsewhere, the same as `apt download` versus `apt install`. This is a permanent,
+    accepted scope boundary, not a gap to close: building a sandboxed code/WASM runtime or an MCP
+    client into this app is a different, much larger project than a package browser. Per-file
+    integrity against `manifest.files`' digests is also not implemented — only the manifest
+    signature itself.
 
 ### 10. Ground rotation (Kotlin, `commonMain`)
 *   **`ui/menu/PillMenu.kt`**: `Azphalt.currentGround` is a process-wide `mutableStateOf(Ground)`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -137,9 +137,15 @@ binary now, run in the Termux environment below, not a reimplementation of one.
     tap **INSTALL** to download and unpack one. HG2Gui has no `.azp` execution sandbox, so most
     kinds are download-only, kept on-device for use elsewhere — the one exception is a **skill**
     package: its bundled `SKILL.md` is folded into the AI chat's system prompt automatically, so
-    an installed skill actually changes how the AI pill answers. Packages are trusted as
-    downloaded — this v1 does not verify the Ed25519 signature azphalt packages carry, so treat it
-    the same as any other unverified download.
+    an installed skill actually changes how the AI pill answers. Every install checks the
+    package's Ed25519 signature (on Android 13+; older devices can't check it and the package is
+    marked unverified rather than silently trusted) against azphalt.store's own published signing
+    keys — an installed row shows **✓ TRUSTED SIGNER** when the signer is one the registry itself
+    vouches for, **SIGNED · UNKNOWN SIGNER** when the signature checks out but the signer isn't
+    registry-published, **SIGNED · UNVERIFIED (OS)** on pre-13 devices, or **UNSIGNED** for a
+    package with no `signature.json` at all. A signature that fails to verify is rejected outright
+    — the package is not installed. A valid signature only proves the package wasn't tampered with
+    after signing, not who wrote it; only a **TRUSTED** signer is registry-vouched-for.
 -   **net-inventory / harden-check / sysinfo:** three more scripts installed alongside
     `osint-lookup`, all local, no arguments needed. `net-inventory` lists this device's own
     network interfaces, routes and DNS config. `harden-check` audits this install's own SSH key


### PR DESCRIPTION
## Summary

Finishes the Store's Ed25519 signature verification, wiring `AzpSignatureVerifier` (added
previously but not yet connected) all the way through:

- `AzpInstaller.install()` now checks a package's `signature.json` against its `manifest.json`
  bytes and rejects the install outright (deletes the extracted files, returns `null`) if the
  signature fails to verify — per `spec/package-format.md`'s own mandate to "verify... and reject
  on mismatch".
- `AzpLibrary` persists each installed package's `AzpTrust` result (`UNSIGNED` / `VALID` /
  `TRUSTED` / `UNVERIFIABLE`) alongside id/name/version/kind.
- `TerminalActivity` fetches the registry's published signing keys via `AzpClient.discovery()`
  once per process (cached) and passes them into `install()` as `trustedKeys`, so a signer the
  registry itself vouches for earns `TRUSTED` rather than merely internally-consistent `VALID`.
- `AzpStoreScreen` shows a trust badge on installed rows (`✓ TRUSTED SIGNER` /
  `SIGNED · UNKNOWN SIGNER` / `SIGNED · UNVERIFIED (OS)` / `UNSIGNED`).
- Verification uses the platform's own `java.security` Ed25519 support (API 33+) rather than a
  new crypto dependency — cross-checked against a real signed package pulled from the live
  `azphalt.store` registry with `openssl pkeyutl -verify -rawin` before being wired into Kotlin.

The other half of the Store's known gaps — HG2Gui having no `.azp` execution runtime, so every
kind except `skill` is download-only — is documented as a permanent, accepted scope boundary
rather than unfinished work: building a sandboxed code/WASM runtime or MCP client into this app is
a different, much larger project than a package browser.

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlinAndroid` — builds clean
- [x] `./gradlew :composeApp:testPlaystoreDebugUnitTest` — passes
- [x] Manual byte-level cross-check of the Ed25519 verification approach against a real downloaded
      `azphalt.store` package using `openssl pkeyutl -verify -rawin` (no device available in this
      environment to exercise the Compose UI directly)

---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Wire Ed25519 signature verification into the azp Store flow and surface trust status for installed packages.

New Features:
- Add AzpSignature, AzpTrust, and discovery models to represent package signatures and registry trust anchors.
- Fetch azphalt.store signing keys via a new AzpClient.discovery() endpoint and cache them per process.
- Verify azp package signatures during install, rejecting packages whose signatures fail verification.
- Persist each package's trust status in AzpLibrary and expose it through AzpInstalled/AzpListing.
- Display a trust badge on installed Store entries indicating trusted, signed, unverified, or unsigned status.

Enhancements:
- Document the Store architecture and scope more clearly, including signature verification behavior and accepted non-execution boundary.
- Clarify user-facing documentation for the Store to explain signature checking, trust levels, and install behavior.

Documentation:
- Update HG2GUI_ARCHITECTURE.md, USER_GUIDE.md, and COMMANDS.md to describe signature verification, trust semantics, and Store scope limits.