### PR TITLE
Bring the host pill in from the edge; overlap trail crumbs

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -27,10 +27,11 @@ changes. A pill with no end-cap still right-aligns its label.
 ## 3. Selecting a host
 
 Tapping a host sends the entire stack further left: every unselected pill leaves the screen,
-and the host stops with its **right end parked at 22.44%** of the frame — whatever its length —
-so only its label and end-cap remain visible. (`HOST_WIDTH × HOST_RIGHT_EDGE` in `PillMenu.kt` -
-`HOST_RIGHT_EDGE` names a factor in that product, not the resting position itself.) It then
-**drops to the bottom of the screen**, `rowsBelow × pitch`, and stays pinned there.
+and the host stops with its **right end parked at 36.3%** of the frame — whatever its length —
+so its label and end-cap stay legible, with the rest of the pill bled off the left edge like
+everywhere else in this menu. (`HOST_WIDTH × HOST_RIGHT_EDGE` in `PillMenu.kt` - `HOST_RIGHT_EDGE`
+names a factor in that product, not the resting position itself.) It then **drops to the bottom
+of the screen**, `rowsBelow × pitch`, and stays pinned there.
 
 ## 4. Children cascade upward
 
@@ -71,12 +72,14 @@ whatever row it lands on.
 
 A picked child doesn't just cascade its own children in — it also drops out of the band and
 settles beside the host as a **trail crumb**, the record of what's been picked so far. The
-trail starts at 24% of the frame, just clear of the host's right end, and runs left to right in
-pick order. Unlike every other pill (sized as a fraction of the screen), a crumb is sized by its
-own content, with a 56dp floor so a short label like `ls` doesn't shrink-wrap smaller than
-everything around it. Tapping a crumb pops the trail back to just before it and re-opens that
-pill's own band — each level is its own fresh cascade, never more pills piled onto the one
-before it.
+trail starts at 38.3% of the frame, just clear of the host's right end, and runs left to right
+in pick order. Unlike every other pill (sized as a fraction of the screen), a crumb is sized by
+its own content, with a 56dp floor so a short label like `ls` doesn't shrink-wrap smaller than
+everything around it. Each crumb overlaps the one after it by 14dp - a fanned, shingled read
+(the same overlap/bleed language the rest of the menu already uses) rather than a plain row of
+gapped pills; the earlier crumb draws on top, so it's the later one that visibly tucks under.
+Tapping a crumb pops the trail back to just before it and re-opens that pill's own band — each
+level is its own fresh cascade, never more pills piled onto the one before it.
 
 ## 5. Motion
 
@@ -87,10 +90,10 @@ before it.
 | Child turn (swing) | 173ms, linear |
 | Lift | final 10% of the turn |
 | Cascade | strictly sequential — 173ms per step |
-| Host rests at | 22.44% of the frame |
+| Host rests at | 36.3% of the frame |
 | Child pill | 34% wide, 30% in |
-| Trail starts at | 24% of the frame |
-| Trail crumb | content-sized, 56dp floor |
+| Trail starts at | 38.3% of the frame |
+| Trail crumb | content-sized, 56dp floor, 14dp overlap |
 | Overhang | 62dp past the left edge |
 | Row pitch | 20dp |
 | Pick grows to | 1.15× before settling back to 1× |

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -174,17 +174,30 @@ fun Azphalt.Ground.pageBrush(): Brush = Brush.linearGradient(0f to page, 0.5f to
 private val PILL_HEIGHT = 17.dp
 private val ROW_PITCH = 20.dp
 private val OVERHANG = 62.dp
+// Negative Arrangement.spacedBy for TrailRow - each crumb's left edge tucks this far under the
+// crumb before it. A quarter of TrailCrumb's own 56dp floor width: enough to read as a deliberate
+// overlap (the "each crumb overlapped by the one before it" fan) without hiding a short crumb
+// like `ls` entirely behind its neighbor.
+private val TRAIL_OVERLAP = (-14).dp
 private const val HOST_WIDTH = 0.66f
-private const val HOST_RIGHT_EDGE = 0.34f
+// HostPill's own right edge lands at exactly HOST_WIDTH * HOST_RIGHT_EDGE of the full width (see
+// the comment on that math below) - which, since HostPill is HOST_WIDTH wide, also happens to be
+// the fraction of the host's *own* width left on-screen (the rest bleeds off the left edge). At
+// 0.34 that was only 34% of the label visible - "Package management" read as an unrecognizable
+// "...MANAGEMENT" fragment, not a deliberate bleed. Raised to 0.55 so most host labels stay
+// legible; still bleeds some off the left edge, matching the house style used everywhere else in
+// this menu (OVERHANG, the root stack's own absoluteBleed), just no longer past the point of
+// losing the label's own meaning.
+private const val HOST_RIGHT_EDGE = 0.55f
 private const val CHILD_LEFT = 0.30f
 private const val CHILD_WIDTH = 0.34f
 // Menu Style Guide rule 01 (4%-per-row width variation, "so the stack reads as a stack") is
 // applied only to StackPill's own resting width below, via ROOT_WIDTH_STEP / rootWidthFraction -
 // never to HostPill. HostPill's constraint propagation (offsetByFractionOfParent / fillMaxWidth /
-// absoluteBleed interacting to park the host at HOST_RIGHT_EDGE = 34%) has been hand-tuned across
-// two prior PRs (#91/#92); every line of HostPill (and every constant it reads - HOST_WIDTH,
-// HOST_RIGHT_EDGE) is left exactly as it was, so this variation can never touch that math. It's
-// safe to vary StackPill alone because of how offsetByFractionOfParent composes with fillMaxWidth:
+// absoluteBleed interacting to park the host at HOST_RIGHT_EDGE) has been hand-tuned across two
+// prior PRs (#91/#92, and the HOST_RIGHT_EDGE value itself once more since); every line of
+// HostPill is left exactly as it was, so this variation can never touch that math. It's safe to
+// vary StackPill alone because of how offsetByFractionOfParent composes with fillMaxWidth:
 // StackPill's fillMaxWidth(fraction) modifier runs *first*, narrowing the constraints handed to
 // offsetByFractionOfParent, so with offset 0f (the resting, non-leaving state) a pill's right edge
 // simply lands at `fraction` of the full screen width - changing that one fillMaxWidth fraction
@@ -748,13 +761,19 @@ private fun TrailRow(
             Modifier
                 .align(Alignment.BottomStart)
                 .offsetByFractionOfParent(TRAIL_LEFT_OF_FULL),
-            horizontalArrangement = Arrangement.spacedBy(4.dp)
+            // Negative spacing overlaps each crumb into the one after it, like a fanned hand of
+            // cards - the same shingled read as the rest of this menu's overlaps/bleeds. A plain
+            // Row draws later children over earlier ones, which would overlap backwards ("each
+            // crumb sits ON the one before it" instead of the other way around); TrailCrumb's own
+            // zIndex below reverses that so a crumb is drawn *under* every crumb that follows it.
+            horizontalArrangement = Arrangement.spacedBy(TRAIL_OVERLAP)
         ) {
             trail.forEachIndexed { i, node ->
                 key(node.id) {
                     TrailCrumb(
                         node = node,
                         hueOwner = hueOwner,
+                        zIndex = (trail.size - i).toFloat(),
                         onClick = { onTapCrumb(i) },
                         onPositioned = { onCrumbPositioned(node.id, it) }
                     )
@@ -765,7 +784,13 @@ private fun TrailRow(
 }
 
 @Composable
-private fun TrailCrumb(node: MenuNode, hueOwner: String, onClick: () -> Unit, onPositioned: (Rect) -> Unit = {}) {
+private fun TrailCrumb(
+    node: MenuNode,
+    hueOwner: String,
+    zIndex: Float,
+    onClick: () -> Unit,
+    onPositioned: (Rect) -> Unit = {}
+) {
     Pill(
         label = node.label,
         cap = node.cap,
@@ -777,6 +802,7 @@ private fun TrailCrumb(node: MenuNode, hueOwner: String, onClick: () -> Unit, on
         // doesn't shrink-wrap into something visibly smaller than everything around it.
         modifier = Modifier
             .defaultMinSize(minWidth = 56.dp)
+            .zIndex(zIndex)
             .clickable(onClick = onClick)
             .onGloballyPositioned { onPositioned(it.boundsInRoot()) }
     )

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 versionMajor=0
 versionMinor=6
-versionPatch=97
-versionBuild=258
+versionPatch=98
+versionBuild=259


### PR DESCRIPTION
## Summary

Two fixes to the breadcrumb layout (host pill + trail), per your feedback that the first one is pulled too far to the side and each following pill should overlap the one before it:

- **`HOST_RIGHT_EDGE` was 0.34**, meaning only 34% of the host pill's own width stayed on-screen — that's exactly what made "Package management" read as an unrecognizable `...MANAGEMENT` fragment in the earlier screenshot, not a deliberate bleed. Raised to 0.55 (right edge at 36.3% of the frame, up from 22.44%) so a host label stays legible while still bleeding some off the left edge, matching this menu's existing overlap/bleed language elsewhere. `TRAIL_LEFT_OF_FULL` derives from this constant, so the trail's own start position (38.3%, up from 24%) moves out in step with it automatically — no separate change needed there.

- **Trail crumbs sat side by side with a plain 4dp gap.** Replaced that with a `-14dp` overlap (`Arrangement.spacedBy` accepts negative values), so each crumb tucks under the one before it like a fanned hand of cards — consistent with the shingled/overlapping look already used throughout this menu. A plain `Row` draws later children over earlier ones by default, which would have overlapped *backwards* ("each crumb sits on top of the one before it"); `TrailCrumb` now takes an explicit `zIndex` (higher for earlier crumbs) so the actual draw order is reversed to match what you asked for — each crumb overlapped *by* the one before it.

`DESIGN.md`'s own percentages/table (§3, §4a, §5) updated to match.

Note: `HostPill`'s positioning math carried a comment from two prior PRs (#91/#92) saying it was hand-tuned and shouldn't be touched — that comment was guarding against a specific, unrelated refactor (row-width variation leaking into the host's math), not against a deliberate value change like this one, so I updated the comment rather than working around it.

## Test plan

- [x] `./gradlew :shared:compileKotlinMetadata` — compiles clean
- [ ] Visual check on-device: host label should read clearly with only a modest left bleed, and trail crumbs should visibly overlap/fan rather than sit in a gapped row


---
_Generated by [Claude Code](https://claude.ai/code/session_017bPj23QxAhJrA6sDdRRycX)_

## Summary by Sourcery

Adjust breadcrumb host and trail layout to keep host labels legible while visually overlapping trail crumbs in a shingled, card-like fan.

Enhancements:
- Increase host pill on-screen positioning so more of the host label remains visible while preserving a partial left-edge bleed.
- Update trail crumb row to use overlapping spacing with explicit z-index ordering for a forward-facing, fanned visual effect.
- Refresh DESIGN.md layout percentages, trail behavior description, and motion table to reflect the new host and trail positions and overlap.
- Bump patch and build versions to reflect the UI layout changes.