### PR TITLE
Drop Olive from the ground rotation - too close to Mustard's yellow

### DIFF
--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -222,7 +222,8 @@ reflection-based command engine underneath it — eleven built-ins are a fixed d
     (not `remember`-scoped) so every screen agrees on the same background, including
     `EditorScreen` - which runs in its own Activity (`EditorActivity`) with its own composition,
     so a per-composition roll would let it disagree with the rest of the app. `Azphalt.grounds`
-    (Mustard weighted heavily as the primary, six others sharing the rest) and
+    (Mustard weighted heavily as the primary, five others sharing the rest - a sixth, Olive, was
+    dropped for reading too close to Mustard's own yellow) and
     `Azphalt.randomGround(exclude)` (weighted pick) predate this; `currentGround` just makes one
     of those picks the shared, observable one.
 *   `Azphalt.rerollGround()` swaps to a new weighted pick (never repeating the current one),

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -90,18 +90,20 @@ object Azphalt {
      *  heavier since it's the primary. */
     data class Ground(val name: String, val page: Color, val foldLight: Color, val foldDark: Color, val weight: Int = 1)
 
-    // Mustard's fold-light/fold-dark are the style guide's own literal tokens. The other six
+    // Mustard's fold-light/fold-dark are the style guide's own literal tokens. The other five
     // grounds are given as a single reference swatch each (no separate fold tokens in the
     // source) - foldLight/foldDark are derived from that one swatch with a fixed lighten/darken
     // step, matching Mustard's own light/dark offset, until real per-ground tokens exist.
+    // "Olive" (a dark yellow-green, #8F8A2E) used to be here too - close enough to Mustard's own
+    // yellow in hue that rolling it read as "the yellow background is gone" rather than as a
+    // deliberately different ground, so it's been dropped from the rotation entirely.
     val grounds: List<Ground> = listOf(
         Ground("Mustard", Color(0xFFE8C81E), Color(0xFFF2D82C), Color(0xFFD9B615), weight = 6),
         Ground("Maroon", Color(0xFF8F1F34), Color(0xFFA22940), Color(0xFF7A1A2C)),
         Ground("Navy", Color(0xFF163A63), Color(0xFF204B7C), Color(0xFF0F2C4C)),
         Ground("Cerulean", Color(0xFF2D6EA8), Color(0xFF3C82C2), Color(0xFF215A8C)),
         Ground("Teal", Color(0xFF1D6B62), Color(0xFF267F74), Color(0xFF14554E)),
-        Ground("Pink", Color(0xFFD4728F), Color(0xFFDD879F), Color(0xFFC15D7A)),
-        Ground("Olive", Color(0xFF8F8A2E), Color(0xFFA29C36), Color(0xFF747024))
+        Ground("Pink", Color(0xFFD4728F), Color(0xFFDD879F), Color(0xFFC15D7A))
     )
 
     /** Picks a ground, weighted per [Ground.weight], optionally never returning [exclude] - used

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 versionMajor=0
 versionMinor=6
-versionPatch=60
-versionBuild=221
+versionPatch=61
+versionBuild=222


### PR DESCRIPTION
## Summary
- `Azphalt.grounds` randomly rotates the app's background across several colors each session, weighted heavily toward the yellow "Mustard" ground.
- "Olive" (`#8F8A2E`, a dark yellow-green) was close enough in hue to Mustard's own yellow that landing on it read as "the yellow background disappeared" rather than as a deliberately different ground.
- Removed Olive from the rotation entirely and updated `docs/HG2GUI_ARCHITECTURE.md`'s ground count to match.

## Test plan
- [x] `:shared:compileAndroidMain` / `:shared:compileKotlinMetadata` compile clean
- [ ] Manual: confirm the background never rotates to anything but Mustard/Maroon/Navy/Cerulean/Teal/Pink (no device available in this environment)

---
_Generated by [Claude Code](https://claude.ai/code/session_016zMr3PrpxtiDrrZJo9MM9z)_

## Summary by Sourcery

Remove the Olive background from Azphalt's ground rotation for clearer distinction from the primary Mustard background.

Enhancements:
- Simplify Azphalt ground configuration to use Mustard plus five distinct secondary backgrounds.

Build:
- Increment application patch and build versions for the ground rotation change.

Documentation:
- Update architecture documentation to reflect the reduced set of Azphalt grounds and explain the removal of Olive.