### PR TITLE
Stop the row-0 pill priming itself on first render

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -58,7 +58,9 @@ the same tick lands it on one and a gentle release snaps almost immediately
 goes ink, the same "primed" look a pill gets from anywhere else in the menu, whenever a pill
 scrolls to rest there: a purely cosmetic marker of what's nearest the front of the stack. It
 never fires anything by itself - every pill is tappable wherever it sits in the band, and
-scrolling one to row 0 doesn't substitute for that tap.
+scrolling one to row 0 doesn't substitute for that tap. This only ever kicks in after an actual
+drag or fling - whichever pill happens to start out at row 0 before any input never goes ink on
+its own, so nothing reads as pre-selected the instant a stack first appears.
 
 Scrolling isn't bounded to the stack's own content either: a drag or a fling can carry the stack
 past its first or last row, leaving blank space above the top or below the bottom. Nothing

--- a/docs/HG2GUI_ARCHITECTURE.md
+++ b/docs/HG2GUI_ARCHITECTURE.md
@@ -96,7 +96,9 @@ reflection-based command engine underneath it — eleven built-ins are a fixed d
     would size the scroll region to each pill's own viewport-sized Box, not to the stack's real
     extent). Used for both the root stack and any `ChildBand`. Whichever pill scrolls to rest at
     row 0 goes ink ("primed") purely as a cosmetic marker - selecting a pill always requires an
-    explicit tap, never a scroll-and-wait.
+    explicit tap, never a scroll-and-wait. That marker only ever applies once the user has
+    actually dragged or flung the stack at least once; before any input, nothing is primed, even
+    if a pill happens to start out sitting at row 0.
 *   `FileBrowser` (also `androidMain`) supplies the file-argument case: a `file…` node (attached
     to `edit` and to every discovered shell binary) whose `wizardId` opens the graphical Select
     File/Folder picker instead of drilling further into the pill stack - see section 13 below.

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -227,7 +227,10 @@ private const val BAND_BASE_ROW = 1
 // one is open. [StackScroll.alignedRow] names whichever row currently sits at that fixed spot,
 // which reads as "primed" (ink) purely as a cosmetic marker of what's nearest the front of the
 // stack - it never fires anything by itself. Every pill is tappable wherever it sits in the
-// band; scrolling never substitutes for the tap.
+// band; scrolling never substitutes for the tap. -1 (never a real row) until the user has
+// actually dragged or flung the stack at least once - without that guard, whichever pill starts
+// out sitting at row 0 (the stack's own resting position, before any input) rendered ink from
+// the very first frame, reading as something already auto-selected.
 private class StackScroll(val modifier: Modifier, val offsetPx: Float, val alignedRow: Int)
 
 @Composable
@@ -235,11 +238,13 @@ private fun rememberStackScroll(): StackScroll {
     val density = LocalDensity.current
     val pitchPx = with(density) { ROW_PITCH.toPx() }
     var offsetPx by remember { mutableStateOf(0f) }
+    var hasScrolled by remember { mutableStateOf(false) }
     // Unbounded on both ends - dragging or flinging past either end of the stack's own content
     // reveals blank space above the top row or below the bottom one, rather than stopping dead
     // at the content edge. Nothing auto-corrects it back: it stays wherever the gesture leaves
     // it, the same "no bounce, no self-correcting" house rule the settle already follows.
     val scrollState = rememberScrollableState { delta ->
+        hasScrolled = true
         offsetPx += delta
         delta
     }
@@ -249,7 +254,7 @@ private fun rememberStackScroll(): StackScroll {
         state = scrollState,
         flingBehavior = flingBehavior
     )
-    val alignedRow = if (pitchPx > 0f) (offsetPx / pitchPx).roundToInt() else 0
+    val alignedRow = if (hasScrolled && pitchPx > 0f) (offsetPx / pitchPx).roundToInt() else -1
     return StackScroll(modifier, offsetPx, alignedRow)
 }
 

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 versionMajor=0
 versionMinor=6
-versionPatch=79
-versionBuild=240
+versionPatch=80
+versionBuild=241


### PR DESCRIPTION
## Summary

- On opening the app, whichever pill naturally sits at row 0 of a freshly-rendered stack (the last root in the command tree — e.g. the `Context` category) rendered with the "primed"/ink styling before any user interaction, because `rememberStackScroll`'s `alignedRow` was computed as `round(offsetPx / pitch)`, which is `0` right from the first frame (offset starts at `0`). That row-0 styling is the exact same "already picked" visual language used elsewhere in the menu, so it read as an unwanted auto-selection even though nothing had actually been tapped or fired.
- `alignedRow` now stays `-1` (never a real row) until the user has genuinely dragged or flung the stack at least once, so no pill looks primed until they've actually scrolled.
- Updated `docs/DESIGN.md` and `docs/HG2GUI_ARCHITECTURE.md` to document that the "primed" marker only ever kicks in after real scroll input.

This is a follow-up to a prior fix (`5e9dbc4`) that removed the scroll-and-dwell auto-select mechanic entirely; this closes the one remaining cosmetic vestige of it (a pill rendering as "primed" with zero input).

## Test plan

- [x] `./gradlew :shared:compileKotlinMetadata` — compiles clean
- [x] `./gradlew :shared:compileAndroidMain` — compiles clean
- [x] `./gradlew :shared:testAndroidHostTest` — existing tests pass
- [ ] Manual check on-device: open the app fresh and confirm no pill in the root stack shows the ink "primed" styling until the stack is actually scrolled


---
_Generated by [Claude Code](https://claude.ai/code/session_017bPj23QxAhJrA6sDdRRycX)_

## Summary by Sourcery

Prevent pills from appearing primed on initial render by deferring row alignment until after user scroll input and document the behavior change.

Bug Fixes:
- Ensure the pill at row 0 no longer shows primed styling on first render before any user interaction.

Enhancements:
- Introduce a scroll-state guard so alignedRow only becomes a real row after the stack has been dragged or flung at least once.

Documentation:
- Clarify in design and architecture docs that the primed/ink marker is applied only after actual scroll gestures and never on initial appearance.

Chores:
- Bump patch and build versions to reflect the change.