### PR TITLE
Drop the expected-vs-actual versionCode equality gate

### DIFF
--- a/.github/actions/play-publish/action.yml
+++ b/.github/actions/play-publish/action.yml
@@ -11,10 +11,6 @@ inputs:
   token-file:
     description: "Path to a file containing a short-lived Play API token (created by play-api-token action)"
     required: true
-  expected-version-code:
-    description: "The VERSION_CODE built by Gradle (for an additional sanity check)"
-    required: false
-    default: ''
   completed-track:
     description: "Track to roll out (completed)"
     required: true
@@ -56,7 +52,6 @@ runs:
         PACKAGE_NAME: ${{ inputs.package-name }}
         AAB: ${{ inputs.aab }}
         TOKEN_FILE: ${{ inputs.token-file }}
-        EXPECTED_VERSION_CODE: ${{ inputs.expected-version-code }}
         COMPLETED_TRACK: ${{ inputs.completed-track }}
         DRAFT_TRACKS: ${{ inputs.draft-tracks }}
         RELEASE_NAME: ${{ inputs.release-name }}
@@ -65,7 +60,7 @@ runs:
         set -euo pipefail
         out="$RUNNER_TEMP/play-publish-out.json"
         # Run the publisher script; it writes JSON to $out on success.
-        ./.github/actions/play-publish/publish.sh "$PACKAGE_NAME" "$AAB" "$TOKEN_FILE" "$EXPECTED_VERSION_CODE" "$COMPLETED_TRACK" "$DRAFT_TRACKS" "$RELEASE_NAME" "$RELEASE_NOTES" "$out"
+        ./.github/actions/play-publish/publish.sh "$PACKAGE_NAME" "$AAB" "$TOKEN_FILE" "$COMPLETED_TRACK" "$DRAFT_TRACKS" "$RELEASE_NAME" "$RELEASE_NOTES" "$out"
         jq -r '.versionCode // ""' "$out" | awk '{print "version-code="$0}' >> "$GITHUB_OUTPUT"
         jq -r '.rolledOut // ""' "$out" | awk '{print "rolled-out="$0}' >> "$GITHUB_OUTPUT"
         jq -r '.drafted // [] | join(" ")' "$out" | awk '{print "drafted="$0}' >> "$GITHUB_OUTPUT"

--- a/.github/actions/play-publish/publish.sh
+++ b/.github/actions/play-publish/publish.sh
@@ -4,12 +4,11 @@ set -euo pipefail
 package="$1"
 aab_glob="$2"
 token_file="$3"
-expected_vc="$4"
-completed_track="$5"
-draft_tracks="$6"
-release_name="$7"
-release_notes="$8"
-out_file="$9"
+completed_track="$4"
+draft_tracks="$5"
+release_name="$6"
+release_notes="$7"
+out_file="$8"
 
 # Resolve aab (glob)
 aab=""
@@ -95,12 +94,11 @@ if [ -z "$version_code" ]; then
   exit 1
 fi
 
-# Optional sanity check
-if [ -n "$expected_vc" ] && [ "$expected_vc" != "$version_code" ]; then
-  echo "::error::Expected VERSION_CODE $expected_vc but upload produced $version_code"
-  curl -sS -o /dev/null -X DELETE -H "Authorization: Bearer $token" "$api/edits/${edit_id}" || true
-  exit 1
-fi
+# Play only ever rejects a versionCode for being too low, never for differing from some other
+# script's own prediction of what it "should" be - that's already checked, against Play's real
+# highest versionCode, by release-play.yml's "Confirm the built versionCode clears Play" step
+# *before* this upload runs. $version_code here is Play's own read of what actually got uploaded,
+# and it's what every release/draft below is staged with - there's nothing to reconcile it against.
 
 # Build release JSON helper (status = completed/draft)
 make_release() {

--- a/.github/workflows/release-play.yml
+++ b/.github/workflows/release-play.yml
@@ -288,7 +288,6 @@ jobs:
           package-name: ${{ env.APP_ID }}
           aab: ${{ env.AAB_PATH }}
           token-file: ${{ steps.publish-token.outputs.token-file }}
-          expected-version-code: ${{ env.VERSION_CODE }}
           completed-track: ${{ env.COMPLETED_TRACK }}
           draft-tracks: ${{ env.DRAFT_TRACKS }}
           release-name: ${{ env.VERSION_NAME }}

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 versionMajor=0
 versionMinor=6
-versionPatch=87
-versionBuild=248
+versionPatch=88
+versionBuild=249

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 versionMajor=0
 versionMinor=6
-versionPatch=89
-versionBuild=250
+versionPatch=90
+versionBuild=251


### PR DESCRIPTION
## Summary

You're right that this was an unnecessary logic gate. Play's actual constraint on `versionCode` is "not lower than what's already published" — it doesn't care whether the uploaded value matches some other script's independent prediction of what it "should" be. That real constraint is already enforced, against Play's own highest `versionCode`, by `release-play.yml`'s "Confirm the built versionCode clears Play" step — *before* the upload even runs.

`play-publish/publish.sh` had a second, separate check (its own "Optional sanity check") that compared the upload's actual reported `versionCode` against an `expected-version-code` computed independently in the workflow, and hard-failed on any mismatch. That's what turned #140's double-increment bug into a failed run rather than a merely-inconsistent one — useful for catching that particular bug in the moment, but not something Play itself has ever required, and just an extra way for two independently-computed numbers to needlessly diverge in the future. `$version_code` (Play's own read of what was actually uploaded) was already the only number used for every release/draft staged afterward, so removing the check doesn't change what gets published — only removes the failure mode.

Removed the now-unused `expected-version-code` input end to end:
- `publish.sh`'s positional args (renumbered)
- `play-publish/action.yml`'s input declaration, env passthrough, and script invocation
- `release-play.yml`'s `expected-version-code:` line

`VERSION_CODE` itself is untouched — it still feeds the pre-upload "too low" check, which is the one that actually matters.

## Test plan

- [x] `bash -n .github/actions/play-publish/publish.sh` — syntax OK
- [x] `python3 -c "import yaml; ..."` — both YAML files parse cleanly
- [x] Manually traced the positional-argument renumbering against every call site
- [ ] Watch the next push-triggered `release-play.yml` run (after this and #140 both merge) to confirm the publish completes without this check in the way


---
_Generated by [Claude Code](https://claude.ai/code/session_017bPj23QxAhJrA6sDdRRycX)_

## Summary by Sourcery

Remove the redundant expected-vs-actual versionCode equality gate from the Play publish workflow and script so publishes rely solely on Play’s own versionCode constraints.

Build:
- Remove the expected-version-code input from the play-publish composite action and its environment wiring.
- Update the play-publish script invocation to reflect the simplified argument list without expected-version-code.

CI:
- Simplify the release-play workflow’s Play publish step by dropping the expected-version-code parameter, relying on the pre-upload versionCode check already present.