### PR TITLE
Verify per-file digests on .azp install, not just the manifest signature

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpInstaller.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpInstaller.kt
@@ -8,6 +8,8 @@ import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import java.io.File
+import java.security.MessageDigest
+import java.security.DigestOutputStream
 import java.util.zip.ZipInputStream
 
 data class AzpInstallResult(val kind: String, val skillIds: List<String>, val trust: AzpTrust)
@@ -17,17 +19,28 @@ data class AzpInstallResult(val kind: String, val skillIds: List<String>, val tr
  * at the root - into `filesDir/azp/<id>/<version>/`. HG2Gui has no `.azp` code/WASM runtime, so
  * for every kind except `skill` this is just "download and keep, for use elsewhere" - the same
  * as `apt download` versus `apt install`. A `skill` package's `SKILL.md` files are real usable
- * content here: AzpLibrary reads them back to extend the AI chat's system prompt.
+ * content here: AzpLibrary reads them back to extend the AI chat's system prompt - which is
+ * exactly why per-file integrity matters more here than it might look: a package's Ed25519
+ * signature (see [AzpSignatureVerifier]) only covers `manifest.json`'s bytes, never the payload.
+ * A signature check alone confirms the *manifest* wasn't altered after signing; it says nothing
+ * about whether the `SKILL.md` bytes sitting next to it are the ones the signer actually shipped.
+ * Without a per-file digest check, a tampered `SKILL.md` - content that lands verbatim in this
+ * app's own AI system prompt - would verify as TRUSTED right alongside a swapped-in prompt
+ * injection. So every extracted payload file's SHA-256 is checked against `manifest.files[path]`
+ * (package-format.md's own integrity contract - the same check `@azphalt/azp`'s `verifyAzp` runs),
+ * and any file present in the archive but absent from `manifest.files` is rejected outright,
+ * mirroring `verifyAzp`'s "unlisted payload" check (a ZIP-confusion / signature-bypass vector:
+ * an entry nothing hashed is an entry nothing can vouch for).
  *
- * Signature verification (see [AzpSignatureVerifier]) runs when the package carries a
- * `signature.json`; a package whose signature fails to verify is rejected outright (the
- * extracted files are deleted and `install()` returns null) - package-format.md's own mandate:
- * "verify the signature... and reject on mismatch". An unsigned package still installs, same
- * trust posture as this app's other locally-stored, unverified settings (e.g. the MCP pairing
- * token) - only its [AzpTrust] is [AzpTrust.UNSIGNED] instead of [AzpTrust.VALID]/[AzpTrust.TRUSTED].
- * Per-file integrity against `manifest.files`' digests is not implemented - only the manifest
- * signature itself. Only free packages are supported; paid packages need a Bearer entitlement
- * this client does not yet obtain.
+ * Signature verification runs when the package carries a `signature.json`; a package whose
+ * signature fails to verify, or whose payload fails the digest check above, is rejected outright
+ * (the extracted files are deleted and `install()` returns null) - package-format.md's own
+ * mandate: "verify the signature... and reject on mismatch". An unsigned package still installs,
+ * same trust posture as this app's other locally-stored, unverified settings (e.g. the MCP
+ * pairing token) - only its [AzpTrust] is [AzpTrust.UNSIGNED] instead of
+ * [AzpTrust.VALID]/[AzpTrust.TRUSTED]; the digest check still applies regardless of signing, since
+ * `manifest.files` is a plain integrity contract independent of trust. Only free packages are
+ * supported; paid packages need a Bearer entitlement this client does not yet obtain.
  */
 object AzpInstaller {
     private val json = Json { ignoreUnknownKeys = true }
@@ -46,6 +59,11 @@ object AzpInstaller {
             val dest = rootDir(context, id, version)
             dest.mkdirs()
 
+            // path (as stored in the archive, "/"-separated) -> lowercase-hex SHA-256 digest of
+            // the bytes actually written to disk. Computed inline via DigestOutputStream so the
+            // check costs no extra read pass over what was just extracted.
+            val extractedDigests = mutableMapOf<String, String>()
+
             ZipInputStream(bytes.inputStream()).use { zip ->
                 var entry = zip.nextEntry
                 while (entry != null) {
@@ -60,7 +78,9 @@ object AzpInstaller {
                         target.mkdirs()
                     } else {
                         target.parentFile?.mkdirs()
-                        target.outputStream().use { out -> zip.copyTo(out) }
+                        val digest = MessageDigest.getInstance("SHA-256")
+                        DigestOutputStream(target.outputStream(), digest).use { out -> zip.copyTo(out) }
+                        extractedDigests[name] = digest.digest().joinToString("") { "%02x".format(it) }
                     }
                     zip.closeEntry()
                     entry = zip.nextEntry
@@ -78,6 +98,18 @@ object AzpInstaller {
                     ?: emptyList()
             } else emptyList()
 
+            // Integrity: every payload entry's digest must match `manifest.files`, and every
+            // entry (besides the detached `signature.json`, which is exempt - it's the signature,
+            // not a signed payload file, mirroring @azphalt/azp's verifyAzp) must be listed there.
+            // A digest mismatch or an unlisted payload file both fail installation the same way a
+            // bad signature does: reject and delete, don't install partially-trusted content.
+            val declaredFiles = manifest["files"]?.jsonObject
+                ?.mapValues { (_, v) -> v.jsonPrimitive.content.removePrefix("sha256-") }
+                ?: emptyMap()
+            if (!filesMatchDigests(extractedDigests, declaredFiles)) {
+                dest.deleteRecursively(); return@withContext null
+            }
+
             val signatureFile = File(dest, "signature.json")
             val signature = if (signatureFile.exists()) {
                 try { json.decodeFromString(AzpSignature.serializer(), signatureFile.readText()) } catch (e: Exception) { null }
@@ -87,4 +119,21 @@ object AzpInstaller {
 
             AzpInstallResult(kind, skillIds, trust)
         }
+}
+
+/**
+ * True iff every non-manifest, non-signature entry in [extracted] (path -> lowercase-hex SHA-256
+ * of the bytes actually on disk) has a matching digest in [declared] (path -> lowercase-hex
+ * SHA-256, `manifest.files` with its `sha256-` prefix already stripped). A path present in
+ * [extracted] but absent from [declared] fails ("unlisted payload"), as does any digest mismatch.
+ * Pure and Context-free by design, specifically so it's unit-testable without a Robolectric/
+ * instrumented Android runtime - see AzpInstallerDigestTest.
+ */
+internal fun filesMatchDigests(extracted: Map<String, String>, declared: Map<String, String>): Boolean {
+    for ((path, actualDigest) in extracted) {
+        if (path == "manifest.json" || path == "signature.json") continue
+        val wantDigest = declared[path] ?: return false
+        if (!wantDigest.equals(actualDigest, ignoreCase = true)) return false
+    }
+    return true
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/hereliesaz/hg2gui/azp/AzpInstallerDigestTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/hereliesaz/hg2gui/azp/AzpInstallerDigestTest.kt
@@ -1,0 +1,73 @@
+package com.hereliesaz.hg2gui.azp
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * [filesMatchDigests] is the integrity check [AzpInstaller.install] runs before ever trusting a
+ * package's payload - see the class doc on AzpInstaller.kt for why this matters specifically for
+ * `skill` packages (SKILL.md content lands directly in the AI system prompt). These cases are the
+ * ones a real attack would actually try.
+ */
+class AzpInstallerDigestTest {
+
+    private val digestA = "a".repeat(64)
+    private val digestB = "b".repeat(64)
+
+    @Test
+    fun matchingDigests_pass() {
+        val extracted = mapOf("skills/foo/SKILL.md" to digestA)
+        val declared = mapOf("skills/foo/SKILL.md" to digestA)
+        assertTrue(filesMatchDigests(extracted, declared))
+    }
+
+    @Test
+    fun tamperedPayload_fails() {
+        // Same declared digest as a real install, but the bytes on disk hash differently - a
+        // SKILL.md swapped after signing, which is exactly the attack this check exists for.
+        val extracted = mapOf("skills/foo/SKILL.md" to digestB)
+        val declared = mapOf("skills/foo/SKILL.md" to digestA)
+        assertFalse(filesMatchDigests(extracted, declared))
+    }
+
+    @Test
+    fun unlistedPayload_fails() {
+        // A file present in the archive that the manifest never hashed at all - nothing vouches
+        // for it, so it must be rejected even though no *declared* digest was violated.
+        val extracted = mapOf(
+            "skills/foo/SKILL.md" to digestA,
+            "skills/foo/scripts/evil.sh" to digestB,
+        )
+        val declared = mapOf("skills/foo/SKILL.md" to digestA)
+        assertFalse(filesMatchDigests(extracted, declared))
+    }
+
+    @Test
+    fun manifestAndSignature_areExempt() {
+        // manifest.json and signature.json are never in manifest.files (the manifest doesn't
+        // digest itself, and the signature is the detached signature, not a signed payload file)
+        // - both must be ignored by this check, exactly like @azphalt/azp's verifyAzp.
+        val extracted = mapOf(
+            "manifest.json" to digestA,
+            "signature.json" to digestB,
+            "skills/foo/SKILL.md" to digestA,
+        )
+        val declared = mapOf("skills/foo/SKILL.md" to digestA)
+        assertTrue(filesMatchDigests(extracted, declared))
+    }
+
+    @Test
+    fun caseInsensitiveHexComparison_stillMatches() {
+        // manifest.files digests are lowercase hex by convention (package-format.md), but the
+        // check itself shouldn't be sensitive to case - it compares digests, not string literals.
+        val extracted = mapOf("assets/x.cube" to digestA.uppercase())
+        val declared = mapOf("assets/x.cube" to digestA)
+        assertTrue(filesMatchDigests(extracted, declared))
+    }
+
+    @Test
+    fun emptyPackage_passesVacuously() {
+        assertTrue(filesMatchDigests(emptyMap(), emptyMap()))
+    }
+}


### PR DESCRIPTION
## Summary

Found while reviewing HG2Gui's azphalt compliance: `AzpInstaller` checked a package's Ed25519
signature but never compared the extracted payload bytes against `manifest.files`' declared SHA-256
digests.

That matters more here than it might look. The signature only covers `manifest.json`'s bytes, never the
payload — it's tamper-evidence for the manifest, not for what's next to it. A tampered `SKILL.md` (content
that lands verbatim in this app's own AI system prompt, via `AzpLibrary.installedSkillTexts` →
`AiClient.ask`) would verify as `TRUSTED` right alongside a swapped-in prompt injection, since nothing
was ever checking that the `SKILL.md` bytes on disk are the ones the signer actually shipped.

This adds the same two checks `@azphalt/azp`'s reference `verifyAzp` runs:
- every payload file's digest must match `manifest.files`
- any file present in the archive but absent from `manifest.files` ("unlisted payload") is rejected — a
  ZIP-confusion vector the reference implementation specifically guards against

Digests are computed inline via `DigestOutputStream` during extraction, so this costs no extra read pass
over what's already being written to disk. A failure here rejects and deletes, exactly like a bad
signature does — no partially-trusted install.

The check itself (`filesMatchDigests`) is pulled out as a pure, `Context`-free function specifically so
it's unit-testable without Robolectric or an instrumented run.

## Test plan

- [x] New unit test `AzpInstallerDigestTest` — 6 cases (matching digests, tampered payload, unlisted
  payload, manifest/signature exemption, case-insensitive hex comparison, empty package). All pass.
- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlinAndroid` — BUILD SUCCESSFUL
- [x] `./gradlew :composeApp:testPlaystoreDebugUnitTest --tests AzpInstallerDigestTest` — 6 tests, 0
  failures

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiD9pMMfBwDUPmo8fSapdE)_

## Summary by Sourcery

Enforce per-file payload integrity for .azp installs by validating extracted file digests against manifest declarations and failing installs on mismatch or unlisted payloads.

New Features:
- Add SHA-256 digest tracking for each extracted payload file during .azp installation and validate them against manifest.files entries.
- Introduce a pure filesMatchDigests helper to encapsulate per-file integrity checking independent of Android runtime.

Bug Fixes:
- Prevent tampered or unlisted payload files in .azp archives from being treated as trusted content by requiring manifest.files-backed digest verification before completing installation.

Tests:
- Add AzpInstallerDigestTest unit suite covering matching digests, tampered payloads, unlisted payloads, manifest/signature exemptions, case-insensitive hex comparison, and empty package behavior.