### PR TITLE
merged-build.yml: declare explicit least-privilege permissions

### DIFF
--- a/.github/workflows/merged-build.yml
+++ b/.github/workflows/merged-build.yml
@@ -15,6 +15,15 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Explicit, least-privilege, and matching exactly what the called _reusable-build.yml job itself
+# declares - without this, the effective GITHUB_TOKEN permissions for the whole run fall back to
+# the repo/org's default token permissions setting instead of being pinned here.
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+  checks: read
+
 jobs:
   android-debug:
     uses: ./.github/workflows/_reusable-build.yml


### PR DESCRIPTION
Fixes CodeQL alert #6 ("Workflow does not contain permissions").

`merged-build.yml`'s only job calls `_reusable-build.yml` via `uses:`, so it couldn't declare permissions at the job level the way every other workflow in this repo already does. Added a workflow-level `permissions:` block instead, matching exactly what the reusable workflow's own job requires (`contents: write`, `issues: write`, `pull-requests: write`, `checks: read`) — no broader than before, just explicit instead of falling back to the repo/org default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

CI:
- Add explicit least-privilege GITHUB_TOKEN permissions to merged-build.yml to match the called reusable build workflow.