### PR TITLE
Fix release-play.yml crashing on "VERSION_CODE: unbound variable"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,15 @@ tasks.register("printVersionEnv") {
             val patch = (props.getProperty("versionPatch")?.toInt() ?: 0) + 1
             val build = (props.getProperty("versionBuild")?.toInt() ?: 0) + 1
             val versionName = "$major.$minor.$patch.$build"
+            // Mirrors composeApp/build.gradle.kts's own `resolvedVersionCode` exactly (same
+            // `legacyVersionCode = 205` floor, same +1) - this is a separate Gradle script with
+            // no shared code between the two, so nothing enforces they stay in lockstep short of
+            // this comment. release-play.yml's "Confirm the built versionCode clears Play" step
+            // (and the Play API upload's expected-version-code) both read this VERSION_CODE - a
+            // build actually invokes `bundleRelease` with no `-PversionBuild` override, so it too
+            // resolves versionCode from version.properties, not this script's own $build.
+            val legacyVersionCode = 205
+            val versionCode = maxOf(build, legacyVersionCode + 1)
 
             val githubEnv = System.getenv("GITHUB_ENV")
             if (githubEnv != null) {
@@ -57,6 +66,7 @@ tasks.register("printVersionEnv") {
                     VERSION_PATCH=$patch
                     VERSION_BUILD=$build
                     VERSION_NAME=$versionName
+                    VERSION_CODE=$versionCode
                     """.trimIndent() + "\n"
                 )
             }
@@ -65,6 +75,7 @@ tasks.register("printVersionEnv") {
             println("VERSION_PATCH=$patch")
             println("VERSION_BUILD=$build")
             println("VERSION_NAME=$versionName")
+            println("VERSION_CODE=$versionCode")
         }
     }
 }

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 versionMajor=0
 versionMinor=6
-versionPatch=85
-versionBuild=246
+versionPatch=86
+versionBuild=247


### PR DESCRIPTION
## Summary

Follow-up to #138. Once a push to master actually attempted a Play publish for the first time, it hit a second, previously-unexercised bug: **run [31932424250](https://github.com/HereLiesAz/HG2Gui/actions/runs/31932424250)** (the merge of #138) got through Play API preflight fine (`PLAY_MAX_VERSION_CODE: 244` read back correctly), built and signed the bundle fine, and then died at "Confirm the built versionCode clears Play" with:

```
line 3: VERSION_CODE: unbound variable
```

Not an actual "your versionCode is too low" rejection — that step's script (`set -euo pipefail`) reads `$VERSION_CODE`, but nothing had ever set it. `printVersionEnv` (invoked by the "Get app version" step, which populates `$GITHUB_ENV` for everything after it) only ever emitted `VERSION_MAJOR/MINOR/PATCH/BUILD/NAME` — never `VERSION_CODE`. That variable is also what `release-play.yml`'s `Publish to Google Play` step passes as `expected-version-code`. This line has existed since the workflow was written, but every publish-gated step was silently `skipped` before #138, so nothing had ever actually executed it.

**Fix:** `printVersionEnv` now computes and emits `VERSION_CODE`, using the exact same formula `composeApp/build.gradle.kts`'s own `resolvedVersionCode` already uses: `max(build, legacyVersionCode + 1)` with the same `legacyVersionCode = 205` floor. That's the versionCode a real `bundleRelease` invocation resolves to, since `release-play.yml`'s build step doesn't pass a `-PversionBuild` override — it reads `version.properties` directly, same as `printVersionEnv` does.

## Test plan

- [x] `./gradlew -q printVersionEnv` locally now prints `VERSION_CODE=247` against the current `version.properties` (`versionBuild=246`) — matches what `composeApp/build.gradle.kts`'s formula resolves to for the same file
- [ ] Watch the next push-triggered `release-play.yml` run: "Confirm the built versionCode clears Play" should pass, and `Publish to Google Play` should actually run


---
_Generated by [Claude Code](https://claude.ai/code/session_017bPj23QxAhJrA6sDdRRycX)_

## Summary by Sourcery

Compute and expose VERSION_CODE from version.properties in the printVersionEnv Gradle task to unblock the Play release workflow.

Enhancements:
- Extend printVersionEnv to derive VERSION_CODE from versionBuild with the same legacy floor logic used in composeApp's resolvedVersionCode.

Build:
- Update version.properties to bump patch and build numbers for the next release.