### PR TITLE
Fix release automation: artifact path pointed at a flavor that no longer exists

### DIFF
--- a/.github/workflows/merged-build.yml
+++ b/.github/workflows/merged-build.yml
@@ -21,7 +21,7 @@ jobs:
     with:
       gradle_task: assembleDebug
       artifact_name: android-debug-apk
-      artifact_path_pattern: "composeApp/build/outputs/apk/fdroid/*.apk"
+      artifact_path_pattern: "composeApp/build/outputs/apk/playstore/debug/*.apk"
       release_tag_prefix: "latest-debug"
       publish_to_release: true
       signing_enabled: true

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 versionMajor=0
 versionMinor=6
-versionPatch=81
-versionBuild=242
+versionPatch=82
+versionBuild=243


### PR DESCRIPTION
## Summary

- The `android-debug` job's `artifact_path_pattern` in `merged-build.yml` was `composeApp/build/outputs/apk/fdroid/*.apk`, but `composeApp/build.gradle.kts` only declares a single `playstore` product flavor — there's no `fdroid` flavor anymore, so Android Gradle Plugin never writes anything to that path.
- Because the glob matches nothing, the `for FILE in <pattern>; do [ -f "$FILE" ] && gh release upload ...; done` loop in the "Publish Release" step iterates once over the literal, unexpanded pattern string, and the failing `[ -f ]` test's exit status becomes the whole step's exit status (it's the last command the script runs) — failing the job on every push to `master` with no visible error, and leaving the `latest-debug-v0.6` prerelease with no APK attached.
- Fixed the pattern to `composeApp/build/outputs/apk/playstore/debug/*.apk`, matching what AGP actually produces for the `playstore` flavor's debug build type.

Root-caused from the CI log of the run triggered by merging #136 — `actions/upload-artifact` logged `No files were found with the provided path: composeApp/build/outputs/apk/fdroid/*.apk`, and the release step then failed with a bare `Process completed with exit code 1` and no other output, which traces back to the same stale path. This has been failing on every push to `master` for some time (checked several prior runs, all the same failure).

## Test plan

- [x] `./gradlew :composeApp:assembleDebug` locally — produces `composeApp/build/outputs/apk/playstore/debug/composeApp-playstore-debug.apk`, confirming the corrected pattern matches the real output path
- [x] Reproduced the exact silent-exit-1 mechanism locally with a minimal bash script mirroring the loop shape
- [ ] Confirm on the next push to `master`: the "Publish Release" step succeeds and the `latest-debug-v0.6` release gets an APK asset


---
_Generated by [Claude Code](https://claude.ai/code/session_017bPj23QxAhJrA6sDdRRycX)_

## Summary by Sourcery

Fix Android debug release automation to upload the correct Play Store debug APK and bump the app version.

Build:
- Update merged-build GitHub Actions workflow to collect the Play Store debug APK instead of a removed fdroid flavor path.

CI:
- Correct the android-debug job artifact path pattern so the Publish Release step finds and uploads the generated APK instead of failing silently.

Chores:
- Increment patch and build numbers in version.properties.