### PR TITLE
Fix apt/coreutils failing with the system shell's "inaccessible or not found"

### DIFF
--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/DistroManager.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/DistroManager.kt
@@ -42,9 +42,17 @@ object DistroManager {
     fun prefixDir(context: Context): File = File(context.filesDir, "usr")
     fun homeDir(context: Context): File = File(context.filesDir, "home")
 
+    // Requires a working bin/bash, not just the directories existing: CommandTree.scanShell()
+    // lists whatever's actually sitting in usr/bin/ and gates entirely on this check, so an
+    // existence-only check let it advertise real binaries (apt, coreutils, ...) from an install
+    // whose bash is missing, a dangling symlink, or otherwise non-executable - ShellSession
+    // .forAndroid() already requires this same bin/bash.canExecute() before it'll use the
+    // bootstrap shell at all, so a command picked from such a tree fell through to the bare
+    // /system/bin/sh fallback and failed with its "inaccessible or not found" instead of
+    // whatever apt/coreutils would have actually said.
     fun isInstalled(context: Context): Boolean {
         val usrDir = prefixDir(context)
-        return usrDir.isDirectory && File(usrDir, "bin").isDirectory
+        return usrDir.isDirectory && File(usrDir, "bin").isDirectory && File(usrDir, "bin/bash").canExecute()
     }
 
     fun bootstrap(context: Context, client: OkHttpClient): Flow<String> = flow {

--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/TerminalEngine.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/TerminalEngine.kt
@@ -19,10 +19,17 @@ import java.io.File
  */
 class TerminalEngine(
     private val context: Context,
-    home: File? = null
+    private val home: File? = null
 ) {
 
-    private val shell = ShellSession.forAndroid(home, context)
+    // var, not val: a fresh `bootstrap` run replaces this once the install actually lands (see
+    // the "bootstrap" branch of run() below). Without that, a session that picked the
+    // /system/bin/sh fallback before a bootstrap existed - or before this specific run's install
+    // finished - stays pinned to it for the rest of its life: every command after that keeps
+    // failing with the bare system shell's "inaccessible or not found", even though
+    // CommandTree.from() re-scans the filesystem live on every render and correctly starts
+    // offering apt/pkg/coreutils pills the moment the bootstrap directory is actually populated.
+    private var shell = ShellSession.forAndroid(home, context)
 
     // Only bootstrap still needs an HTTP client, now that RSS/weather/etc. are gone with the
     // rest of the legacy engine.
@@ -50,6 +57,13 @@ class TerminalEngine(
         if (verb == "bootstrap") {
             launch(Dispatchers.IO) {
                 DistroManager.bootstrap(context, client).collect { trySend(it) }
+                // Re-pick the shell now that the bootstrap either just landed or, on failure,
+                // was rolled back - forAndroid() re-checks DistroManager.isInstalled() and a
+                // real bash's presence itself, so this converges to whatever's actually usable
+                // now instead of leaving `shell` pinned to whatever was true at construction.
+                val old = shell
+                shell = ShellSession.forAndroid(home, context)
+                old.close()
                 close()
             }
         } else if (verb in Builtins.NAMES) {

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 versionMajor=0
 versionMinor=6
-versionPatch=94
-versionBuild=255
+versionPatch=95
+versionBuild=256


### PR DESCRIPTION
## Summary

Traced from the screenshot: a command picked from the `Package management > apt > install` pills ran as `apt install`, and the buffer showed:

```
/system/bin/sh: <stdin>[1]: apt: inaccessible or not found
```

That exact wording is mksh/toybox's error format for a command piped in on stdin with no PATH match — it can only come from `ShellSession`'s `DEFAULT_SHELL` fallback (`/system/bin/sh`, no PATH override), never from the Termux bootstrap's own `bash` (which sets `PATH="$PREFIX/bin"` explicitly). But `apt` only ever shows up as a pill at all because `CommandTree.scanShell()` found it as a real file under the bootstrap's `usr/bin/` — so the UI and the execution engine had fallen out of sync about whether a working bootstrap actually existed.

Two compounding bugs:

1. **`TerminalEngine` picked its shell once, at construction, and never again.** `private val shell = ShellSession.forAndroid(home, context)` — if that pick happened before a bootstrap existed (or before this run's own `bootstrap` install finished), every command for the rest of that `TerminalEngine`'s life kept hitting the stale fallback shell, while `CommandTree.from()` re-scans the filesystem fresh on every render and correctly started offering `apt`/coreutils pills the moment the bootstrap directory was actually populated. Fixed by making `shell` a `var` and re-picking it via `ShellSession.forAndroid()` right after a `bootstrap` command's flow completes (success or rollback), instead of leaving it pinned forever.

2. **`DistroManager.isInstalled()` was existence-only** (`usr/` and `usr/bin/` both being directories) — which `CommandTree.scanShell()` gates entirely on to decide whether to advertise binaries at all. A directory that exists but whose `bash` is missing, a dangling symlink, or non-executable (the file's own `UX-6` comment already documents partial-install as a known hazard) still passed, letting the tree advertise binaries the execution engine could never actually reach — `ShellSession.forAndroid()` itself already requires `bin/bash.canExecute()` before it'll use the bootstrap shell at all. `isInstalled()` now requires that same check, so the two stay in agreement.

I also reviewed the rest of the screenshot for other issues: the pill bleeding off the left screen edge and the gap above the pill stack are both the app's existing, intentional design (hand-tuned bleed / bottom-anchored stacking, already documented in `PillMenu.kt` and `DESIGN.md` — not new). The floating camera/slider control near the right edge is an Android screen-recording overlay, not part of the app.

## Test plan

- [x] `./gradlew :shared:compileAndroidMain` — compiles clean
- [ ] Manual: fresh install, tap `bootstrap`, wait for it to finish, then tap `apt` → `install` — should now hit the real bootstrap `bash`/`apt` instead of the system shell fallback


---
_Generated by [Claude Code](https://claude.ai/code/session_017bPj23QxAhJrA6sDdRRycX)_

## Summary by Sourcery

Ensure terminal sessions switch to the installed bootstrap shell after running bootstrap so command pills execute against the correct environment.

Bug Fixes:
- Prevent apt/coreutils commands from being executed with the system fallback shell when a usable bootstrap bash is present.
- Avoid advertising command pills from a partially installed or broken bootstrap where bash is missing or not executable.

Enhancements:
- Refresh the ShellSession after bootstrap completes and cleanly close the previous shell instance to keep the terminal engine aligned with the current distro state.

Build:
- Bump application patch and build versions to reflect the fix.