### PR TITLE
Fix a hidden double version-bump that broke the Play upload's versionCode

### DIFF
--- a/.github/workflows/release-play.yml
+++ b/.github/workflows/release-play.yml
@@ -230,7 +230,15 @@ jobs:
           KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
           KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
           REQUIRE_SIGNING: 'true'
-        run: ./gradlew bundleRelease
+        # -PskipAutoIncrementVersion: version.properties was already finalized by "Increment
+        # and push version" above - without this, the root build.gradle.kts's blanket
+        # auto-bump-on-any-compile/assemble/bundle/kapt-task convenience (meant for local/
+        # debug builds that never call incrementAndPushVersion themselves) silently bumps it
+        # *again* during this task's own execution, and the next Gradle invocation in this job
+        # (`printVersionEnv`, for the versionCode-clears-Play check and the Play upload's
+        # expected-version-code) then reads that further-incremented file and disagrees with
+        # what actually got signed into the .aab.
+        run: ./gradlew bundleRelease -PskipAutoIncrementVersion=true
 
       - name: Verify the bundle is signed by the expected key
         run: |

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -135,10 +135,30 @@ tasks.register("incrementAndPushVersion") {
     }
 }
 
+// release-play.yml sets this before invoking bundleRelease: that workflow has already called
+// incrementAndPushVersion explicitly and reconciled the result against Play's own highest
+// versionCode, so version.properties is deliberately final by the time bundleRelease's
+// configuration phase reads it. Without this switch, autoIncrementVersion still ran as a hidden
+// dependency of whatever compile/assemble/bundle/kapt task happened to be in that build's task
+// graph - not just composeApp's own bundleRelease/bundlePlaystoreRelease, but any library
+// subproject's plain compile task too (e.g. :shared:compileAndroidMain), none of which are named
+// distinctly enough to exclude by a name pattern - and rewrote version.properties *again* (its
+// own execution phase, right after bundleRelease's configuration phase had already captured
+// versionCode from the file). That was invisible to the build itself, but it meant the *next*
+// Gradle invocation in the same job (`printVersionEnv`, for "Confirm the built versionCode clears
+// Play" / the Play upload's expected-version-code) read that further-incremented file and
+// reported a version one higher than what was actually signed into the .aab - confirmed on run
+// 31933127627: expected 250, Play reported the upload as 249. Debug-build-type tasks
+// (assembleDebug, the only other consumer of this project's Gradle tasks) still get the
+// auto-bump: that pipeline's own versioning is provided by an explicit -PversionBuild instead, so
+// nothing there depends on file-read timing the way release-play.yml's does.
+val skipAutoIncrement = providers.gradleProperty("skipAutoIncrementVersion").isPresent
+
 subprojects {
     tasks.configureEach {
         val taskName = name.lowercase()
-        if ((taskName.contains("compile") || taskName.contains("assemble") || taskName.contains("bundle") || taskName.contains("kapt"))
+        if (!skipAutoIncrement
+            && (taskName.contains("compile") || taskName.contains("assemble") || taskName.contains("bundle") || taskName.contains("kapt"))
             && name != "autoIncrementVersion"
             && name != "incrementAndPushVersion"
             && name != "printVersionEnv"

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 versionMajor=0
 versionMinor=6
-versionPatch=87
-versionBuild=248
+versionPatch=88
+versionBuild=249


### PR DESCRIPTION
## Summary

Second follow-up to #138 (first was #139). Run [31933127627](https://github.com/HereLiesAz/HG2Gui/actions/runs/31933127627) (the merge of #139) got all the way to actually calling the Play API for the first time ever — preflight, version-code check, and signed build all passed — and failed at the real `Publish to Google Play` call with:

```
Expected VERSION_CODE 250 but upload produced 249
```

**Root cause:** `release-play.yml`'s "Increment and push version" step deliberately finalizes `version.properties` before `bundleRelease` runs, so the rest of the job can treat it as stable. But root `build.gradle.kts` has a blanket `subprojects` hook that makes *every* `compile`/`assemble`/`bundle`/`kapt`-named task across *every* subproject silently `dependsOn(autoIncrementVersion)` — not just `composeApp`'s own `bundleRelease`/`bundlePlaystoreRelease`, but plain library-module compile tasks too (e.g. `:shared:compileAndroidMain`, part of `composeApp`'s own dependency graph). That's meant as a local/debug convenience so nobody has to remember to bump the version by hand — but its execution phase rewrites `version.properties` *again*, invisibly, right after `bundleRelease`'s configuration phase had already captured the (still-correct) versionCode used to actually sign the `.aab`. The *next* Gradle invocation in the same job (`printVersionEnv`, feeding both the "Confirm the built versionCode clears Play" check and the Play upload's own `expected-version-code`) then reads that further-incremented file and reports a version one higher than what was actually shipped.

I initially tried excluding `bundleRelease` by exact task name, then by `!taskName.contains("release")` — neither held up once I dry-ran the actual task graph, since the culprit turned out to be library-module tasks with no "release" in their name at all (see commit history on this branch).

**Fix:** `release-play.yml` now passes `-PskipAutoIncrementVersion=true` to the `bundleRelease` invocation, and the `subprojects` hook checks that property once and skips the `dependsOn(autoIncrementVersion)` wiring entirely for that build — regardless of which task in the graph would otherwise have triggered it. `assembleDebug` (the only other consumer of these Gradle tasks) is unaffected: that pipeline already gets its version number from an explicit `-PversionBuild` override, so it was never exposed to this file-read-timing issue.

## Test plan

- [x] `./gradlew :composeApp:bundleRelease -PskipAutoIncrementVersion=true --dry-run` — `autoIncrementVersion` is completely absent from the task graph (present without the flag, and still present for `assembleDebug` either way — confirmed all three)
- [x] Ran a real (unsigned-keystore-incomplete, but otherwise fully executed through Kotlin compilation) `bundleRelease -PskipAutoIncrementVersion=true` locally: `version.properties`'s checksum is identical before and after
- [ ] Watch the next push-triggered `release-play.yml` run: the Play upload's `expected-version-code` should match what Play reports back, and the release should actually roll out


---
_Generated by [Claude Code](https://claude.ai/code/session_017bPj23QxAhJrA6sDdRRycX)_

## Summary by Sourcery

Prevent release builds from double-incrementing the version code used for Play Store uploads.

Bug Fixes:
- Ensure the Play release workflow uses a stable version.properties during bundleRelease so expected versionCode matches the uploaded artifact.

Enhancements:
- Add a Gradle property to disable automatic version increments for specific builds while keeping the behavior for debug/local builds.

Build:
- Wire the new skipAutoIncrementVersion Gradle property into subproject task configuration to conditionally skip autoIncrementVersion.
- Update the release-play GitHub Actions workflow to pass -PskipAutoIncrementVersion=true when running bundleRelease.

Chores:
- Bump project versionPatch and versionBuild values in version.properties for the new release.