### PR TITLE
Extend ground-contrast text fix to AzpStoreScreen and GuideReaderScreen

### DIFF
--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import com.hereliesaz.hg2gui.ui.menu.onPage
 import com.hereliesaz.hg2gui.ui.menu.pageBrush
 
 /** A search result row, or an already-installed package - shared shape for the list.
@@ -116,7 +117,7 @@ fun AzpStoreScreen(
                 ) {
                     Text(
                         k.uppercase(),
-                        color = if (selected) Azphalt.Yellow else Azphalt.Ink,
+                        color = if (selected) Azphalt.Yellow else Azphalt.currentGround.onPage,
                         fontSize = 8.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
                     )
                 }
@@ -185,29 +186,30 @@ private fun AzpRow(listing: AzpListing, installing: Boolean, onInstall: (AzpList
             .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically
     ) {
+        val onPage = Azphalt.currentGround.onPage
         Column(Modifier.weight(1f)) {
             Row(verticalAlignment = Alignment.CenterVertically) {
                 Text(
                     listing.name,
-                    style = MaterialTheme.typography.bodyMedium.copy(color = Azphalt.Ink, fontWeight = FontWeight.ExtraBold)
+                    style = MaterialTheme.typography.bodyMedium.copy(color = onPage, fontWeight = FontWeight.ExtraBold)
                 )
                 Spacer(Modifier.width(8.dp))
                 Text(
                     listing.kind.uppercase(),
-                    color = Azphalt.Ink.copy(alpha = .5f),
+                    color = onPage.copy(alpha = .5f),
                     fontSize = 8.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
                 )
             }
             if (listing.description.isNotBlank()) {
                 Text(
                     listing.description,
-                    color = Azphalt.Ink.copy(alpha = .65f), fontSize = 10.sp,
+                    color = onPage.copy(alpha = .65f), fontSize = 10.sp,
                     modifier = Modifier.padding(top = 2.dp)
                 )
             }
             Text(
                 "${listing.author} · v${listing.version}",
-                color = Azphalt.Ink.copy(alpha = .45f), fontSize = 9.sp,
+                color = onPage.copy(alpha = .45f), fontSize = 9.sp,
                 modifier = Modifier.padding(top = 2.dp)
             )
             if (listing.installed && listing.trust.isNotBlank()) {
@@ -225,7 +227,7 @@ private fun AzpRow(listing: AzpListing, installing: Boolean, onInstall: (AzpList
                 // states that plainly: trust is unknown until install, not silently assumed good.
                 Text(
                     "TRUST UNKNOWN · CHECKED AT INSTALL",
-                    color = Azphalt.Ink.copy(alpha = .4f),
+                    color = onPage.copy(alpha = .4f),
                     fontSize = 8.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em,
                     modifier = Modifier.padding(top = 3.dp)
                 )
@@ -233,7 +235,7 @@ private fun AzpRow(listing: AzpListing, installing: Boolean, onInstall: (AzpList
             if (listing.installed && listing.kind == "script") {
                 Text(
                     if (listing.scriptCommand.isNotBlank()) "→ ${listing.scriptCommand}" else "AWAITING BOOTSTRAP",
-                    color = Azphalt.Ink.copy(alpha = .45f),
+                    color = onPage.copy(alpha = .45f),
                     fontSize = 8.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em,
                     modifier = Modifier.padding(top = 3.dp)
                 )
@@ -273,7 +275,7 @@ private fun trustLabel(trust: String): String = when (trust) {
 /** Single source of truth for "is this the TRUSTED tier" - [trustLabel] and this must never
  *  disagree about which string means trusted, so both read the same comparison. */
 private fun trustColor(trust: String): Color =
-    if (trust == "TRUSTED") Azphalt.hues[3] else Azphalt.Ink.copy(alpha = .45f)
+    if (trust == "TRUSTED") Azphalt.hues[3] else Azphalt.currentGround.onPage.copy(alpha = .45f)
 
 @Composable
 private fun Eyebrow(text: String) {

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideReaderScreen.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideReaderScreen.kt
@@ -36,6 +36,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
+import com.hereliesaz.hg2gui.ui.menu.onPage
 import com.hereliesaz.hg2gui.ui.menu.pageBrush
 import kotlinx.coroutines.delay
 
@@ -127,7 +128,7 @@ private fun ColumnScope.GuideIndex(onBack: () -> Unit, onOpenEntry: (Int) -> Uni
     Column(Modifier.fillMaxWidth().padding(start = 20.dp, end = 20.dp, top = 18.dp)) {
         Text(
             "THE GUIDE",
-            color = Azphalt.Ink,
+            color = Azphalt.currentGround.onPage,
             fontSize = 34.sp,
             lineHeight = 30.sp,
             fontWeight = FontWeight.Black,
@@ -136,7 +137,7 @@ private fun ColumnScope.GuideIndex(onBack: () -> Unit, onOpenEntry: (Int) -> Uni
         Text(
             "The galaxy's largest repository of half-truths and pseudo-knowledge required to " +
                 "pocket a wild Linux environment. Proceed with a care-free sort of caution.",
-            color = Azphalt.Ink.copy(alpha = .78f),
+            color = Azphalt.currentGround.onPage.copy(alpha = .78f),
             fontSize = 13.sp,
             lineHeight = 18.sp,
             modifier = Modifier.padding(top = 8.dp)
@@ -159,14 +160,14 @@ private fun ColumnScope.GuideIndex(onBack: () -> Unit, onOpenEntry: (Int) -> Uni
                 Column(verticalArrangement = Arrangement.spacedBy(6.dp)) {
                     Text(
                         chapter.label.uppercase(),
-                        color = Azphalt.Ink.copy(alpha = .45f),
+                        color = Azphalt.currentGround.onPage.copy(alpha = .45f),
                         fontSize = 9.sp,
                         fontWeight = FontWeight.ExtraBold,
                         letterSpacing = 0.18.em
                     )
                     Text(
                         chapter.title.uppercase(),
-                        color = Azphalt.Ink,
+                        color = Azphalt.currentGround.onPage,
                         fontSize = 16.sp,
                         fontWeight = FontWeight.Black,
                         letterSpacing = (-0.01).em
@@ -179,7 +180,7 @@ private fun ColumnScope.GuideIndex(onBack: () -> Unit, onOpenEntry: (Int) -> Uni
                         // a pick that would otherwise never exist.
                         Text(
                             chapter.intro,
-                            color = Azphalt.Ink.copy(alpha = .7f),
+                            color = Azphalt.currentGround.onPage.copy(alpha = .7f),
                             fontSize = 12.sp,
                             lineHeight = 18.sp,
                             modifier = Modifier.padding(vertical = 11.dp)
@@ -196,7 +197,7 @@ private fun ColumnScope.GuideIndex(onBack: () -> Unit, onOpenEntry: (Int) -> Uni
                         ) {
                             Text(
                                 entry.cmd,
-                                color = Azphalt.Ink,
+                                color = Azphalt.currentGround.onPage,
                                 fontSize = 13.sp,
                                 fontWeight = FontWeight.ExtraBold,
                                 letterSpacing = 0.01.em,
@@ -204,7 +205,7 @@ private fun ColumnScope.GuideIndex(onBack: () -> Unit, onOpenEntry: (Int) -> Uni
                             )
                             Text(
                                 entry.teaser,
-                                color = Azphalt.Ink.copy(alpha = .55f),
+                                color = Azphalt.currentGround.onPage.copy(alpha = .55f),
                                 fontSize = 12.sp,
                                 lineHeight = 16.sp,
                                 modifier = Modifier.weight(0.6f)
@@ -253,7 +254,7 @@ private fun ColumnScope.GuideEntryReader(
         WipeItem(2, wipeKey, wide = true, modifier = Modifier.padding(top = 16.dp)) {
             Text(
                 entry.cmd.uppercase(),
-                color = Azphalt.Ink,
+                color = Azphalt.currentGround.onPage,
                 fontSize = 34.sp,
                 lineHeight = 30.sp,
                 fontWeight = FontWeight.Black,
@@ -284,7 +285,7 @@ private fun ColumnScope.GuideEntryReader(
             WipeItem(seq++, wipeKey, wide = true, modifier = Modifier.padding(top = 16.dp)) {
                 Text(
                     entry.blurb,
-                    color = Azphalt.Ink.copy(alpha = .78f),
+                    color = Azphalt.currentGround.onPage.copy(alpha = .78f),
                     fontSize = 15.sp,
                     lineHeight = 21.sp
                 )
@@ -293,7 +294,7 @@ private fun ColumnScope.GuideEntryReader(
             WipeItem(seq++, wipeKey, wide = true, modifier = Modifier.padding(top = 10.dp)) {
                 Text(
                     "STANDS FOR “${entry.full.uppercase()}”",
-                    color = Azphalt.Ink.copy(alpha = .45f),
+                    color = Azphalt.currentGround.onPage.copy(alpha = .45f),
                     fontSize = 10.sp,
                     fontWeight = FontWeight.ExtraBold,
                     letterSpacing = 0.14.em
@@ -325,7 +326,7 @@ private fun ColumnScope.GuideEntryReader(
                         )
                         Text(
                             anim,
-                            color = Azphalt.Ink.copy(alpha = .78f),
+                            color = Azphalt.currentGround.onPage.copy(alpha = .78f),
                             fontSize = 13.sp,
                             lineHeight = 19.sp,
                             modifier = Modifier.padding(top = 8.dp)
@@ -338,7 +339,7 @@ private fun ColumnScope.GuideEntryReader(
                 WipeItem(seq++, wipeKey, wide = true, modifier = Modifier.padding(top = 16.dp)) {
                     Text(
                         note,
-                        color = Azphalt.Ink.copy(alpha = .55f),
+                        color = Azphalt.currentGround.onPage.copy(alpha = .55f),
                         fontSize = 12.sp,
                         lineHeight = 17.sp,
                         fontWeight = FontWeight.Medium
@@ -350,14 +351,14 @@ private fun ColumnScope.GuideEntryReader(
                 Column {
                     Text(
                         "FROM THE CHAPTER",
-                        color = Azphalt.Ink.copy(alpha = .45f),
+                        color = Azphalt.currentGround.onPage.copy(alpha = .45f),
                         fontSize = 9.sp,
                         fontWeight = FontWeight.ExtraBold,
                         letterSpacing = 0.18.em
                     )
                     Text(
                         entry.chapterIntro,
-                        color = Azphalt.Ink.copy(alpha = .78f),
+                        color = Azphalt.currentGround.onPage.copy(alpha = .78f),
                         fontSize = 12.sp,
                         lineHeight = 17.sp,
                         modifier = Modifier.padding(top = 6.dp)
@@ -400,7 +401,7 @@ private fun GuideWash(word: String, wipeKey: Int) {
     }
     Text(
         word,
-        color = Azphalt.Ink.copy(alpha = .09f),
+        color = Azphalt.currentGround.onPage.copy(alpha = .09f),
         fontSize = 100.sp,
         lineHeight = 84.sp,
         fontWeight = FontWeight.Black,
@@ -420,10 +421,10 @@ private fun FactRow(label: String, value: String) {
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
         Text(
-            label.uppercase(), color = Azphalt.Ink.copy(alpha = .55f),
+            label.uppercase(), color = Azphalt.currentGround.onPage.copy(alpha = .55f),
             fontSize = 10.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.09.em
         )
-        Text(value, color = Azphalt.Ink, fontSize = 12.sp, fontWeight = FontWeight.Bold)
+        Text(value, color = Azphalt.currentGround.onPage, fontSize = 12.sp, fontWeight = FontWeight.Bold)
     }
     Box(Modifier.fillMaxWidth().height(1.dp).background(Azphalt.Ink.copy(alpha = .16f)))
 }
@@ -440,7 +441,7 @@ private fun Chip(
     onClick: () -> Unit = {}
 ) {
     val bg = if (filled) background else Azphalt.Ink.copy(alpha = .14f)
-    val fg = if (filled) foreground else Azphalt.Ink.copy(alpha = .55f)
+    val fg = if (filled) foreground else Azphalt.currentGround.onPage.copy(alpha = .55f)
     // UI-7: the visible chip (padding(vertical = 8.dp) around 9sp type) renders well under the
     // 48dp minimum touch target. Rather than growing the chip itself - which would blow up its
     // whole visual proportions - the clickable region is a separate, invisible 48dp-tall Box the


### PR DESCRIPTION
## Summary

Completes the ground-contrast sweep started in #149/#150 — the last two of ten screens.

- `AzpStoreScreen.kt` and `GuideReaderScreen.kt`: every `Text`/icon color explicitly set to `Azphalt.Ink` that sits directly on the rotating page ground (or a translucent Ink tint over it) now reads `Azphalt.currentGround.onPage` instead, so it stays legible on every ground (not just the light Mustard one), matching the fix already applied to every other screen.
- Left every genuinely fixed, ground-independent pairing alone: an opaque Ink background with Yellow text, Ink text on a fixed `Azphalt.hues[...]` background, background fills themselves, and the hairline divider rules (`.background(Azphalt.Ink.copy(alpha = .16f))` used as a 1dp rule color, not text).

## Test plan

- [x] `:shared:compileAndroidMain` compiles cleanly.
- [x] `detekt` clean.
- [ ] Manually verify the Store and Guide screens stay legible across a few ground rerolls (Mustard, Navy, Maroon).

---
_Generated by [Claude Code](https://claude.ai/code/session_018X7LN1wZoJ15zdAyTu2Riq)_

## Summary by Sourcery

Make the Azp Store and Guide Reader content remain legible as the page ground changes.

Bug Fixes:
- Improve text and icon contrast on the Azp Store and Guide Reader screens across all rotating page grounds.

Enhancements:
- Use ground-aware page foreground colors while preserving intentionally fixed color pairings and divider styling.