### PR TITLE
Wire up automatic Play publishing on push to master

### DIFF
--- a/.github/workflows/release-play.yml
+++ b/.github/workflows/release-play.yml
@@ -25,7 +25,16 @@ name: Release to Play
 #   KEYSTORE_PRIVATE / KEYSTORE_RSA / KEYSTORE_PUBLIC / KEYSTORE_CHAIN
 
 on:
+  # A push to master is treated as publish=true (internal track rolled out,
+  # alpha staged as a draft) - the same defaults workflow_dispatch itself
+  # uses. The `inputs` context GitHub Actions gives every other job below
+  # only exists for workflow_dispatch/workflow_call, so a plain push event
+  # never sees `inputs.publish` at all; env.DO_PUBLISH (and friends, below)
+  # is what actually makes a push behave like inputs.publish=true instead of
+  # every publish step silently reporting "skipped" while the job as a whole
+  # still reports success.
   push:
+    branches: [master, main]
     paths-ignore:
       - 'version.properties'
   # Called by the workflows that publish a GitHub release, so a Play publish
@@ -77,12 +86,22 @@ on:
 
 jobs:
   build-publish:
-    name: Build signed AAB${{ inputs.publish && ' + publish' || '' }}
+    name: Build signed AAB${{ (inputs.publish || github.event_name == 'push') && ' + publish' || '' }}
     runs-on: ubuntu-latest
     # contents: write so "Increment and push versionBuild" can commit and push the bumped
     # version.properties. Everything else here only talks to Google.
     permissions:
       contents: write
+    # The effective inputs for this run. workflow_dispatch/workflow_call already populate
+    # `inputs.*`, in which case these are just that value again; a plain push event never
+    # populates `inputs.*` at all, so every fallback here is that same trigger's own default
+    # (matching workflow_dispatch's `default:` above) rather than an empty string.
+    env:
+      DO_PUBLISH: ${{ inputs.publish || github.event_name == 'push' }}
+      COMPLETED_TRACK: ${{ inputs.completed_track || 'internal' }}
+      DRAFT_TRACKS: ${{ inputs.draft_tracks || 'alpha' }}
+      RELEASE_NOTES: ${{ inputs.release_notes || '' }}
+      VERSION_CODE_MODE: ${{ inputs.version_code_mode || 'auto' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7
@@ -133,7 +152,7 @@ jobs:
       # own actions.
       - name: Mint a Play API token (preflight)
         id: preflight-token
-        if: ${{ inputs.publish }}
+        if: ${{ env.DO_PUBLISH == 'true' }}
         uses: ./.github/actions/play-api-token
         with:
           service-account-json: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
@@ -148,7 +167,7 @@ jobs:
       # It also reads back the highest versionCode Play holds, which is the
       # number the next step needs.
       - name: Preflight Google Play API access
-        if: ${{ inputs.publish }}
+        if: ${{ env.DO_PUBLISH == 'true' }}
         run: |
           set -euo pipefail
           token=$(cat "${{ steps.preflight-token.outputs.token-file }}")
@@ -195,9 +214,9 @@ jobs:
       # This step's only job is invoking it with what only CI knows (Play's current
       # max) before bundleRelease ever runs.
       - name: Increment and push version
-        if: ${{ inputs.publish }}
+        if: ${{ env.DO_PUBLISH == 'true' }}
         run: |
-          if [ "${{ inputs.version_code_mode }}" = "strict" ]; then
+          if [ "${{ env.VERSION_CODE_MODE }}" = "strict" ]; then
             ./gradlew -q incrementAndPushVersion -PversionCodeMode=strict
           else
             ./gradlew -q incrementAndPushVersion -PversionCodeMode=auto -PplayMaxVersionCode="${PLAY_MAX_VERSION_CODE:-0}"
@@ -233,7 +252,7 @@ jobs:
       # actually built. Belt and braces, because the cost of getting it wrong is
       # a rejected rollout and a burned versionCode.
       - name: Confirm the built versionCode clears Play
-        if: ${{ inputs.publish }}
+        if: ${{ env.DO_PUBLISH == 'true' }}
         run: |
           set -euo pipefail
           play_max=${PLAY_MAX_VERSION_CODE:-0}
@@ -256,27 +275,27 @@ jobs:
       # and the build sits in between.
       - name: Mint a Play API token (publish)
         id: publish-token
-        if: ${{ inputs.publish }}
+        if: ${{ env.DO_PUBLISH == 'true' }}
         uses: ./.github/actions/play-api-token
         with:
           service-account-json: ${{ secrets.PLAY_SERVICE_ACCOUNT_JSON }}
 
       - name: Publish to Google Play
         id: play
-        if: ${{ inputs.publish }}
+        if: ${{ env.DO_PUBLISH == 'true' }}
         uses: ./.github/actions/play-publish
         with:
           package-name: ${{ env.APP_ID }}
           aab: ${{ env.AAB_PATH }}
           token-file: ${{ steps.publish-token.outputs.token-file }}
           expected-version-code: ${{ env.VERSION_CODE }}
-          completed-track: ${{ inputs.completed_track }}
-          draft-tracks: ${{ inputs.draft_tracks }}
+          completed-track: ${{ env.COMPLETED_TRACK }}
+          draft-tracks: ${{ env.DRAFT_TRACKS }}
           release-name: ${{ env.VERSION_NAME }}
-          release-notes: ${{ inputs.release_notes }}
+          release-notes: ${{ env.RELEASE_NOTES }}
 
       - name: Say what landed where
-        if: ${{ inputs.publish }}
+        if: ${{ env.DO_PUBLISH == 'true' }}
         run: |
           echo "versionCode ${{ steps.play.outputs.version-code }} is live on the ${{ steps.play.outputs.rolled-out }} track."
           drafted="${{ steps.play.outputs.drafted }}"

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 versionMajor=0
 versionMinor=6
-versionPatch=83
-versionBuild=244
+versionPatch=84
+versionBuild=245


### PR DESCRIPTION
## Summary

Diagnosed why `release-play.yml` never actually publishes to Google Play despite running "successfully" on every push.

**Root cause:** every real publish step (`Mint a Play API token`, `Preflight Google Play API access`, `Increment and push version`, `Confirm the built versionCode clears Play`, `Publish to Google Play`, `Say what landed where`) is gated with `if: ${{ inputs.publish }}`. But the workflow's automatic trigger is a plain `on: push` with no `branches:` filter — and GitHub Actions only populates the `inputs` context for `workflow_dispatch` and `workflow_call` events, never for `push`. So on every push, to every branch, `inputs.publish` was always `null`/falsy, every publish-gated step reported `"skipped"`, and the job as a whole still reported **success** — indistinguishable from a healthy publish in the Actions UI. Confirmed directly on run `31930821342` (the merge of #137 to master): all six publish steps skipped, job green.

The file's own header comment says it's meant to be `workflow_call`'d automatically after a GitHub release goes out — that hookup was never actually built anywhere in `.github/workflows/`. The *only* way this has ever actually published to Play is a manual `workflow_dispatch` run with `publish` explicitly checked.

**Fix (per your choice of "push to master triggers it directly"):**
- `on.push` now has `branches: [master, main]` (previously *every* branch push triggered a full signed-AAB build, uploaded as an artifact nobody asked for — that also stops now).
- Added a job-level `env` block (`DO_PUBLISH`, `COMPLETED_TRACK`, `DRAFT_TRACKS`, `RELEASE_NOTES`, `VERSION_CODE_MODE`) that falls back to each input's already-documented default whenever `inputs.*` isn't populated. Every `if: inputs.publish` and every direct `inputs.*` reference now reads the resolved `env.*` value instead.

**Net effect:** a push to master will now actually roll out to the **internal** track and stage an **alpha** draft — the same thing picking those defaults by hand in `workflow_dispatch` always did. Nothing reaches production/open testing without a human promoting a draft in the Play Console. This does mean the very next push to master (e.g. merging this PR) will attempt a real publish, assuming `PLAY_SERVICE_ACCOUNT_JSON` and the keystore secrets are configured — worth watching that first run.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-play.yml'))"` — YAML parses cleanly
- [x] Manually traced every `if:`/`inputs.*` site to confirm each now resolves through `env.*` with the documented default
- [ ] Watch the first push-triggered run after merge: publish steps should show real conclusions (not `skipped`), and Play Console should show a new internal-track release + alpha draft


---
_Generated by [Claude Code](https://claude.ai/code/session_017bPj23QxAhJrA6sDdRRycX)_

## Summary by Sourcery

Wire automatic Google Play publishing to run on pushes to the main branches and ensure publish-gated steps execute correctly for non-dispatch triggers.

New Features:
- Treat pushes to master and main as publish runs that roll out to the internal track and stage an alpha draft by default.

Bug Fixes:
- Fix release workflow steps being skipped on push events due to missing inputs context by routing publish conditions through environment-backed defaults.

Enhancements:
- Introduce job-level environment defaults for Play release workflow inputs so both push and manual triggers share consistent behaviour and defaults.

Build:
- Restrict the Play release workflow push trigger to master and main branches to avoid unnecessary signed build generation on other branches.

Chores:
- Bump version.properties patch and build numbers for the new Play release.