### PR TITLE
Add a stable -latest.apk alias to the rolling release, keep every build

### DIFF
--- a/.github/workflows/_reusable-build.yml
+++ b/.github/workflows/_reusable-build.yml
@@ -164,22 +164,24 @@ jobs:
             gh release create "$TAG_NAME" --prerelease --title "Latest Build ($TAG_NAME)" --notes "Auto-build from $GITHUB_SHA" --target "$GITHUB_SHA"
           fi
 
-          # This tag is a single rolling "latest" release, not a version archive - each APK's own
-          # filename embeds its full version for traceability (see composeApp/build.gradle.kts),
-          # but only the CURRENT build's asset should ever be here. Without this, GitHub's asset
-          # list sorts alphabetically, not by version or date - "...0.7.9....apk" sorts *after*
-          # "...0.7.11....apk" - so an old build left sitting here can look like the latest one
-          # and get downloaded instead of it. `--clobber` on the upload below only replaces a
-          # same-named asset (i.e. an exact re-run of the same version); every differently-named
-          # one from a previous build has to be deleted explicitly first.
-          if [ "$RELEASE_EXISTS" = true ]; then
-            OLD_ASSETS=$(gh release view "$TAG_NAME" --json assets --jq '.assets[].name')
-            for OLD_ASSET in $OLD_ASSETS; do
-              gh release delete-asset "$TAG_NAME" "$OLD_ASSET" -y || true
-            done
-          fi
-
-          # Find and upload all artifacts matching pattern
+          # Every build's own versioned APK accumulates here on purpose - older builds are kept,
+          # not deleted, so a previously-shared download link keeps working and the release page
+          # is a real history. But GitHub's asset list sorts alphabetically, not by version or
+          # date - "...0.7.9....apk" sorts *after* "...0.7.11....apk" - so with several versions
+          # sitting side by side, nothing marks which one is actually current. Alongside each
+          # file's own versioned name, also upload it under a second, fixed "-latest.apk" name
+          # that always sits at the same spot in the list and always gets overwritten
+          # (--clobber) with whatever just built - an unambiguous, permanent link to "whatever's
+          # newest right now" that coexists with the growing version history instead of replacing
+          # it.
           for FILE in ${{ inputs.artifact_path_pattern }}; do
-            [ -f "$FILE" ] && gh release upload "$TAG_NAME" "$FILE" --clobber
+            [ -f "$FILE" ] || continue
+            gh release upload "$TAG_NAME" "$FILE" --clobber
+            BASE="$(basename "$FILE")"
+            ALIAS="$(echo "$BASE" | sed -E 's/-[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+\.apk$/-latest.apk/')"
+            if [ "$ALIAS" != "$BASE" ]; then
+              ALIAS_PATH="$(dirname "$FILE")/$ALIAS"
+              cp "$FILE" "$ALIAS_PATH"
+              gh release upload "$TAG_NAME" "$ALIAS_PATH" --clobber
+            fi
           done

--- a/.github/workflows/_reusable-build.yml
+++ b/.github/workflows/_reusable-build.yml
@@ -155,14 +155,30 @@ jobs:
           # `gh release edit` only works on a release that already exists - it can't create one,
           # so the first build under a new TAG_NAME (e.g. right after a versionMajor/versionMinor
           # bump, since that's what TAG_NAME is keyed on) had no release to edit and failed the
-          # whole step with "release not found". `gh release view` above already tells us which
-          # case we're in.
+          # whole step with "release not found".
+          RELEASE_EXISTS=false
           if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            RELEASE_EXISTS=true
             gh release edit "$TAG_NAME" --prerelease --title "Latest Build ($TAG_NAME)" --notes "Auto-build from $GITHUB_SHA" --target "$GITHUB_SHA"
           else
             gh release create "$TAG_NAME" --prerelease --title "Latest Build ($TAG_NAME)" --notes "Auto-build from $GITHUB_SHA" --target "$GITHUB_SHA"
           fi
-          
+
+          # This tag is a single rolling "latest" release, not a version archive - each APK's own
+          # filename embeds its full version for traceability (see composeApp/build.gradle.kts),
+          # but only the CURRENT build's asset should ever be here. Without this, GitHub's asset
+          # list sorts alphabetically, not by version or date - "...0.7.9....apk" sorts *after*
+          # "...0.7.11....apk" - so an old build left sitting here can look like the latest one
+          # and get downloaded instead of it. `--clobber` on the upload below only replaces a
+          # same-named asset (i.e. an exact re-run of the same version); every differently-named
+          # one from a previous build has to be deleted explicitly first.
+          if [ "$RELEASE_EXISTS" = true ]; then
+            OLD_ASSETS=$(gh release view "$TAG_NAME" --json assets --jq '.assets[].name')
+            for OLD_ASSET in $OLD_ASSETS; do
+              gh release delete-asset "$TAG_NAME" "$OLD_ASSET" -y || true
+            done
+          fi
+
           # Find and upload all artifacts matching pattern
           for FILE in ${{ inputs.artifact_path_pattern }}; do
             [ -f "$FILE" ] && gh release upload "$TAG_NAME" "$FILE" --clobber


### PR DESCRIPTION
## Summary
The first commit on this PR deleted old assets before each publish - wrong direction: older builds should stay downloadable, not get wiped out every time a new one lands. The actual problem was narrower: GitHub's release asset list sorts alphabetically, not by version or date, so with several versioned APKs sitting side by side (`0.7.9...`, `0.7.11...`, `0.7.13...`) there was nothing marking which one is current - `"...0.7.9....apk"` sorts *after* `"...0.7.11....apk"`, so an old build could look like the newest one and get downloaded instead of it.

The second commit reverses that and fixes it properly: every build's own versioned APK still accumulates (never deleted), and alongside it, each build also uploads a second, fixed `-latest.apk`-named copy that's always overwritten (`--clobber`) with whatever just built - one permanent, unambiguous link to "whatever's newest right now" that coexists with the growing version history instead of replacing it.

## Test plan
- [x] YAML syntax validated with `yaml.safe_load`
- [x] The alias-name substitution (`sed`) verified against real filenames: `hg2gui-playstore-debug-0.7.13.284.apk` -> `hg2gui-playstore-debug-latest.apk`, and confirmed it's a no-op for names that don't match the versioned pattern
- [ ] Next merge to master: confirm the release keeps every prior versioned APK *and* gets a fresh `hg2gui-playstore-debug-latest.apk`

## Summary by Sourcery

Add a stable latest APK asset alongside versioned release artifacts so users can reliably download the newest build.

New Features:
- Publish a stable `-latest.apk` asset alias that is overwritten with each new build for unambiguous latest-download access.

Bug Fixes:
- Prevent stale versioned APK assets from being mistaken for the current build by providing a consistently named latest asset.

Enhancements:
- Retain versioned APK assets as release history while updating the rolling latest alias.