### PR TITLE
Document and surface 'edit' builtin; update docs, modules, and tooling versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Inspired by the *Hitchhiker's Guide to the Galaxy* (2005) aesthetic and built on
     needed. Hyphenated command families (`apt-get`, `apt-key`, `apt-mark`, …) nest under one
     shared parent pill instead of cluttering the list as unrelated flat entries.
 *   **A graphical file picker.** Any command that takes a file argument gets a `file…` pill that
-    browses the real filesystem through the same pill stack — no separate screen, no typing a
-    path by hand.
+    opens a graphical Select File/Folder screen from the settled pill crumb — no typing a path by
+    hand.
 *   **Interactive prompts, answered graphically.** A command that stops mid-run to ask a
     yes/no question gets a dedicated **Answer** stack (`YES`/`NO`) instead of leaving you to
     type a blind reply; anything else falls back to the input field, whose Run button becomes
@@ -38,9 +38,10 @@ Inspired by the *Hitchhiker's Guide to the Galaxy* (2005) aesthetic and built on
 *   **Sessions.** Named terminal sessions, each with its own scrollback and working directory.
 *   **Aliases.** Native shell aliases plus `ShellAliases.kt`'s own suggestion pills — no
     duplicate alias system layered on top of the real shell's.
-*   **A real file manager.** Search, sort, multi-select batch actions, in-place rename, an
-    automatic media grid, and a storage-by-type breakdown over the `vfs` sandbox — folders are
-    capsules that expand in place, siblings squishing into thin coloured rods beside them.
+*   **A real file manager.** Search, sort, kind/hidden/recency filters, multi-select batch actions,
+    in-place rename, an automatic media grid, and a storage-by-type breakdown over the `vfs`
+    sandbox — folders are capsules that expand in place, siblings squishing into thin coloured
+    rods beside them.
 *   **The Guide.** A chaptered glossary of real commands paired with invented, Hitchhiker's-
     Guide-style definitions, reachable from the command picker — reading material, not another
     way to run something.
@@ -55,7 +56,7 @@ cascades its children upward from it. Output arrives in a record tile, not a scr
 ## Project structure
 
 Kotlin Multiplatform (Compose) for the UI and execution layer. There is no separate command
-framework: the ten built-ins are a fixed dispatch table (`terminal/Builtins.kt`), not a
+framework: the eleven built-ins are a fixed dispatch table (`terminal/Builtins.kt`), not a
 reflection-discovered plugin system.
 
 *   `composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/`
@@ -78,13 +79,13 @@ reflection-discovered plugin system.
     *   `terminal/` — execution. `ShellSession.kt` (the `actual` implementation: a long-lived
         shell framed by a sentinel that reports exit status and working directory, with
         idle-based detection of a stalled interactive prompt), `TerminalEngine.kt` (routes a
-        line to a built-in, the bootstrap installer, or the shell), `Builtins.kt` (the ten
+        line to a built-in, the bootstrap installer, or the shell), `Builtins.kt` (the eleven
         built-ins: system toggles, `call`/`contacts`, `vfs`, `calc`, `edit`), `DistroManager.kt`
         (downloads and extracts the real Termux bootstrap), `DpkgCatalog.kt` (reads dpkg's own
         bookkeeping for which package owns a given binary — Termux's packages carry no Debian
         Section field to read a category from directly, so `CommandTree`'s own hand-curated map
         turns package into category).
-    *   `ui/menu/CommandTree.kt` — builds the tree: the ten built-ins into System / Apps & nav /
+    *   `ui/menu/CommandTree.kt` — builds the tree: the eleven built-ins into Device / Apps & nav /
         Features, real PATH binaries by category (Package management, Network, Development, …)
         with hyphenated command families (`apt-get`/`apt-key`/…) nested under their shared
         parent.
@@ -95,10 +96,15 @@ reflection-discovered plugin system.
     *   `util/` — the handful of shared helpers (logging, crash reporting, the interactive-shell
         wrapper, `GenericFileProvider`) still in use.
 *   `composeApp/src/androidMain/res/` — resources. Jost lives in `res/font/`.
+*   `terminal-emulator/` — the headless VT100 parser used to normalize shell output. Shell
+    processes still use ordinary `ProcessBuilder` pipes, not a PTY.
+*   `termux-shared/` — the Android library shared with the app for Termux-compatible filesystem,
+    process, and terminal utilities; it depends on `terminal-emulator`.
 
 ## Build
 
-JDK 21, Gradle 8.13, AGP 8.13, Kotlin 2.2.20. `compileSdk`/`targetSdk` 37, `minSdk` 24.
+JDK 21, Gradle 9.7.0, AGP 9.3.1, Kotlin 2.4.10, Compose Multiplatform 1.11.1.
+`compileSdk`/`targetSdk` 37, `minSdk` 24.
 
 ```bash
 ./gradlew assembleDebug

--- a/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/Builtins.kt
+++ b/composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/Builtins.kt
@@ -28,7 +28,7 @@ import java.io.File
 /**
  * The fixed set of commands the real Termux shell has no path to: Android system toggles
  * (there is no shell binary for airplane mode), the sandboxed VFS, and the in-app editor.
- * Dispatched by verb, no reflection - there are exactly these ten, by design, not by convention.
+ * Dispatched by verb, no reflection - there are exactly these eleven, by design, not by convention.
  */
 object Builtins {
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,7 @@
 # Architecture
 
+**Current version:** 0.6.50.211
+
 HG2Gui is an Android **terminal application** — not a launcher. The UI and execution layer are
 Kotlin Multiplatform (Compose); there is no separate reflection-based command framework. Built-in
 commands are a fixed dispatch table in `terminal/Builtins.kt`.
@@ -33,10 +35,11 @@ The entry point.
     same rootfs zip archive the official Termux app installs, giving genuine `bash`, `apt`/
     `pkg`, and coreutils. Runs automatically on first launch (see `TerminalActivity`) and can
     also be triggered by hand via the `bootstrap` verb.
-*   `Builtins.kt` — the ten commands the real shell has no path to: `wifi`, `bluetooth`,
+*   `Builtins.kt` — the eleven commands the real shell has no path to: `wifi`, `bluetooth`,
     `airplane`, `flash`, `volume`, `brightness` (system toggles with no shell binary behind
     them), `call`/`contacts` (via `ContactManager`), `vfs` (the sandboxed filesystem, see below),
-    `calc` (via `util/CalculationEngine.kt`). A plain `fun run(context, line): String` dispatch
+    `calc` (via `util/CalculationEngine.kt`), and `edit` (the Compose editor). A plain
+    `fun run(context, line): String` dispatch
     on the verb — no interface, no reflection, no per-command class.
 *   `TerminalEngine.kt` — decides where a line runs: `bootstrap` streams from `DistroManager`,
     a verb in `Builtins.NAMES` goes to `Builtins.run` (a single synchronous result), anything
@@ -72,7 +75,7 @@ Compose. A screen is a function of state; there is no view-hierarchy manager cla
     that hand-off until the pick's own trail crumb has actually settled and reported its on-screen
     position (`onCrumbPositioned`) - for a wizard whose entrance animation needs to grow out from
     that exact spot, like the Select File/Folder pill.
-*   `ui/menu/CommandTree.kt` — builds the tree: the ten `Builtins` verbs (fixed lists, not
+*   `ui/menu/CommandTree.kt` — builds the tree: the eleven `Builtins` verbs (fixed lists, not
     discovered) into Device / Apps & nav / Features, and the shell's real PATH binaries into one
     root category per package category — `DpkgCatalog` reads which package owns a binary from
     dpkg's own bookkeeping, and a hand-curated map (Termux's packages carry no Debian Section
@@ -100,7 +103,8 @@ Compose. A screen is a function of state; there is no view-hierarchy manager cla
 *   `ui/editor/EditorScreen.kt` — the `edit` command's text editor: a plain Compose screen (Save/
     Back pills, a text field), hosted by `EditorActivity` so it's also a valid target for another
     app's VIEW/EDIT intent on a text file.
-*   `ui/files/FilesScreen.kt` — the graphical explorer over `VfsManager`'s sandbox.
+*   `ui/files/FilesScreen.kt` — the graphical explorer over `VfsManager`'s sandbox, with search,
+    sorting, kind/hidden/recency filters, batch actions, rename, media grid, and storage views.
 *   `Theme.kt` — Azphalt colour and type tokens.
 
 ## Package Structure (`com.hereliesaz.hg2gui`)
@@ -108,16 +112,64 @@ Compose. A screen is a function of state; there is no view-hierarchy manager cla
 *   **root**: `TerminalActivity`, `EditorActivity` — the only two activities.
 *   **`ui/`**: Compose UI and the pill menu, `ui/editor/`, `ui/files/`.
 *   **`managers/`**: `ContactManager` (contacts, backs `call`/`contacts`), `VfsManager` (a
-    sandboxed file layer rooted at `filesDir/vfs` — real files, but confined to the app's private
-    storage and never touched by the real shell), `flashlight/` (the torch implementation behind
-    `flash`).
-*   **`terminal/`**: `ShellSession`, `TerminalEngine`, `Builtins` (the ten built-in commands),
+    sandboxed file layer rooted at `filesDir/vfs`; normal operations stay confined to app-private
+    storage, while the explicit root-only `vfs mount` command can bind-mount it into the real
+    filesystem), `flashlight/` (the torch implementation behind `flash`).
+*   **`terminal/`**: `ShellSession`, `TerminalEngine`, `Builtins` (the eleven built-in commands),
     `DistroManager` (the Termux bootstrap installer), `DpkgCatalog` (reads dpkg's own bookkeeping
     for which package owns a binary — `CommandTree`'s hand-curated map turns that into a
     category).
 *   **`util/`**: `CalculationEngine` (the `calc` expression parser, `commonMain`), plus a handful
     of Android-only helpers still in use — logging/crash reporting, the interactive-shell wrapper
     `vfs mount` needs for `su`, `GenericFileProvider`.
+
+## Gradle Module Boundaries
+
+*   **`:composeApp`** — the Android application and Kotlin Multiplatform Compose UI, orchestration,
+    terminal routing, managers, and platform integrations.
+*   **`:terminal-emulator`** — a headless VT100 output parser. It does not provide a PTY; the shell
+    remains a `ProcessBuilder` process connected through ordinary streams.
+*   **`:termux-shared`** — reusable Termux-compatible Android utilities consumed by `:composeApp`;
+    depends on `:terminal-emulator`.
+
+## Product Subsystems
+
+*   **MCP:** an explicit-start, loopback-only JSON-RPC server. VFS tools are sandboxed; shell
+    execution is separately biometric-gated and uses a service-owned terminal engine.
+*   **Workflows and AI:** workflows expand reviewed command templates; AI produces command
+    suggestions and optional token explanations. Neither path executes a suggestion automatically.
+*   **Azphalt store:** package extraction is path-contained and signature-checked; every extracted
+    payload must be declared and match its declared SHA-256 digest. Skill text can augment AI
+    prompts. `script` packages can
+    resolve Termux dependencies and install a PATH wrapper; other package kinds remain stored data.
+*   **Context and Guide:** the OS-context tree offers static remote-OS reference commands, while
+    the Guide is reading material. Neither pretends to discover a remote machine.
+
+## Invariants
+
+1.  The app is a terminal, not a launcher: there is no `HOME` intent filter.
+2.  Built-ins are an explicit eleven-verb dispatch table; no reflection discovers commands.
+3.  `bootstrap` routes first, built-ins win command-name ties, and all other input reaches the shell.
+4.  Every terminal tab owns its engine, shell, UI state, history, scrollback, and working directory.
+5.  VFS operations resolve paths canonically beneath `filesDir/vfs`; shell access requires the
+    explicit, root-only `vfs mount` escape hatch.
+6.  Shell processes are persistent but have no PTY, job control, or full-screen cursor semantics.
+7.  Wizard- and AI-produced commands are assembled for review, never executed automatically.
+8.  MCP binds only to loopback; shell tools remain disabled until explicit biometric approval.
+9.  Azphalt extraction never writes outside its package directory; every extracted payload must be
+    declared and match its declared SHA-256 digest, and the package must pass signature policy.
+
+## Decisions and Reasons
+
+*   **Compose-only presentation:** separate editor and file surfaces replace cursor-addressed terminal
+    programs because the shell transport deliberately has no PTY.
+*   **Fixed built-ins:** only Android capabilities with no useful shell binary live in Kotlin, keeping
+    the real shell authoritative for everything else.
+*   **Per-session engines:** persistent shell state is useful, but leaking it between tabs is not.
+*   **Curated command categories:** Termux package metadata has no reliable Debian Section field, so
+    dpkg supplies ownership while a checked-in map supplies human-facing categories.
+*   **Review before execution:** graphical wizards and AI may assemble commands, but user intent is
+    established only when the user runs them.
 
 ## Data Flow
 

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -42,7 +42,7 @@ predates them (`DistroManager.ensureBundledScripts`):
 
 See `docs/USER_GUIDE.md` for the full description of each.
 
-Two more root pills sit alongside the shell categories, neither backed by a shell binary:
+Four more root pills sit alongside the shell categories, none backed by a shell binary:
 
 *   **Workflows**: saved command templates. Each saved one is a pill that asks for any
     `{placeholder}` values the template needs, then drops the assembled command onto the command
@@ -59,18 +59,18 @@ Two more root pills sit alongside the shell categories, neither backed by a shel
     locally real, the package/service managers don't. Picking one just assembles the command onto
     the command line like any other pill; nothing runs automatically.
 *   **Store**: one `search…` pill opening the azphalt.store package browser — the same idea as
-    `pkg`/`apt`, but for `.azp` extensions (assets, code, packs, companion apps, MCP-server
-    headers, and AI-skill bundles). Filter by kind, then INSTALL downloads and unpacks a package.
-    HG2Gui has no `.azp` execution runtime, so only `skill`-kind packages do anything further —
-    their `SKILL.md` content is folded into the AI chat's system prompt. Everything else is
-    download-only, for use elsewhere, the same as `apt download`. Every install verifies the
-    package's Ed25519 signature against the registry's published signing keys and shows a trust
-    badge (TRUSTED / SIGNED / UNSIGNED); a signature that fails to verify is rejected. See
+    `pkg`/`apt`, but for `.azp` extensions (assets, code, packs, companion apps, scripts,
+    MCP-server headers, and AI-skill bundles). Filter by kind, then INSTALL downloads and unpacks
+    a package. Skill content augments AI chat; script packages resolve declared Termux dependencies
+    and install a verified entry-point wrapper. Other kinds remain download-only. Every install
+    enforces path containment, requires each extracted payload to match its declared SHA-256 digest,
+    verifies any Ed25519 signature,
+    and shows its trust state; a digest or signature failure rejects the package. See
     `docs/USER_GUIDE.md`.
 
 ## Built-in commands
 
-These ten are the only commands HG2Gui itself implements — see `terminal/Builtins.kt`. Every
+These eleven are the only commands HG2Gui itself implements — see `terminal/Builtins.kt`. Every
 other verb (app launching, file sharing, `alias`, editing with `nano`/`vim`, and so on) is a
 real shell binary now, not a reimplementation of one.
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -36,7 +36,8 @@ are out of scope.
         timing or layout.
 
 ## Toolchain
-JDK 21, Gradle 8.13, AGP 8.13, Kotlin 2.2.20, `compileSdk` 37, `minSdk` 24.
+JDK 21, Gradle 9.7.0, AGP 9.3.1, Kotlin 2.4.10, Compose Multiplatform 1.11.1,
+`compileSdk` 37, `minSdk` 24.
 
 ## Pull Requests
 1.  Fork the repository.

--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -4,8 +4,8 @@
 HG2Gui is a touch-optimised terminal emulator for Android. It is **not a launcher** — there is
 no `category.HOME` filter, no launcher lifecycle behaviour, and no app drawer.
 
-The UI, execution layer, and the ten built-in commands are all Kotlin. There is no separate
-reflection-based command engine underneath it — built-ins are a fixed dispatch table.
+The UI, execution layer, and the eleven built-in commands are all Kotlin. There is no separate
+reflection-based command engine underneath it — eleven built-ins are a fixed dispatch table.
 
 ## Core Components
 
@@ -29,8 +29,8 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
 *   **Responsibility**: The tree's state machine (browsing, leaving, open) and its motion.
     Each pill is an `Animatable`; the choreography is specified in [DESIGN.md](DESIGN.md).
 
-### 4. `Builtins` (Kotlin, the ten commands the shell can't provide)
-*   **Role**: The fixed dispatch table for the ten built-in commands.
+### 4. `Builtins` (Kotlin, the eleven commands the shell can't provide)
+*   **Role**: The fixed dispatch table for the eleven built-in commands.
 *   **Responsibility**: `wifi`, `bluetooth`, `airplane`, `flash`, `volume`, `brightness` (system
     toggles Android exposes no shell path to), `call`/`contacts` (via `ContactManager`), `vfs`
     (the sandboxed filesystem), `calc` (via `util/CalculationEngine.kt`), `edit` (opens
@@ -57,7 +57,7 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
 
 ### 6. `CommandTree` (Kotlin, `androidMain`)
 *   **Role**: Turns the fixed `Builtins` list and the shell's own PATH into the menu.
-*   **Responsibility**: The ten built-ins group into Device / Apps & nav / Features from a fixed
+*   **Responsibility**: The eleven built-ins group into Device / Apps & nav / Features from a fixed
     list, with argument hints from a static map, per [COMMANDS.md](COMMANDS.md). "Device" (the
     hardware toggles: wifi/bluetooth/airplane/flash/volume/brightness) is deliberately not called
     "System" - a shell-discovered category is also named "System" (procps/tmux/htop/util-linux and
@@ -80,11 +80,13 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
     *and* its hyphenated siblings, not just the siblings). Before a bootstrap exists, Shell offers
     exactly one pill: `bootstrap`.
 *   **Overflow**: a category or a root stack can hold more pills than one screen's height at
-    `PillMenu.kt`'s `ROW_PITCH` - `rememberStackScroll` (in `PillMenu.kt`) tracks a plain drag
-    offset applied on top of every pill's own animated position, since the stack's absolute-
+    `PillMenu.kt`'s `ROW_PITCH` - `rememberStackScroll` tracks drag and decay-fling offsets, then
+    snaps to the nearest row. The offset is applied on top of every pill's animated position,
+    since the stack's absolute-
     `translationY` positioning can't use a stock `verticalScroll`/`LazyColumn` (Compose would size
     the scroll region to each pill's own viewport-sized Box, not to the stack's real extent). Used
-    for both the root stack and any `ChildBand`.
+    for both the root stack and any `ChildBand`. Dwelling on a newly scrolled-in navigational pill
+    for 550 ms advances into it; terminal leaves and wizard actions never fire from dwell.
 *   `FileBrowser` (also `androidMain`) supplies the file-argument case: a `file…` node (attached
     to `edit` and to every discovered shell binary) whose `wizardId` opens the graphical Select
     File/Folder picker instead of drilling further into the pill stack - see section 13 below.
@@ -190,20 +192,20 @@ reflection-based command engine underneath it — built-ins are a fixed dispatch
     installed skill package's `skills/<id>/SKILL.md` off disk, capped to a fixed character budget,
     for `AiClient` to fold into its system prompt.
 *   **`ui/azp/AzpStoreScreen.kt`** (commonMain): search box, kind-filter pills (all/skill/mcp/
-    code/pack/asset/app), and a result list with an INSTALL/INSTALLED pill per package — same
+    code/pack/asset/app/script), and a result list with an INSTALL/INSTALLED pill per package — same
     visual idiom as `AiChatScreen`. An installed row also shows a trust badge (TRUSTED SIGNER /
     SIGNED · UNKNOWN SIGNER / SIGNED · UNVERIFIED (OS) / UNSIGNED) — `AzpListing.trust` carries
     the androidMain `AzpTrust` enum's name as a plain string, since commonMain can't reference a
     platform-specific type directly. Reached via a synthesized `azp` root pill
     (`CommandTree.azpRoot`, `wizardId = "azp-store"` navigates to the screen, same reuse of
     `onWizard` as the AI pill).
-*   HG2Gui has no `.azp` execution runtime (no WASM sandbox, no MCP client), so "install" for
-    every kind except `skill` is download-and-unpack only — the package sits on-device for the
-    user's own use elsewhere, the same as `apt download` versus `apt install`. This is a permanent,
-    accepted scope boundary, not a gap to close: building a sandboxed code/WASM runtime or an MCP
-    client into this app is a different, much larger project than a package browser. Per-file
-    integrity against `manifest.files`' digests is also not implemented — only the manifest
-    signature itself.
+*   `AzpInstaller` computes SHA-256 while extracting and rejects a package when a payload is
+    unlisted or differs from `manifest.files`; path containment and signature checks still apply.
+    For `kind:"script"`, `ScriptInstaller` resolves declared `apt` dependencies through the Termux
+    prefix and writes an executable wrapper into `prefix/bin`, pointing at the verified entry file.
+    HG2Gui still has no general WASM runtime or MCP client: kinds other than `skill` and `script`
+    remain download-and-unpack data. That boundary avoids pretending arbitrary packages are safe or
+    executable merely because they arrived in a ZIP.
 
 ### 10. Ground rotation (Kotlin, `commonMain`)
 *   **`ui/menu/PillMenu.kt`**: `Azphalt.currentGround` is a process-wide `mutableStateOf(Ground)`

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -50,7 +50,7 @@ The keyboard is not forced open. Tap the command line to type; suggestions still
 go, so you can type `git` and tap `commit` rather than spelling it out.
 
 ## Basic Commands
-The ten built-in commands are `wifi`, `bluetooth`, `airplane`, `flash`, `volume`, `brightness`,
+The eleven built-in commands are `wifi`, `bluetooth`, `airplane`, `flash`, `volume`, `brightness`,
 `call`, `contacts`, `vfs`, `calc` and `edit` — see [Commands](COMMANDS.md) for what each does.
 Everything else — `apps`, `alias`, `clear`, listing packages, and so on — is a real shell
 binary now, run in the Termux environment below, not a reimplementation of one.
@@ -141,11 +141,13 @@ binary now, run in the Termux environment below, not a reimplementation of one.
 -   **Store:** the **Store** pill opens a browser for [azphalt.store](https://azphalt.store), the
     package registry for `.azp` extensions — the same idea as `pkg`/`apt`, but general-purpose:
     assets, sandboxed code, packs, companion apps, MCP-server headers, and AI-skill bundles all
-    ship as `.azp` packages. Search, filter by kind (skill / mcp / code / pack / asset / app), and
-    tap **INSTALL** to download and unpack one. HG2Gui has no `.azp` execution sandbox, so most
-    kinds are download-only, kept on-device for use elsewhere — the one exception is a **skill**
-    package: its bundled `SKILL.md` is folded into the AI chat's system prompt automatically, so
-    an installed skill actually changes how the AI pill answers. Every install checks the
+    ship as `.azp` packages. Search, filter by kind (skill / mcp / code / pack / asset / app /
+    script), and
+    tap **INSTALL** to download and unpack one. Most kinds are download-only, kept on-device for
+    use elsewhere. A **skill** package folds its bundled `SKILL.md` into the AI chat's system
+    prompt. A **script** package can resolve declared Termux dependencies and install an executable
+    wrapper for its digest-verified entry file. Every install rejects unlisted payloads and requires
+    each extracted payload to match its declared SHA-256 digest before it checks the
     package's Ed25519 signature (on Android 13+; older devices can't check it and the package is
     marked unverified rather than silently trusted) against azphalt.store's own published signing
     keys — an installed row shows **✓ TRUSTED SIGNER** when the signer is one the registry itself


### PR DESCRIPTION
### Motivation

- Make the fact that `edit` is a first-class built-in explicit across the codebase and documentation by updating counts and descriptions from ten to eleven built-ins. 
- Bring project metadata and developer-facing docs up to date with recent module additions and platform/tooling bumps. 
- Clarify user-facing behaviour for the graphical file picker and file manager and tighten package-install verification semantics for `.azp` packages.

### Description

- Update `Builtins.kt` commentary and the public `NAMES` description to reflect eleven built-ins (including `edit`).
- Revise `README.md` to add `:terminal-emulator` and `:termux-shared` modules, clarify the file picker wording, expand the file manager feature list, and bump toolchain versions to Gradle `9.7.0`, AGP `9.3.1`, Kotlin `2.4.10`, and Compose MPP `1.11.1`.
- Update architecture and user documentation (`docs/ARCHITECTURE.md`, `docs/HG2GUI_ARCHITECTURE.md`, `docs/COMMANDS.md`, `docs/USER_GUIDE.md`, `docs/CONTRIBUTING.md`) to: call out eleven built-ins, describe the `edit` editor screen, document the `terminal-emulator` and shared module, add `script`-package handling for `.azp` and per-payload SHA-256 verification, and tighten various UX wording around file picking and VFS behaviour.
- Minor phrasing and formatting tweaks across docs to keep counts, categories and examples consistent with the code and product decisions.

### Testing

- Built the Android app with `./gradlew assembleDebug` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7ec1be8fa8832fabf4838b57bbc5af)

## Summary by Sourcery

Clarify and document the `edit` command as a first-class built-in and align architecture, user docs, and tooling metadata with the current app behaviour and module layout.

New Features:
- Document the terminal-emulator and termux-shared Gradle modules as part of the project structure and architecture.
- Describe product subsystems such as MCP, workflows and AI, Azphalt store, and Context/Guide, along with core invariants and design decisions.

Enhancements:
- Update references to built-ins across architecture and user documentation to reflect eleven commands including `edit`.
- Expand documentation of the file manager and file picker to better describe their capabilities and UX behaviour.
- Detail VFS behaviour, including path containment and the explicit `vfs mount` escape hatch, in architecture docs.
- Clarify azphalt.store package semantics, including script-package handling and per-payload SHA-256 verification in docs.
- Refine descriptions of CommandTree scrolling, dwell behaviour, and menu grouping for better architectural clarity.

Build:
- Refresh documented toolchain versions to Gradle 9.7.0, AGP 9.3.1, Kotlin 2.4.10, and Compose Multiplatform 1.11.1.

Documentation:
- Add current app version metadata to architecture docs.
- Align README and docs with the new module layout, terminal-emulator usage, and shared Termux utilities.
- Tighten wording and formatting across multiple documents to keep counts, categories, and examples consistent with code and product decisions.