### PR TITLE
Version the APK filename; stop wiping prior release assets

### DIFF
--- a/.github/workflows/_reusable-build.yml
+++ b/.github/workflows/_reusable-build.yml
@@ -152,12 +152,6 @@ jobs:
           git tag -fa "$TAG_NAME" -m "Automated Release"
           git push origin "refs/tags/$TAG_NAME" --force
 
-          # Handle existing release update
-          OLD_ASSETS=$(gh release view "$TAG_NAME" --json assets --jq '.assets[].name' || true)
-          for OLD_ASSET in $OLD_ASSETS; do
-             gh release delete-asset "$TAG_NAME" "$OLD_ASSET" -y || true
-          done
-
           # `gh release edit` only works on a release that already exists - it can't create one,
           # so the first build under a new TAG_NAME (e.g. right after a versionMajor/versionMinor
           # bump, since that's what TAG_NAME is keyed on) had no release to edit and failed the

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.android.build.api.variant.impl.VariantOutputImpl
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import java.util.Properties
 
@@ -110,6 +111,24 @@ android {
     }
     ndkVersion = "29.0.14206865"
     buildToolsVersion = "37.0.0"
+}
+
+// The default output name (composeApp-<flavor>-<buildType>.apk) carries no version at all - every
+// build overwrites the same filename, and once one lands on the "latest-debug"/"latest" GitHub
+// Release (see _reusable-build.yml's Publish Release step, which uploads this exact file) there's
+// no way to tell which build a previously-downloaded APK actually is. VariantOutputImpl's
+// outputFileName is the actual mutable Property; the public VariantOutput interface only exposes
+// it read-only, so every AGP renaming setup - this one included - casts down to the impl class.
+androidComponents {
+    onVariants(selector().all()) { variant ->
+        variant.outputs.forEach { output ->
+            if (output is VariantOutputImpl) {
+                output.outputFileName.set(
+                    "hg2gui-${variant.flavorName}-${variant.buildType}-$resolvedVersionName.apk"
+                )
+            }
+        }
+    }
 }
 
 dependencies {


### PR DESCRIPTION
## Summary
- Every APK build's output filename now embeds the full version string (e.g. `hg2gui-playstore-debug-0.7.7.278.apk`) instead of the generic `composeApp-<flavor>-<buildType>.apk`, so a downloaded APK can be traced back to the exact build that produced it.
- The release workflow's "Publish Release" step no longer deletes every existing asset on the release before uploading — that loop was harmless while every build shared one filename (the upload's `--clobber` already handled replacement), but now that filenames are version-specific, it would have deleted every previously-published version's APK on each new build instead of letting them accumulate.

## Test plan
- [x] `:composeApp:assembleDebug` — verified the resulting file is `hg2gui-playstore-debug-0.7.7.278.apk`
- [x] `:composeApp:detekt` — clean
- [x] YAML syntax of `_reusable-build.yml` validated with `yaml.safe_load`
- [ ] CI build + release publish (watching)


---
_Generated by [Claude Code](https://claude.ai/code/session_018X7LN1wZoJ15zdAyTu2Riq)_

## Summary by Sourcery

Version APK artifacts and retain prior release assets when publishing new builds.

New Features:
- Include the full application version in every APK filename so published artifacts can be traced to their exact build.

Bug Fixes:
- Preserve previously published release APKs by stopping the release workflow from deleting existing assets before uploads.