### PR TITLE
Install kind:"script" packages as real Termux commands

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -36,6 +36,7 @@ import com.hereliesaz.hg2gui.ai.AiClient
 import com.hereliesaz.hg2gui.ai.AiReply
 import com.hereliesaz.hg2gui.azp.AzpClient
 import com.hereliesaz.hg2gui.azp.AzpInstaller
+import com.hereliesaz.hg2gui.azp.ScriptInstaller
 import com.hereliesaz.hg2gui.managers.AiSettings
 import com.hereliesaz.hg2gui.managers.AzpLibrary
 import com.hereliesaz.hg2gui.managers.ContactManager
@@ -383,7 +384,8 @@ class TerminalActivity : FragmentActivity() {
                                         id = pkg.id, name = pkg.name, author = pkg.author,
                                         description = pkg.description, version = pkg.version,
                                         kind = pkg.kind, installed = inst != null,
-                                        trust = inst?.trust?.name ?: ""
+                                        trust = inst?.trust?.name ?: "",
+                                        scriptCommand = inst?.let { AzpLibrary.scriptCommand(this@TerminalActivity, it.id) }.orEmpty()
                                     )
                                 }
                                 azpBusy = false
@@ -399,11 +401,17 @@ class TerminalActivity : FragmentActivity() {
                                         val install = AzpInstaller.install(
                                             this@TerminalActivity, listing.id, listing.version, bytes, trustedKeys
                                         ) ?: return@withContext null
+                                        val scriptCommand = install.script?.let { script ->
+                                            val outcome = ScriptInstaller.install(
+                                                this@TerminalActivity, listing.id, listing.version, script
+                                            )
+                                            (outcome as? ScriptInstaller.Result.Installed)?.command
+                                        }
                                         AzpLibrary.record(
                                             this@TerminalActivity, listing.id, listing.name, listing.version,
-                                            install.kind, install.skillIds, install.trust
+                                            install.kind, install.skillIds, install.trust, scriptCommand
                                         )
-                                        install
+                                        install to scriptCommand
                                     }
                                 } catch (e: Exception) {
                                     // A dropped connection or a malformed archive/manifest must
@@ -411,8 +419,11 @@ class TerminalActivity : FragmentActivity() {
                                     null
                                 }
                                 if (result != null) {
+                                    val (install, scriptCommand) = result
                                     azpResults = azpResults.map {
-                                        if (it.id == listing.id) it.copy(installed = true, trust = result.trust.name) else it
+                                        if (it.id == listing.id) {
+                                            it.copy(installed = true, trust = install.trust.name, scriptCommand = scriptCommand.orEmpty())
+                                        } else it
                                     }
                                 }
                                 azpInstallingId = null

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpInstaller.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpInstaller.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.decodeFromJsonElement
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -12,7 +13,13 @@ import java.security.DigestOutputStream
 import java.security.MessageDigest
 import java.util.zip.ZipInputStream
 
-data class AzpInstallResult(val kind: String, val skillIds: List<String>, val trust: AzpTrust)
+data class AzpInstallResult(
+    val kind: String,
+    val skillIds: List<String>,
+    val trust: AzpTrust,
+    /** Present only for `kind:"script"` - see [ScriptDto] and `ScriptInstaller`. */
+    val script: ScriptDto? = null,
+)
 
 /**
  * Unpacks a downloaded `.azp` - a plain ZIP archive per spec/package-format.md, `manifest.json`
@@ -102,6 +109,11 @@ object AzpInstaller {
                         ?.mapNotNull { it.jsonObject["id"]?.jsonPrimitive?.content }
                         ?: emptyList()
                 } else emptyList()
+                val script = if (kind == "script") {
+                    manifest["script"]?.jsonObject?.let {
+                        try { json.decodeFromJsonElement(ScriptDto.serializer(), it) } catch (e: Exception) { null }
+                    }
+                } else null
 
                 // Integrity: every payload entry's digest must match `manifest.files`, and every
                 // entry (besides the detached `signature.json`, which is exempt - it's the
@@ -134,7 +146,7 @@ object AzpInstaller {
                 }
                 if (trust == AzpTrust.INVALID) { dest.deleteRecursively(); return@withContext null }
 
-                AzpInstallResult(kind, skillIds, trust)
+                AzpInstallResult(kind, skillIds, trust, script)
             } catch (e: Exception) {
                 dest.deleteRecursively()
                 null

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpModels.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/AzpModels.kt
@@ -62,6 +62,22 @@ data class AzpDiscovery(
     val signingKeys: List<AzpSigningKeyInfo> = emptyList(),
 )
 
+/**
+ * The `script` block of a `kind:"script"` package (`spec/script.md`) - a native script installed
+ * and run the way a package manager installs its own package. `dependencies` maps a
+ * package-manager namespace to the packages it needs; only `"apt"` means anything to this
+ * Termux-backed app (any other namespace is present-but-unusable here, same as an unrecognized
+ * `mcp` `grants` entry), resolved by [ScriptInstaller] before the script is made runnable.
+ */
+@Serializable
+data class ScriptDto(
+    val interpreter: String = "",
+    val entry: String = "",
+    val command: String? = null,
+    val args: List<String> = emptyList(),
+    val dependencies: Map<String, List<String>> = emptyMap(),
+)
+
 /** The outcome of verifying a package's `signature.json` against its `manifest.json` bytes -
  *  see [com.hereliesaz.hg2gui.azp.AzpSignatureVerifier]. */
 enum class AzpTrust {

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/ScriptInstaller.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/azp/ScriptInstaller.kt
@@ -1,0 +1,92 @@
+package com.hereliesaz.hg2gui.azp
+
+import android.content.Context
+import com.hereliesaz.hg2gui.terminal.DistroManager
+import com.hereliesaz.hg2gui.terminal.TerminalEngine
+import java.io.File
+
+/**
+ * Turns an installed `kind:"script"` package's [ScriptDto] into an actually-runnable command -
+ * the `pkg install` step `spec/script.md` describes, mirroring how a real package manager (apt,
+ * brew, ...) resolves a package's declared dependencies before exposing its binary. Only the
+ * `"apt"` dependency namespace means anything here, since HG2Gui's real OS access is entirely
+ * through its bundled Termux prefix (see [DistroManager]) - any other namespace (e.g. `"brew"`)
+ * is present-but-unusable, same as an `mcp` package's unrecognized `grants` entry.
+ *
+ * Once dependencies resolve, a thin wrapper is written to `prefix/bin/<command>` that `exec`s the
+ * interpreter against the package's own extracted, digest-verified entry file - never copying or
+ * rewriting those bytes, so the integrity check [AzpInstaller] already ran keeps covering exactly
+ * what runs. Requires a Termux bootstrap to already be installed (see [DistroManager.isInstalled])
+ * - there is no OS package manager, and nothing to install a package's dependencies with, until
+ * the user has bootstrapped one.
+ */
+object ScriptInstaller {
+
+    sealed class Result {
+        /** The wrapper is written and executable, callable as [command] from any shell session. */
+        data class Installed(val command: String) : Result()
+        /** `pkg install -y` for one or more declared dependencies exited non-zero; [output] is
+         *  the shell transcript for diagnosis. Nothing is wired onto PATH. */
+        data class DependencyFailed(val output: String) : Result()
+        /** No Termux bootstrap yet - there's no `pkg`/`apt` to resolve dependencies with, and no
+         *  `prefix/bin` to place a wrapper in. The package's bytes are still on disk from
+         *  [AzpInstaller.install]; only becoming runnable is deferred. */
+        object BootstrapMissing : Result()
+    }
+
+    suspend fun install(
+        context: Context,
+        id: String,
+        version: String,
+        script: ScriptDto,
+    ): Result {
+        if (!DistroManager.isInstalled(context)) return Result.BootstrapMissing
+
+        val prefix = DistroManager.prefixDir(context)
+        val engine = TerminalEngine(context)
+        try {
+            val aptPackages = script.dependencies["apt"].orEmpty()
+            if (aptPackages.isNotEmpty()) {
+                val (output, exitCode) = engine.runToCompletion(
+                    "pkg install -y " + aptPackages.joinToString(" ") { it.shellQuoted() }
+                )
+                if (exitCode != 0) return Result.DependencyFailed(output)
+            }
+
+            val entryFile = File(AzpInstaller.rootDir(context, id, version), script.entry)
+            val command = script.command?.takeIf { it.isNotBlank() } ?: commandNameFor(script.entry)
+            val interpreter = resolveOnPrefix(prefix, script.interpreter)
+            val argsSuffix = script.args.joinToString("") { " " + it.shellQuoted() }
+
+            val wrapper = File(prefix, "bin/$command")
+            wrapper.writeText(
+                "#!${File(prefix, "bin/bash").absolutePath}\n" +
+                    "exec ${interpreter.shellQuoted()} ${entryFile.absolutePath.shellQuoted()}$argsSuffix \"\$@\"\n"
+            )
+            wrapper.setExecutable(true)
+            return Result.Installed(command)
+        } finally {
+            engine.destroy()
+        }
+    }
+
+    /** The interpreter's absolute path within the prefix if it's there (e.g. just installed as a
+     *  dependency), otherwise its bare name - resolved via the shell's own inherited PATH, which
+     *  ShellSession already points at `prefix/bin` for every Termux-backed session. */
+    private fun resolveOnPrefix(prefix: File, interpreter: String): String {
+        val direct = File(prefix, "bin/$interpreter")
+        return if (direct.canExecute()) direct.absolutePath else interpreter
+    }
+}
+
+/** `script.entry`'s filename, extension stripped - the fallback `command` name when a package
+ *  omits one, e.g. `script/git-sync.sh` -> `git-sync`. Pure and Context-free, split out from
+ *  [ScriptInstaller.install] specifically so it's unit-testable without a Robolectric/instrumented
+ *  Android runtime - see ScriptInstallerTest. */
+internal fun commandNameFor(entry: String): String =
+    File(entry).nameWithoutExtension.ifBlank { "script" }
+
+/** Single-quotes [this] for safe interpolation into a generated shell wrapper, escaping any
+ *  embedded single quote the POSIX-shell way (`'\''`). Pure and Context-free for the same
+ *  testability reason as [commandNameFor]. */
+internal fun String.shellQuoted(): String = "'" + replace("'", "'\\''") + "'"

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/AzpLibrary.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/AzpLibrary.kt
@@ -51,6 +51,10 @@ object AzpLibrary {
         kind: String,
         skillIds: List<String>,
         trust: AzpTrust = AzpTrust.UNSIGNED,
+        /** For `kind:"script"` only - the name it's callable as on PATH once [ScriptInstaller]
+         *  has written its wrapper, so the store row can show it. Blank if installation didn't
+         *  reach that point (e.g. no Termux bootstrap yet - see [ScriptInstaller.Result]). */
+        scriptCommand: String? = null,
     ) {
         val p = prefs(context)
         val ids = p.getStringSet(KEY_IDS, emptySet()).orEmpty() + id
@@ -61,8 +65,11 @@ object AzpLibrary {
             putString("$id.kind", kind)
             putString("$id.skillIds", skillIds.joinToString(","))
             putString("$id.trust", trust.name)
+            if (scriptCommand != null) putString("$id.scriptCommand", scriptCommand) else remove("$id.scriptCommand")
         }
     }
+
+    fun scriptCommand(context: Context, id: String): String? = prefs(context).getString("$id.scriptCommand", null)
 
     fun remove(context: Context, id: String) {
         val p = prefs(context)
@@ -70,6 +77,7 @@ object AzpLibrary {
         p.edit {
             putStringSet(KEY_IDS, ids)
             remove("$id.name"); remove("$id.version"); remove("$id.kind"); remove("$id.skillIds"); remove("$id.trust")
+            remove("$id.scriptCommand")
         }
     }
 

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/TerminalEngine.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/TerminalEngine.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
 import okhttp3.Cache
 import okhttp3.OkHttpClient
 import java.io.File
@@ -67,6 +68,23 @@ class TerminalEngine(
             }
         }
         awaitClose { }
+    }
+
+    /**
+     * Runs [line] to completion on the real shell and returns its final transcript plus exit
+     * code - for headless one-shot commands (e.g. `pkg install` while resolving a `kind:"script"`
+     * package's dependencies, see `azp/ScriptInstaller.kt`) that need to know whether the command
+     * actually succeeded, unlike [run]'s `Flow<String>` (which streams the transcript but
+     * discards the exit code `ShellSession.stream` itself returns). Always answers a stalled
+     * interactive prompt with `null` (bail rather than hang) - there's no UI here to ask a human,
+     * and a one-shot dependency install has no business waiting on one. Bypasses the
+     * `bootstrap`/[Builtins] branches [run] has, since neither is a real shell command this needs
+     * to route through.
+     */
+    suspend fun runToCompletion(line: String): Pair<String, Int> = withContext(Dispatchers.IO) {
+        var transcript = ""
+        val exitCode = shell.stream(line, onLine = { transcript = it }, onNeedInput = { null })
+        transcript to exitCode
     }
 
     fun destroy() {

--- a/composeApp/src/androidUnitTest/kotlin/com/hereliesaz/hg2gui/azp/ScriptInstallerTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/hereliesaz/hg2gui/azp/ScriptInstallerTest.kt
@@ -1,0 +1,47 @@
+package com.hereliesaz.hg2gui.azp
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+/**
+ * [commandNameFor] and [shellQuoted] are the pure pieces [ScriptInstaller.install] builds a
+ * package's wrapper script from - see ScriptInstaller.kt's class doc. Everything else in
+ * `install()` needs a real Context/Termux prefix, so it's exercised manually rather than here.
+ */
+class ScriptInstallerTest {
+
+    @Test
+    fun commandNameFor_stripsDirectoryAndExtension() {
+        assertEquals("git-sync", commandNameFor("script/git-sync.sh"))
+    }
+
+    @Test
+    fun commandNameFor_handlesNoExtension() {
+        assertEquals("git-sync", commandNameFor("git-sync"))
+    }
+
+    @Test
+    fun commandNameFor_fallsBackWhenBlank() {
+        // An entry that's just a bare extension (or empty) has no usable filename stem.
+        assertEquals("script", commandNameFor(".sh"))
+    }
+
+    @Test
+    fun shellQuoted_wrapsPlainStringInSingleQuotes() {
+        assertEquals("'git'", "git".shellQuoted())
+    }
+
+    @Test
+    fun shellQuoted_escapesEmbeddedSingleQuote() {
+        // The POSIX way to embed a literal ' inside a single-quoted string: close the quote,
+        // escape a literal ', reopen the quote.
+        assertEquals("'it'\\''s'", "it's".shellQuoted())
+    }
+
+    @Test
+    fun shellQuoted_leavesSpacesAndGlobsInert() {
+        // The whole point of quoting: a value with spaces or shell metacharacters must survive
+        // as one literal argument, not be re-split or glob-expanded by the wrapper's shell.
+        assertEquals("'--flag *.txt'", "--flag *.txt".shellQuoted())
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
@@ -42,9 +42,13 @@ data class AzpListing(
     val kind: String,
     val installed: Boolean,
     val trust: String = "",
+    /** For an installed `kind:"script"` package - the name it's callable as on PATH once
+     *  `ScriptInstaller` has resolved its dependencies. Blank if not a script, not yet installed,
+     *  or the host has no Termux bootstrap to wire it onto PATH with yet. */
+    val scriptCommand: String = "",
 )
 
-private val KINDS = listOf("all", "skill", "mcp", "code", "pack", "asset", "app")
+private val KINDS = listOf("all", "skill", "mcp", "code", "pack", "asset", "app", "script")
 
 /**
  * Browses the azphalt registry (spec/repository-api.md) - the same `pkg`/`apt` idiom, but for
@@ -208,6 +212,14 @@ private fun AzpRow(listing: AzpListing, installing: Boolean, onInstall: (AzpList
                 Text(
                     trustLabel(listing.trust),
                     color = trustColor(listing.trust),
+                    fontSize = 8.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em,
+                    modifier = Modifier.padding(top = 3.dp)
+                )
+            }
+            if (listing.installed && listing.kind == "script") {
+                Text(
+                    if (listing.scriptCommand.isNotBlank()) "→ ${listing.scriptCommand}" else "AWAITING BOOTSTRAP",
+                    color = Azphalt.Ink.copy(alpha = .45f),
                     fontSize = 8.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em,
                     modifier = Modifier.padding(top = 3.dp)
                 )


### PR DESCRIPTION
## Summary

Builds the HG2Gui-side consumer for azphalt's `kind:"script"` package kind (azphalt PR #179, `spec/script.md`): a script package is downloaded and unpacked the same way any `.azp` is, then its `script` manifest block (`interpreter`, `entry`, `command`, `args`, `dependencies`) is read and turned into an actually-runnable command, the same way `apt`/`pkg` installs its own packages.

- `TerminalEngine.runToCompletion(line)` runs a command to completion and returns `(transcript, exitCode)` - for exit-code-aware one-shot commands (dependency installs) that `run()`'s streaming `Flow<String>` doesn't expose.
- `AzpModels.ScriptDto` mirrors the `script` manifest block; `AzpInstaller` parses it into `AzpInstallResult.script` alongside the existing digest/signature verification, so a tampered `script.entry` fails the same integrity check a tampered `SKILL.md` already does.
- `ScriptInstaller` resolves `dependencies["apt"]` via `pkg install -y` (the only package-manager namespace this Termux-backed host understands), then writes a wrapper to `prefix/bin/<command>` that `exec`s the interpreter against the package's own extracted, digest-verified entry file - never copying or rewriting those bytes. Returns `BootstrapMissing` when there's no Termux bootstrap yet to install dependencies or place a wrapper with.
- `AzpLibrary` persists the resolved command name so the store screen can show it again after a re-search.
- `AzpStoreScreen`/`AzpListing` (commonMain) gain a `"script"` kind filter chip and an installed-row line showing `→ <command>` (or `AWAITING BOOTSTRAP`).
- `TerminalActivity`'s install flow calls `ScriptInstaller.install()` for `kind:"script"` packages right after `AzpInstaller.install()`.

## Test plan
- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlinAndroid` - succeeds
- [x] `./gradlew :composeApp:testPlaystoreDebugUnitTest --tests "com.hereliesaz.hg2gui.azp.*"` - all pass, including the new `ScriptInstallerTest` (pure `commandNameFor`/`shellQuoted` cases) and the pre-existing `AzpInstallerDigestTest`
- [ ] Manual on-device check: install a real `kind:"script"` `.azp` against a bootstrapped Termux prefix and confirm the resulting command runs from the terminal

---
_Generated by [Claude Code](https://claude.ai/code/session_01EiD9pMMfBwDUPmo8fSapdE)_

## Summary by Sourcery

Add support for installing azphalt script-kind packages as runnable Termux commands and surfacing their command names in the azp store UI.

New Features:
- Support kind:"script" packages in the azp installer by parsing their script manifest block into a ScriptDto and wiring them through a new ScriptInstaller.
- Expose installed script packages as real commands on the Termux PATH by generating wrapper scripts that exec the declared interpreter and entry file.
- Show script-kind packages in the azp store with a dedicated kind filter and an installed-row indicator of the resolved command name or bootstrap status.

Enhancements:
- Extend TerminalEngine with a runToCompletion helper for exit-code-aware, non-interactive shell commands used during script dependency resolution.
- Persist script package command names in AzpLibrary so they can be redisplayed after reloading the store listings.

Tests:
- Add unit tests for ScriptInstaller helper functions to validate command name derivation and safe shell quoting.