### PR TITLE
Fix incrementAndPushVersion's retry loop getting stuck after a concurrent push

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,8 +103,16 @@ tasks.register("incrementAndPushVersion") {
         for (attempt in 1..maxAttempts) {
             try {
                 git("fetch", "origin", branch, "--quiet")
-                // Synchronize version.properties with origin to handle concurrent builds
-                git("checkout", "origin/$branch", "--", "version.properties")
+                // Fully resync local HEAD to origin, not just this one file's working-tree
+                // content: a prior attempt in this same loop may have already run `git commit`
+                // before its `git push` got rejected, leaving a stale local commit that diverges
+                // from origin. `checkout origin/$branch -- version.properties` only overwrote the
+                // file, so HEAD stayed on that stale commit - the next attempt's recomputed bump
+                // then either fails to push (still diverged) or, if it happens to land on the same
+                // numbers the stale commit already has, `git commit` errors with "nothing to
+                // commit" since the working tree already matches HEAD. `reset --hard` discards
+                // that stale commit outright so every attempt starts from origin's real tip.
+                git("reset", "--hard", "origin/$branch")
                 
                 val props = Properties()
                 versionFile.inputStream().use { props.load(it) }

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 versionMajor=0
 versionMinor=6
-versionPatch=91
-versionBuild=252
+versionPatch=92
+versionBuild=253


### PR DESCRIPTION
## Summary

Diagnosed from the CI log you pasted: two workflow runs both tried to bump and push `version.properties` at nearly the same time. The first push attempt was correctly rejected as non-fast-forward — that's exactly the case the retry loop exists to handle — but every subsequent attempt then failed too: first with the same non-fast-forward rejection, then with `nothing to commit, working tree clean`, repeating identically until all 5 attempts were exhausted.

**Root cause:** each retry only ran `git checkout origin/$branch -- version.properties`, which resyncs *that one file's working-tree content* but leaves local `HEAD` wherever it was. `git commit` had already succeeded in attempt 1, before its `git push` got rejected — so `HEAD` stayed on that stale, diverged commit for every later attempt too. Attempt 2 recomputes a bump on top of the resynced file and tries to commit again: the push still can't fast-forward (still diverged), or — if the recomputed numbers happen to coincidentally match what's already sitting in the stale local commit — `git commit` has nothing to commit at all and errors out. Since local `HEAD` never actually moved between attempts, this repeated identically every time.

**Fix:** replaced the file-level `checkout` with `git reset --hard origin/$branch`, which discards any stale local commit and fully resyncs `HEAD` before each attempt recomputes its bump.

## Test plan

- [x] Reproduced the exact failure in an isolated throwaway git repo (two clones; one pushes a concurrent commit mid-loop): the old `checkout -- version.properties` logic reproduces the reported pattern exactly — attempt 1 rejected (non-fast-forward), attempts 2-3 fail with "nothing to commit"
- [x] Same simulation with the new `reset --hard origin/$branch` logic: recovers on attempt 1, correctly builds its bump on top of the concurrent commit, and pushes successfully
- [x] `./gradlew help -q` — `build.gradle.kts` still parses cleanly
- [ ] Watch for this to no longer show up as a failure the next time two release workflows race on a push


---
_Generated by [Claude Code](https://claude.ai/code/session_017bPj23QxAhJrA6sDdRRycX)_

## Summary by Sourcery

Fix the version bump workflow’s retry loop so it correctly resynchronizes local HEAD with the remote branch after a rejected push, preventing it from getting stuck on a stale commit.

Bug Fixes:
- Ensure incrementAndPushVersion resets local HEAD to origin before each retry to avoid repeated non-fast-forward and "nothing to commit" errors.

Build:
- Adjust Gradle incrementAndPushVersion task to use a hard reset of origin/$branch instead of file-level checkout for version.properties.