### PR TITLE
Fix glee audit findings: crash bugs, ASCII-art calibration, azp trust gaps

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -118,19 +118,21 @@ class TerminalActivity : FragmentActivity() {
 
     private val prefs: SharedPreferences by lazy { getSharedPreferences(PREFS_NAME, MODE_PRIVATE) }
 
-    // The registry's signingKeys rarely change, so one fetch per process is enough - cached here
-    // rather than re-requested on every install.
+    // The registry's signingKeys rarely change, so a successful fetch is cached for the rest of
+    // the process rather than re-requested on every install. A *failed* fetch (offline, 5xx,
+    // malformed response) is deliberately never cached - caching it would mean no package could
+    // ever come back TRUSTED again this process, even once the network recovers.
     private var azpTrustedKeysCache: List<String>? = null
 
     private suspend fun azpTrustedKeys(): List<String> {
         azpTrustedKeysCache?.let { return it }
         val keys = try {
-            AzpClient.discovery()?.signingKeys?.map { it.publicKey } ?: emptyList()
+            AzpClient.discovery()?.signingKeys?.map { it.publicKey }
         } catch (e: Exception) {
-            emptyList()
+            null
         }
-        azpTrustedKeysCache = keys
-        return keys
+        if (keys != null) azpTrustedKeysCache = keys
+        return keys ?: emptyList()
     }
 
     // TerminalActivity is singleTop/intoExisting, so a notification tap while it's already
@@ -391,16 +393,22 @@ class TerminalActivity : FragmentActivity() {
                             azpInstallingId = listing.id
                             scope.launch {
                                 val trustedKeys = azpTrustedKeys()
-                                val result = withContext(Dispatchers.IO) {
-                                    val bytes = AzpClient.download(listing.id, listing.version) ?: return@withContext null
-                                    val install = AzpInstaller.install(
-                                        this@TerminalActivity, listing.id, listing.version, bytes, trustedKeys
-                                    ) ?: return@withContext null
-                                    AzpLibrary.record(
-                                        this@TerminalActivity, listing.id, listing.name, listing.version,
-                                        install.kind, install.skillIds, install.trust
-                                    )
-                                    install
+                                val result = try {
+                                    withContext(Dispatchers.IO) {
+                                        val bytes = AzpClient.download(listing.id, listing.version) ?: return@withContext null
+                                        val install = AzpInstaller.install(
+                                            this@TerminalActivity, listing.id, listing.version, bytes, trustedKeys
+                                        ) ?: return@withContext null
+                                        AzpLibrary.record(
+                                            this@TerminalActivity, listing.id, listing.name, listing.version,
+                                            install.kind, install.skillIds, install.trust
+                                        )
+                                        install
+                                    }
+                                } catch (e: Exception) {
+                                    // A dropped connection or a malformed archive/manifest must
+                                    // not crash the app - the row just stays on INSTALL.
+                                    null
                                 }
                                 if (result != null) {
                                     azpResults = azpResults.map {

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpInstaller.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpInstaller.kt
@@ -46,45 +46,64 @@ object AzpInstaller {
             val dest = rootDir(context, id, version)
             dest.mkdirs()
 
-            ZipInputStream(bytes.inputStream()).use { zip ->
-                var entry = zip.nextEntry
-                while (entry != null) {
-                    val name = entry.name
-                    // Path containment: refuse any entry that would escape dest via .. or an
-                    // absolute path (package-format.md's own path-containment requirement).
-                    val target = File(dest, name).canonicalFile
-                    if (!target.path.startsWith(dest.canonicalPath + File.separator) && target != dest) {
-                        zip.closeEntry(); entry = zip.nextEntry; continue
+            // A corrupt archive or a manifest that fails to parse must not crash the caller -
+            // any exception past this point is treated as a failed install, same outcome as an
+            // explicit rejection, with the partially-extracted directory cleaned up either way.
+            try {
+                ZipInputStream(bytes.inputStream()).use { zip ->
+                    var entry = zip.nextEntry
+                    while (entry != null) {
+                        val name = entry.name
+                        // Path containment: refuse any entry that would escape dest via .. or an
+                        // absolute path (package-format.md's own path-containment requirement).
+                        val target = File(dest, name).canonicalFile
+                        if (!target.path.startsWith(dest.canonicalPath + File.separator) && target != dest) {
+                            zip.closeEntry(); entry = zip.nextEntry; continue
+                        }
+                        if (entry.isDirectory) {
+                            target.mkdirs()
+                        } else {
+                            target.parentFile?.mkdirs()
+                            target.outputStream().use { out -> zip.copyTo(out) }
+                        }
+                        zip.closeEntry()
+                        entry = zip.nextEntry
                     }
-                    if (entry.isDirectory) {
-                        target.mkdirs()
-                    } else {
-                        target.parentFile?.mkdirs()
-                        target.outputStream().use { out -> zip.copyTo(out) }
-                    }
-                    zip.closeEntry()
-                    entry = zip.nextEntry
                 }
+
+                val manifestFile = File(dest, "manifest.json")
+                if (!manifestFile.exists()) { dest.deleteRecursively(); return@withContext null }
+                val manifestBytes = manifestFile.readBytes()
+                val manifest = json.parseToJsonElement(String(manifestBytes)).jsonObject
+                val kind = manifest["kind"]?.jsonPrimitive?.content ?: "asset"
+                val skillIds = if (kind == "skill") {
+                    manifest["skill"]?.jsonObject?.get("skills")?.jsonArray
+                        ?.mapNotNull { it.jsonObject["id"]?.jsonPrimitive?.content }
+                        ?: emptyList()
+                } else emptyList()
+
+                val signatureFile = File(dest, "signature.json")
+                val trust = if (!signatureFile.exists()) {
+                    AzpTrust.UNSIGNED
+                } else {
+                    val signature = try {
+                        json.decodeFromString(AzpSignature.serializer(), signatureFile.readText())
+                    } catch (e: Exception) {
+                        null
+                    }
+                    // A signature.json that exists but doesn't even parse isn't "no signature" -
+                    // it's a corrupt or tampered one, and gets the same outright rejection as a
+                    // signature that fails cryptographic verification, not the benign UNSIGNED
+                    // tier AzpSignatureVerifier.verify() would otherwise give a null signature.
+                    if (signature == null) AzpTrust.INVALID
+                    else AzpSignatureVerifier.verify(manifestBytes, signature, trustedKeys)
+                }
+                if (trust == AzpTrust.INVALID) { dest.deleteRecursively(); return@withContext null }
+
+                AzpInstallResult(kind, skillIds, trust)
+            } catch (e: Exception) {
+                dest.deleteRecursively()
+                null
             }
-
-            val manifestFile = File(dest, "manifest.json")
-            if (!manifestFile.exists()) { dest.deleteRecursively(); return@withContext null }
-            val manifestBytes = manifestFile.readBytes()
-            val manifest = json.parseToJsonElement(String(manifestBytes)).jsonObject
-            val kind = manifest["kind"]?.jsonPrimitive?.content ?: "asset"
-            val skillIds = if (kind == "skill") {
-                manifest["skill"]?.jsonObject?.get("skills")?.jsonArray
-                    ?.mapNotNull { it.jsonObject["id"]?.jsonPrimitive?.content }
-                    ?: emptyList()
-            } else emptyList()
-
-            val signatureFile = File(dest, "signature.json")
-            val signature = if (signatureFile.exists()) {
-                try { json.decodeFromString(AzpSignature.serializer(), signatureFile.readText()) } catch (e: Exception) { null }
-            } else null
-            val trust = AzpSignatureVerifier.verify(manifestBytes, signature, trustedKeys)
-            if (trust == AzpTrust.INVALID) { dest.deleteRecursively(); return@withContext null }
-
-            AzpInstallResult(kind, skillIds, trust)
         }
 }

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpModels.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpModels.kt
@@ -65,9 +65,14 @@ data class AzpDiscovery(
 /** The outcome of verifying a package's `signature.json` against its `manifest.json` bytes -
  *  see [com.hereliesaz.hg2gui.azp.AzpSignatureVerifier]. */
 enum class AzpTrust {
+    /** No trust was ever recorded for this install - it predates signature verification, so
+     *  nothing is actually known here (not the same claim as [UNSIGNED]). Re-installing checks
+     *  it for real. */
+    UNCHECKED,
     /** No `signature.json` in the package. */
     UNSIGNED,
-    /** `signature.json` present but the signature does not verify - tampered or corrupt. */
+    /** `signature.json` present but the signature does not verify (or the file itself is corrupt
+     *  and doesn't even parse) - tampered or corrupt either way. */
     INVALID,
     /** Signature verifies, but the signer key isn't one the registry publishes - "tamper-evidence,
      *  not identity" per spec: internally consistent, provenance not established. */

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpSignatureVerifier.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpSignatureVerifier.kt
@@ -9,10 +9,11 @@ import java.security.spec.X509EncodedKeySpec
 /**
  * Ed25519 verification of a package's `manifest.json` against its `signature.json`, per
  * spec/package-format.md § Signing: a detached signature over the exact `manifest.json` bytes as
- * stored in the archive, verbatim - no re-canonicalization. Verified against the real live
- * `azphalt.store` registry's own `packages/azp` implementation (its signed packages verify
- * correctly against these exact bytes with a standard `X509EncodedKeySpec` SPKI key and raw
- * Ed25519 verify - confirmed with `openssl pkeyutl -verify -rawin` before writing this).
+ * stored in the archive, verbatim - no re-canonicalization. Cross-checked against a real signed
+ * package downloaded live from `azphalt.store` (`com.hereliesaz.azphalt.3d-protrusion` 1.0.0):
+ * `openssl pkeyutl -verify -pubin -inkey pub.der -keyform DER -rawin -in manifest.json -sigfile
+ * sig.bin` → `Signature Verified Successfully`, confirming the standard (not URL-safe) base64,
+ * the 44-byte SPKI DER public key shape, and the exact-manifest-bytes assumption this file makes.
  *
  * Uses the platform's own Ed25519 support (`java.security`, API 33+) rather than adding a new
  * crypto dependency - this app's existing anthropic-java dependency already showed how much

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/AzpLibrary.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/AzpLibrary.kt
@@ -30,9 +30,12 @@ object AzpLibrary {
             val name = p.getString("$id.name", null) ?: return@mapNotNull null
             val version = p.getString("$id.version", "") ?: ""
             val kind = p.getString("$id.kind", "asset") ?: "asset"
+            // No stored trust means this record predates signature verification - that's
+            // UNCHECKED, a distinct (unknown) state, not the positive claim UNSIGNED makes
+            // ("checked, and there was no signature.json").
             val trust = p.getString("$id.trust", null)?.let {
-                runCatching { AzpTrust.valueOf(it) }.getOrDefault(AzpTrust.UNSIGNED)
-            } ?: AzpTrust.UNSIGNED
+                runCatching { AzpTrust.valueOf(it) }.getOrDefault(AzpTrust.UNCHECKED)
+            } ?: AzpTrust.UNCHECKED
             AzpInstalled(id, name, version, kind, trust)
         }.sortedBy { it.name }
     }

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/AsciiArt.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/AsciiArt.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.unit.dp
 // in this ramp is read as its "ink density" for AsciiArtCanvas, not rendered as a literal glyph.
 private const val DENSITY_RAMP = " .'`^\",:;Il!i><~+_-?][}{1)(|\\/tfjrxnuvczXYUJCLQ0OZmwqpdbkhao*#MW&8%B@\$"
 
-private fun charDensity(c: Char): Float {
+internal fun charDensity(c: Char): Float {
     if (c.isWhitespace()) return 0f
     // Box-drawing (U+2500-U+257F) and block elements (U+2580-U+259F) are literal solid/partial
     // blocks already, not glyphs to rank - treat them as fully dense.
@@ -43,7 +43,14 @@ fun looksLikeAsciiArt(text: String): Boolean {
     return alnum.toFloat() / chars.length < 0.35f
 }
 
-private const val ISO_LEVEL = 0.42f
+// DENSITY_RAMP is a photo-to-ASCII print-density ramp, so most of the punctuation hand-drawn line
+// art actually leans on - |, \, /, _, -, (, ), <, >, brackets - sits in its low-to-mid range, not
+// near the top: those characters cover little of their own cell, but they're still the lines that
+// draw a shape. 0.42 (this file's original threshold) sat above nearly all of them, so detected
+// art rendered as a near-blank canvas. 0.1 draws the line just past the handful of characters that
+// really do read as visually empty (space, '.', "'", '`', '^', '"', ',') and treats everything
+// denser than that - which is most of an ASCII picture's actual linework - as ink.
+internal const val ISO_LEVEL = 0.1f
 
 /** Linearly interpolates the point along a-b where the density field crosses [ISO_LEVEL]. */
 private fun edgePoint(pa: Offset, va: Float, pb: Offset, vb: Float): Offset {
@@ -134,9 +141,19 @@ fun AsciiArtCanvas(text: String, ink: Color, modifier: Modifier = Modifier, maxC
         }
     }
 
-    BoxWithConstraints(modifier.horizontalScroll(rememberScrollState())) {
+    // maxWidth has to be read from constraints BoxWithConstraints itself is measured with, which
+    // means horizontalScroll can't be on this Box - horizontalScroll always hands its child
+    // Constraints.Infinity, so a BoxWithConstraints inside one never sees a real width to fit to.
+    // Scrolling only kicks in on the Canvas below, once cell has already been sized against the
+    // real available width.
+    BoxWithConstraints(modifier) {
         val cell = min(maxCell, maxWidth / cols)
-        Canvas(Modifier.width(cell * (cols + 2)).height(cell * (rows + 2))) {
+        Canvas(
+            Modifier
+                .horizontalScroll(rememberScrollState())
+                .width(cell * (cols + 2))
+                .height(cell * (rows + 2))
+        ) {
             val path = buildContourPath(density, cell.toPx())
             drawPath(path, color = ink)
         }

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
@@ -322,7 +322,10 @@ private fun BufferEntry(
     // Checked only when the output isn't already art - a block of `label: value` lines and a
     // dense symbol-art block are mutually exclusive readings of the same text.
     val isTable = remember(entry.output) { !isArt && looksLikeKeyValueTable(entry.output) }
-    var showRaw by remember(entry.output) { mutableStateOf(false) }
+    // Keyed on the command, not the output - entry.output mutates on every streamed chunk while
+    // a command is still running, and re-keying on it reset this toggle out from under anyone
+    // reading the raw text of a long-running command.
+    var showRaw by remember(entry.command) { mutableStateOf(false) }
     Column(
         Modifier
             .fillMaxWidth()

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TypesetOutput.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TypesetOutput.kt
@@ -25,31 +25,40 @@ import androidx.compose.ui.unit.sp
  * because a printer once did. Where output is genuinely structured - not prose, not a one-off
  * value - it's set on the page instead: hierarchy from weight/size, a two-column grid, rules at
  * 16% ink, figures right-aligned. This covers the one broadly, safely detectable case: a block of
- * `label: value` lines, the convention a lot of real command output already follows (`ifconfig`,
- * `stat`, `dpkg -s`, and similar). The spec's other views (a manual page, a file index, a diff)
- * each need real semantic parsing of that specific command's output and are out of scope here -
- * this is the one generic, command-agnostic slice. A Plain text toggle (BufferEntry) always falls
- * back to exactly what the command printed, because a reading can be wrong.
+ * `label: value` lines - real examples include HTTP response headers (`curl -I`) and single-field-
+ * per-line output like `openssl x509 -noout -subject -issuer`. Multi-value lines packed with 2+
+ * spaces between fields, the way `stat`'s default format does, are split into one row per field.
+ * Output whose colons don't line-delimit cleanly (`ifconfig`, `dpkg -s`'s wrapped Description
+ * field) just doesn't qualify - it falls back to plain monospace text, which is always correct.
+ * The spec's other views (a manual page, a file index, a diff) each need real semantic parsing of
+ * that specific command's output and are out of scope here - this is the one generic,
+ * command-agnostic slice. A Plain text toggle (BufferEntry) always falls back to exactly what the
+ * command printed, because a reading can be wrong.
  */
 
 private val KEY_VALUE_LINE = Regex("^([^:\\n]{1,32}):\\s+(.+)$")
+// Finds every `label: value` field within one line, where a field ends at a 2+ space gap (the
+// next field's start) or end of line - lets a single-line, multi-field record like `stat`'s
+// `Size: 2843  Blocks: 8  IO Block: 4096  regular file` become three rows instead of one row
+// whose value swallows the rest of the line from the first colon on.
+private val KEY_VALUE_FIELD = Regex("([^:\\n]{1,32}):\\s+(\\S.*?)(?=\\s{2,}|$)")
 
-/** Conservative on purpose: every non-blank line must match `label: value`, or this returns
- *  false - prose and code essentially never satisfy that on every line, so a false positive
- *  (typesetting something that wasn't actually a table) is unlikely. */
+/** Conservative on purpose: every non-blank line must match `label: value` at least once, or
+ *  this returns false - prose and code essentially never satisfy that on every line, so a false
+ *  positive (typesetting something that wasn't actually a table) is unlikely. */
 fun looksLikeKeyValueTable(text: String): Boolean {
     val lines = text.lines().filter { it.isNotBlank() }
     if (lines.size < 3) return false
     return lines.all { KEY_VALUE_LINE.matches(it.trim()) }
 }
 
-private data class KeyValueRow(val label: String, val value: String)
+internal data class KeyValueRow(val label: String, val value: String)
 
-private fun parseKeyValueTable(text: String): List<KeyValueRow> =
-    text.lines().filter { it.isNotBlank() }.mapNotNull { line ->
-        KEY_VALUE_LINE.matchEntire(line.trim())?.let { m ->
+internal fun parseKeyValueTable(text: String): List<KeyValueRow> =
+    text.lines().filter { it.isNotBlank() }.flatMap { line ->
+        KEY_VALUE_FIELD.findAll(line.trim()).map { m ->
             KeyValueRow(m.groupValues[1].trim(), m.groupValues[2].trim())
-        }
+        }.toList()
     }
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
@@ -19,7 +19,6 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.text.font.FontWeight
@@ -208,7 +207,7 @@ private fun AzpRow(listing: AzpListing, installing: Boolean, onInstall: (AzpList
             if (listing.installed && listing.trust.isNotBlank()) {
                 Text(
                     trustLabel(listing.trust),
-                    color = if (listing.trust == "TRUSTED") Azphalt.hues[3] else Azphalt.Ink.copy(alpha = .45f),
+                    color = trustColor(listing.trust),
                     fontSize = 8.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em,
                     modifier = Modifier.padding(top = 3.dp)
                 )
@@ -240,8 +239,15 @@ private fun trustLabel(trust: String): String = when (trust) {
     "TRUSTED" -> "✓ TRUSTED SIGNER"
     "VALID" -> "SIGNED · UNKNOWN SIGNER"
     "UNVERIFIABLE" -> "SIGNED · UNVERIFIED (OS)"
-    else -> "UNSIGNED"
+    "UNSIGNED" -> "UNSIGNED"
+    "UNCHECKED" -> "UNCHECKED · REINSTALL TO VERIFY"
+    else -> "UNCHECKED · REINSTALL TO VERIFY"
 }
+
+/** Single source of truth for "is this the TRUSTED tier" - [trustLabel] and this must never
+ *  disagree about which string means trusted, so both read the same comparison. */
+private fun trustColor(trust: String): Color =
+    if (trust == "TRUSTED") Azphalt.hues[3] else Azphalt.Ink.copy(alpha = .45f)
 
 @Composable
 private fun Eyebrow(text: String) {

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideReaderScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideReaderScreen.kt
@@ -363,9 +363,9 @@ private fun Chip(
 /**
  * One element of the wipe-on sequence: `wide` elements (text/rules) reveal via a left-to-right
  * clip with a slight slide, since the content is already full width - only visibility grows.
- * Non-wide elements are pills/chips, whose actual layout width is animated instead: clip-masking
- * an already-round shape would guillotine its leading curve, where growing the real width lets
- * the rounded end come into being along with everything else.
+ * Non-wide elements are pills/chips, whose actual layout width is animated instead of just
+ * clip-revealing a static full-width shape, so a chip's *slot* in its Row grows along with it
+ * rather than the Row reserving full width for it from the first frame.
  */
 @Composable
 private fun WipeItem(seq: Int, wipeKey: Int, wide: Boolean, modifier: Modifier = Modifier, content: @Composable () -> Unit) {
@@ -387,8 +387,15 @@ private fun Modifier.wipeClip(progress: Float): Modifier = this
     }
     .graphicsLayer { translationX = -14.dp.toPx() * (1f - progress) }
 
-private fun Modifier.wipeGrow(progress: Float): Modifier = this.layout { measurable, constraints ->
-    val placeable = measurable.measure(constraints)
-    val w = (placeable.width * progress).toInt().coerceIn(0, placeable.width)
-    layout(w, placeable.height) { placeable.placeRelative(0, 0) }
-}
+private fun Modifier.wipeGrow(progress: Float): Modifier = this
+    .layout { measurable, constraints ->
+        val placeable = measurable.measure(constraints)
+        val w = (placeable.width * progress).toInt().coerceIn(0, placeable.width)
+        layout(w, placeable.height) { placeable.placeRelative(0, 0) }
+    }
+    // The layout above only shrinks the reported *size* - Compose never clips a child to that
+    // reported size on its own, so without this the full-size pill still drew at every progress
+    // value and overlapped whatever the Row placed next to it. clipToBounds costs the rounded
+    // corner's leading curve mid-animation (a flat edge for a few frames instead), which is a far
+    // smaller cost than two chips rendering on top of each other.
+    .clipToBounds()

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -89,7 +89,7 @@ object Azphalt {
     fun randomGround(exclude: Ground? = null): Ground {
         val pool = grounds.filter { it !== exclude }.ifEmpty { grounds }
         val total = pool.sumOf { it.weight }
-        var roll = (0 until total).random()
+        val roll = (0 until total).random()
         return groundFrom(pool, roll)
     }
 
@@ -156,6 +156,12 @@ private const val HOST_WIDTH = 0.66f
 private const val HOST_RIGHT_EDGE = 0.34f
 private const val CHILD_LEFT = 0.30f
 private const val CHILD_WIDTH = 0.34f
+// Menu Style Guide rule 8 (4%-per-depth width variation) is NOT implemented here. StackPill's
+// resting-state math was confirmed safe to vary by hand-derivation, but HostPill's constraint
+// propagation (offsetByFractionOfParent / fillMaxWidth / absoluteBleed interacting to park the
+// host at HOST_RIGHT_EDGE = 34%) couldn't be confidently resolved without a device to verify
+// against - HostPill's width/offset has been hand-tuned across two prior PRs (#91/#92), and this
+// gap is left open rather than risk regressing it on an unverified derivation.
 // HostPill is HOST_WIDTH wide, offset left by (1 - HOST_RIGHT_EDGE) * HOST_WIDTH, so its right
 // edge lands at HOST_WIDTH * HOST_RIGHT_EDGE of the full width. A band of children clears that
 // safely by rising into row 1+, but the trail row shares row 0 with the host, so it has to start
@@ -237,7 +243,6 @@ fun PillMenu(
                         key(node.id) {
                             StackPill(
                                 node = node,
-                                index = i,
                                 row = roots.size - 1 - i,
                                 leaving = leavingHost != null,
                                 isHost = node.id == leavingHost,
@@ -259,59 +264,70 @@ fun PillMenu(
             }
 
             is Phase.Open -> {
-                val host = roots.first { it.id == p.hostId }
-                val rowsBelow = roots.size - 1 - roots.indexOf(host)
-                val anchor = trail.lastOrNull() ?: host
-                // Resolved once per anchor, not on every recomposition - resolveChildren can do
-                // real I/O (a directory listing, a PATH scan), and remember(anchor.id) keeps
-                // that to one call per navigation into this node.
-                val effectiveChildren = remember(anchor.id) { anchor.resolveChildren?.invoke() ?: anchor.children }
-
-                if (effectiveChildren.isNotEmpty()) {
-                    key(anchor.id) {
-                        ChildBand(
-                            children = effectiveChildren,
-                            hueOwner = host.id,
-                            onPick = { child ->
-                                if (child.wizardId != null) {
-                                    onWizard(child.wizardId)
-                                } else {
-                                    tokens = (trail + child).mapNotNull { it.tokenValue() }
-                                    onRun(tokens, child.isTerminal())
-                                }
-                                scope.launch {
-                                    // Let the pick's own drop-and-grow finish, plus one beat to
-                                    // settle, before swapping the band for its children - so the
-                                    // next cascade always starts after the hand-off is visible,
-                                    // never on top of it.
-                                    delay((Azphalt.DROP_MS + Azphalt.SWING_MS).toLong())
-                                    trail = trail + child
-                                }
-                            }
-                        )
-                    }
-                }
-
-                HostPill(
-                    node = host,
-                    rowsBelow = rowsBelow,
-                    onClick = {
-                        phase = Phase.Browsing
+                // A contextual root (the suggestion/answer host) can vanish from `roots` between
+                // recompositions - e.g. picking it clears the input text that made it appear -
+                // while this phase is still mid-animation toward it. Closing back to Browsing
+                // here avoids crashing on a lookup that can no longer succeed.
+                val host = roots.firstOrNull { it.id == p.hostId }
+                if (host == null) {
+                    LaunchedEffect(p.hostId) {
                         trail = emptyList()
-                        tokens = emptyList()
-                        onRun(tokens, false)
+                        phase = Phase.Browsing
                     }
-                )
+                } else {
+                    val rowsBelow = roots.size - 1 - roots.indexOf(host)
+                    val anchor = trail.lastOrNull() ?: host
+                    // Resolved once per anchor, not on every recomposition - resolveChildren can do
+                    // real I/O (a directory listing, a PATH scan), and remember(anchor.id) keeps
+                    // that to one call per navigation into this node.
+                    val effectiveChildren = remember(anchor.id) { anchor.resolveChildren?.invoke() ?: anchor.children }
 
-                TrailRow(
-                    trail = trail,
-                    hueOwner = host.id,
-                    onTapCrumb = { i ->
-                        trail = trail.take(i)
-                        tokens = trail.mapNotNull { it.tokenValue() }
-                        onRun(tokens, false)
+                    if (effectiveChildren.isNotEmpty()) {
+                        key(anchor.id) {
+                            ChildBand(
+                                children = effectiveChildren,
+                                hueOwner = host.id,
+                                onPick = { child ->
+                                    if (child.wizardId != null) {
+                                        onWizard(child.wizardId)
+                                    } else {
+                                        tokens = (trail + child).mapNotNull { it.tokenValue() }
+                                        onRun(tokens, child.isTerminal())
+                                    }
+                                    scope.launch {
+                                        // Let the pick's own drop-and-grow finish, plus one beat to
+                                        // settle, before swapping the band for its children - so the
+                                        // next cascade always starts after the hand-off is visible,
+                                        // never on top of it.
+                                        delay((Azphalt.DROP_MS + Azphalt.SWING_MS).toLong())
+                                        trail = trail + child
+                                    }
+                                }
+                            )
+                        }
                     }
-                )
+
+                    HostPill(
+                        node = host,
+                        rowsBelow = rowsBelow,
+                        onClick = {
+                            phase = Phase.Browsing
+                            trail = emptyList()
+                            tokens = emptyList()
+                            onRun(tokens, false)
+                        }
+                    )
+
+                    TrailRow(
+                        trail = trail,
+                        hueOwner = host.id,
+                        onTapCrumb = { i ->
+                            trail = trail.take(i)
+                            tokens = trail.mapNotNull { it.tokenValue() }
+                            onRun(tokens, false)
+                        }
+                    )
+                }
             }
         }
     }
@@ -320,7 +336,6 @@ fun PillMenu(
 @Composable
 private fun StackPill(
     node: MenuNode,
-    index: Int,
     row: Int,
     leaving: Boolean,
     isHost: Boolean,

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/theme/AzphaltTokens.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/theme/AzphaltTokens.kt
@@ -1,97 +1,41 @@
 package com.hereliesaz.hg2gui.ui.theme
 
 import androidx.compose.animation.core.CubicBezierEasing
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.em
-import androidx.compose.ui.unit.sp
+import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import com.hereliesaz.hg2gui.ui.menu.pageBrush
 
 /*
- * Design tokens ported 1:1 from the Azphalt capsule style guide (see docs/DESIGN.md / the
- * HG2Gui style-guide DC). PillMenu.kt keeps its own local `Azphalt` object for now — these are
- * the same numbers, exposed as a proper token set for screens outside the menu (Files, the
- * command reference reader, the splash) and for anything that wants to override a slice of the
- * palette per category via [LocalAzphaltPalette].
+ * A handful of Azphalt tokens for screens outside the menu (the splash, the design-system
+ * reference screen) that don't otherwise depend on PillMenu.kt. Everything here delegates to
+ * PillMenu.kt's `Azphalt` object rather than keeping its own copy of the numbers - a hand-copied
+ * palette drifted out of sync with the real one before (the wrong Yellow, and only 10 of what are
+ * now 14 hues), silently, since nothing compared the two. Delegating makes that class of drift
+ * impossible instead of merely documented.
  */
 object AzphaltColors {
-    val Ink = Color(0xFF1E1A17)
-    val Yellow = Color(0xFFE8C81E)
-    val YellowFold = Color(0xFFD9B615)
-    val White = Color(0xFFFFFFFF)
+    val Ink = Azphalt.Ink
+    val Yellow = Azphalt.Yellow
+    val White = Azphalt.White
 
-    // Fixed assignment order: violet, cyan, teal, green, amber, orange, red, magenta, purple, blue.
-    val hues = listOf(
-        Color(0xFF6B4FBB), Color(0xFF2FA9C4), Color(0xFF1F9E86), Color(0xFF5AAE34),
-        Color(0xFFD9A21C), Color(0xFFD9762A), Color(0xFFC6392F), Color(0xFFB03A6E),
-        Color(0xFF8E4FA8), Color(0xFF2E6FB7)
-    )
-    val hueCaps = listOf(
-        Color(0xFF4B3489), Color(0xFF1F7B90), Color(0xFF137060), Color(0xFF3E7D22),
-        Color(0xFFA2760F), Color(0xFFA6551A), Color(0xFF93251D), Color(0xFF7F2A4D),
-        Color(0xFF653578), Color(0xFF1E4E85)
-    )
+    val hues = Azphalt.hues
+    val hueCaps = Azphalt.caps
 
-    // Semantic overrides — hue alone carries no meaning, these five do.
-    val Acquire = Color(0xFFC6392F) // red — primary / run
-    val Done = Color(0xFF1F9E86)    // teal — acquired / receipts
-    val Selected = Ink              // selected / open
+    // Semantic overrides — hue alone carries no meaning, these two do.
+    val Acquire = Azphalt.hues[6] // red — primary / run
+    val Done = Azphalt.hues[2]    // teal — acquired / receipts
+    val Selected = Ink            // selected / open
     val IdleWash = Ink.copy(alpha = 0.14f)
 
-    val page: Brush = Brush.linearGradient(0f to Yellow, 0.5f to YellowFold, 1f to Yellow)
+    val page: Brush = Azphalt.grounds.first().pageBrush()
 
     /** Deterministic hue assignment by hashing an identifier — never by hand. */
-    fun hueOf(id: String): Int = (id.hashCode().let { if (it < 0) -it else it }) % hues.size
-}
-
-object AzphaltType {
-    val displayTracking = (-0.03).em
-    val capsuleLabelTracking = 0.09.em
-    val eyebrowTracking = 0.28.em
-    val microTracking = 0.18.em
-
-    val displaySize = 54.sp
-    val titleSize = 22.sp
-    val eyebrowSize = 11.sp
-    val microSize = 9.sp
-    val bodySize = 15.sp
-    val capsuleLabelSize = 11.sp
-}
-
-object AzphaltSpacing {
-    val capsuleGap = 9.dp
-    val sectionGap = 76.dp
-    val sidePadding = 44.dp
-    val recordRadius = 26.dp
-    val noteRadius = 20.dp
-    val previewRadius = 18.dp
-    val pillRadius = 999.dp
-    val pillHeight = 17.dp
-    val rowPitch = 20.dp
+    fun hueOf(id: String): Int = Azphalt.hueOf(id)
 }
 
 object AzphaltMotion {
     // Fast-out, long-settle — the one curve the whole system uses. Nothing else.
     val unfoldEasing = CubicBezierEasing(0f, .9f, .1f, 1f)
     const val UNFOLD_MS = 420
-    const val STAGGER_MS = 26
-    const val MAX_STAGGER_ROWS = 20
-}
-
-/** A palette slice that can be swapped per top-level category (e.g. mauve/gold/navy grounds). */
-data class AzphaltPalette(
-    val ground: Brush = AzphaltColors.page,
-    val ink: Color = AzphaltColors.Ink,
-    val accent: Color = AzphaltColors.hues[0],
-    val accentCap: Color = AzphaltColors.hueCaps[0]
-)
-
-val LocalAzphaltPalette = staticCompositionLocalOf { AzphaltPalette() }
-
-@Composable
-fun AzphaltCategoryTheme(palette: AzphaltPalette, content: @Composable () -> Unit) {
-    CompositionLocalProvider(LocalAzphaltPalette provides palette, content = content)
 }

--- a/composeApp/src/commonTest/kotlin/com/hereliesaz/hg2gui/ui/AsciiArtTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/hereliesaz/hg2gui/ui/AsciiArtTest.kt
@@ -33,4 +33,21 @@ class AsciiArtTest {
         """.trimIndent()
         assertTrue(looksLikeAsciiArt(text))
     }
+
+    @Test
+    fun commonLineArtCharacters_clearIsoLevel() {
+        // Regression for a miscalibrated ISO_LEVEL that put nearly all real line-art punctuation
+        // below the fill threshold, so detected art rendered as an almost-blank canvas - these are
+        // exactly the characters a hand-drawn ASCII picture is built from.
+        for (c in "|\\/_-()<>[]{}") {
+            assertTrue("'$c' should count as ink at ISO_LEVEL", charDensity(c) >= ISO_LEVEL)
+        }
+    }
+
+    @Test
+    fun trulyBlankPunctuation_staysBelowIsoLevel() {
+        for (c in " .'`") {
+            assertTrue("'$c' should stay below ISO_LEVEL", charDensity(c) < ISO_LEVEL)
+        }
+    }
 }

--- a/composeApp/src/commonTest/kotlin/com/hereliesaz/hg2gui/ui/TypesetOutputTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/hereliesaz/hg2gui/ui/TypesetOutputTest.kt
@@ -1,5 +1,6 @@
 package com.hereliesaz.hg2gui.ui
 
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -39,5 +40,27 @@ class TypesetOutputTest {
             Signal: -47 dBm
         """.trimIndent()
         assertFalse(looksLikeKeyValueTable(text))
+    }
+
+    @Test
+    fun multiFieldLine_splitsIntoOneRowPerField() {
+        // Regression: a `stat`-style line packing several `label: value` fields together with 2+
+        // space gaps used to collapse into a single row whose value swallowed everything after
+        // the first colon.
+        val rows = parseKeyValueTable("Size: 2843  Blocks: 8  IO Block: 4096  regular file")
+        assertEquals(
+            listOf(
+                KeyValueRow("Size", "2843"),
+                KeyValueRow("Blocks", "8"),
+                KeyValueRow("IO Block", "4096"),
+            ),
+            rows
+        )
+    }
+
+    @Test
+    fun singleFieldLine_staysOneRow() {
+        val rows = parseKeyValueTable("Description: A shell for interacting with the system")
+        assertEquals(listOf(KeyValueRow("Description", "A shell for interacting with the system")), rows)
     }
 }

--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -149,8 +149,15 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
     verify yields `AzpTrust.INVALID`; verifying against a key the registry's `discovery()`
     publishes yields `AzpTrust.TRUSTED`, otherwise `AzpTrust.VALID` — "tamper-evidence, not
     identity" per the spec, since counter-signature chains aren't implemented. Cross-checked
-    against a real signed package pulled from the live registry with `openssl pkeyutl -verify
-    -rawin` before being wired in.
+    against a real signed package (`com.hereliesaz.azphalt.3d-protrusion`) downloaded live from
+    `azphalt.store` with `openssl pkeyutl -verify -pubin -inkey pub.der -keyform DER -rawin -in
+    manifest.json -sigfile sig.bin` → `Signature Verified Successfully`, confirming the exact
+    wire assumptions this file makes: standard (not URL-safe) base64, a 44-byte SPKI DER key
+    (`X509EncodedKeySpec`), and the manifest's exact stored bytes with no re-canonicalization. As
+    of that same check, the live registry's `.well-known/azphalt-repository.json` doesn't publish
+    a `signingKeys` field at all yet — `AzpDiscovery.signingKeys` defaults to empty and decodes
+    that response fine, but it means every signed package currently tops out at `AzpTrust.VALID`
+    in practice; `TRUSTED` is real code, just not yet reachable against the live registry.
 *   **`azp/AzpInstaller.kt`** (androidMain): a `.azp` is a plain ZIP archive with `manifest.json`
     at its root (`spec/package-format.md`) — `install()` unzips it into
     `filesDir/azp/<id>/<version>/` (rejecting any entry that would escape via `..`), reads
@@ -206,8 +213,9 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
 *   **`ui/guide/GuideReaderScreen.kt`**: an entry never just appears - each field wipes on in
     reading order via `WipeItem`, sequenced `120 + seq*110` ms apart with
     `CubicBezierEasing(0f, .9f, .1f, 1f)` (the Azphalt "unfold" easing). Text/rules reveal via a
-    left-to-right `clipRect`; capsules/pills instead animate their real layout width from 0, since
-    clip-masking an already-round shape would guillotine its leading curve.
+    left-to-right `clipRect`; capsules/pills instead animate their real layout width from 0 (so a
+    chip's Row slot grows along with it), clipped to that reported width so an in-flight chip
+    never overlaps whatever the Row places next to it.
 *   `GuideWash`: a faint, oversized echo of the entry's own command name (9% ink, ~100sp) behind
     the content, drifting in from the right over 2400ms on the same easing - "depth is speed," no
     blur or dimming. Tied to the same `wipeKey` as every `WipeItem`, so Prev/Next/Replay restart

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -143,9 +143,14 @@ binary now, run in the Termux environment below, not a reimplementation of one.
     keys — an installed row shows **✓ TRUSTED SIGNER** when the signer is one the registry itself
     vouches for, **SIGNED · UNKNOWN SIGNER** when the signature checks out but the signer isn't
     registry-published, **SIGNED · UNVERIFIED (OS)** on pre-13 devices, or **UNSIGNED** for a
-    package with no `signature.json` at all. A signature that fails to verify is rejected outright
-    — the package is not installed. A valid signature only proves the package wasn't tampered with
-    after signing, not who wrote it; only a **TRUSTED** signer is registry-vouched-for.
+    package with no `signature.json` at all, or **UNCHECKED · REINSTALL TO VERIFY** for one
+    installed before this app version could check at all. A signature that fails to verify — or a
+    `signature.json` too corrupt to even parse — is rejected outright, the package is not
+    installed. A valid signature only proves the package wasn't tampered with after signing, not
+    who wrote it; only a **TRUSTED** signer is registry-vouched-for. As of this writing the live
+    registry's discovery document doesn't publish any `signingKeys` yet, so every signed package
+    currently tops out at **SIGNED · UNKNOWN SIGNER** in practice — TRUSTED becomes reachable the
+    day the registry starts publishing keys, with no app update needed.
 -   **net-inventory / harden-check / sysinfo:** three more scripts installed alongside
     `osint-lookup`, all local, no arguments needed. `net-inventory` lists this device's own
     network interfaces, routes and DNS config. `harden-check` audits this install's own SSH key


### PR DESCRIPTION
## Summary

An adversarial audit (`glee` subagent) of this session's prior work turned up several real defects. This PR fixes all of them.

**Two crash bugs, reachable from ordinary use:**
- `PillMenu.kt`'s `Phase.Open` branch did `roots.first { it.id == p.hostId }`, which threw `NoSuchElementException` when a contextual root pill (the autosuggest/answer-prompt host) disappeared between recompositions while its opening animation was still in flight — e.g. tapping a suggestion pill clears the input text that made the pill appear. Now falls back to `Phase.Browsing` instead of crashing.
- The azp Store's install flow (`TerminalActivity.kt`) had no exception handling at all, unlike the sibling search handler — a dropped connection or malformed `manifest.json` crashed the app outright. `AzpInstaller.install()` itself is also now wrapped so a corrupt archive/manifest cleans up and fails gracefully instead of throwing.

**ASCII-art rendering was essentially broken:** `AsciiArt.kt`'s density ramp and `ISO_LEVEL` threshold put nearly every real line-art character (`|`, `\`, `(`, `)`, `_`, `-`, etc.) *below* the fill threshold, so detected art rendered as an almost-blank canvas — the project's own cat-face test fixture would have rendered as four dots. `ISO_LEVEL` dropped from 0.42 to 0.1, calibrated against which characters actually read as "ink" vs. genuinely blank. Also fixed dead fit-to-width sizing code (a `BoxWithConstraints` measured with infinite width because it lived inside `horizontalScroll`, so it always fell back to `maxCell`).

**azp Store signature-verification gaps** (from the previous PR):
- A corrupted/truncated `signature.json` no longer silently downgrades to `UNSIGNED` and installs anyway — it's now `INVALID` and rejected, matching the docs' "rejected outright" claim.
- A failed `discovery()` call no longer permanently caches an empty trusted-key list for the rest of the process — only a *successful* fetch is cached, so the app can recover once the network comes back.
- Packages installed before trust tracking existed now read back as a distinct `UNCHECKED` tier instead of the misleading `UNSIGNED` (which the docs define as a positive claim: "checked, no signature.json").
- Re-verified the Ed25519 wire-format assumptions for real, live, against `azphalt.store` (downloaded `com.hereliesaz.azphalt.3d-protrusion`, cross-checked with `openssl pkeyutl -verify -rawin` → `Signature Verified Successfully`), and recorded the concrete package/command in the docs and code comments — the previous PR's citation of this check had no artifact backing it. Also discovered and documented that the live registry doesn't publish `signingKeys` yet, so `TRUSTED` is real code but not yet reachable in production.
- Merged with a concurrent PR (#109, per-file digest verification) that touched the same file; both sets of checks now compose correctly in `AzpInstaller.install()`.

**Smaller fixes:**
- Guide Motion's `wipeGrow` only faked its reported layout size without clipping, so an in-flight chip rendered at full size and overlapped whatever the Row placed next to it. Now clips to the animated size.
- `TypesetOutput`'s key:value heuristic doc cited `ifconfig`/`dpkg -s` as matching examples — they don't (no colons on most lines). Corrected to real matching examples, and fixed a `stat`-style bug where multiple `label: value` fields on one line collapsed into a single garbled row instead of splitting into one row per field.
- The PLAIN TEXT/ART toggle on a terminal buffer entry was keyed on `entry.output`, so it silently reset on every streamed chunk of a still-running command. Now keyed on `entry.command`.
- `AzphaltTokens.kt` held a hand-copied duplicate of the real Azphalt palette that had drifted out of sync (wrong Yellow — the `--page` hex instead of `--yellow-bright` — and only 10 of 14 hues), and was live on the splash screen. Now delegates to `PillMenu.kt`'s `Azphalt` object instead of duplicating values, so this class of drift is structurally impossible going forward. Also removed several confirmed-dead objects (`AzphaltType`, `AzphaltSpacing`, `AzphaltPalette`, `LocalAzphaltPalette`, `AzphaltCategoryTheme`) that had zero references anywhere.
- A few small dead-code/smell cleanups (unused `index` param, `var` → `val`, unused imports).
- Documented the Menu Style Guide's unimplemented width-variation rule directly in code (previously only in a commit message).

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlinAndroid` — builds clean
- [x] `./gradlew :composeApp:testPlaystoreDebugUnitTest` — all tests pass, including new regression tests for the ASCII-art density threshold and the `stat`-style multi-field typeset parsing
- [x] Manual live cross-check of the Ed25519 verification wire format against a real `azphalt.store` package with `openssl`

---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Harden azp package installation, trust tracking, and signature verification, fix crashes and rendering issues in the menu, ASCII-art, and guide animations, and align Azphalt theming and documentation with the actual palette and trust semantics while adding targeted regression tests.

Bug Fixes:
- Prevent PillMenu from crashing when an open-phase contextual host pill disappears mid-animation.
- Handle corrupt azp package archives, manifests, and signatures gracefully during install instead of crashing.
- Ensure azp registry trusted-key discovery failures do not permanently poison the in-process cache.
- Fix ASCII-art rendering so detected art actually draws linework instead of near-blank output.
- Correct key:value typeset parsing so multi-field lines produce separate rows instead of collapsing.

Enhancements:
- Delegate Azphalt theme tokens to the central Azphalt palette to eliminate drift and remove unused theme structures.
- Refine azp trust-tier semantics and UI labels, including a distinct UNCHECKED tier for pre-verification installs and clarified TRUSTED coloring.
- Tighten azp signature-verification documentation with a concrete live-package verification example and clarified wire-format assumptions.
- Improve guide wipe animations by clipping growing chips to their animated width to avoid overlap and documenting behavior.
- Stabilize terminal buffer plain-text/art toggling by keying the toggle on the command instead of the streaming output.

Documentation:
- Update user and architecture docs to reflect refined azp trust tiers, signature rejection behavior, and current registry capabilities.

Tests:
- Add regression tests for ASCII-art density calibration and common line-art characters relative to ISO_LEVEL.
- Add regression tests for multi-field key:value parsing ensuring one row per field and stable single-field behavior.

Chores:
- Minor code cleanups including removal of unused parameters, vars, imports, and dead Azphalt theme objects.