### PR TITLE
Point apt/curl at the bundled CA bundle so HTTPS actually verifies

### DIFF
--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/DistroManager.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/DistroManager.kt
@@ -256,6 +256,14 @@ object DistroManager {
     // path to a config file it reads before falling back to those compiled-in defaults - so this
     // writes one, with every Dir:: apt.conf(5) documents pointed at this app's real prefix
     // instead, and ShellSession points APT_CONFIG at it for every bootstrap-tier command.
+    //
+    // Acquire::https::CaInfo is here for a related but separate reason: the bootstrap zip already
+    // ships a real CA bundle at etc/tls/cert.pem (extracted like any other regular file, no fixup
+    // needed for the file itself), but on a genuine Termux install that bundle only becomes the
+    // thing TLS actually consults once the `ca-certificates` package's own postinst runs `trust
+    // extract` to activate it - a dpkg step this extraction never runs, so the bundle just sits
+    // there unused otherwise. Pointing apt straight at the raw bundle sidesteps needing that
+    // activation step at all.
     private fun writeAptConf(prefix: File) {
         val p = prefix.absolutePath
         val aptConfDir = File(prefix, "etc/apt")
@@ -283,6 +291,7 @@ object DistroManager {
             Dir::Bin::methods "$p/lib/apt/methods/";
             Dir::Bin::solvers:: "$p/lib/apt/solvers/";
             Dir::Bin::dpkg "$p/bin/dpkg";
+            Acquire::https::CaInfo "$p/etc/tls/cert.pem";
             """.trimIndent()
         )
     }

--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/ShellSession.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/ShellSession.kt
@@ -94,7 +94,12 @@ actual class ShellSession private constructor(
                         // pointed at this app's real prefix instead) before it ever falls back to
                         // those. See DistroManager.writeAptConf's own doc comment for why a config
                         // file, not an env var alone, is what apt actually needs here.
-                        "APT_CONFIG" to "${prefix.absolutePath}/etc/apt/apt.conf"
+                        "APT_CONFIG" to "${prefix.absolutePath}/etc/apt/apt.conf",
+                        // apt.conf's Acquire::https::CaInfo covers apt itself; these are the same
+                        // bundle for every other bootstrap-tier tool that talks TLS (curl, wget,
+                        // git, ...) via the conventions each already knows to check.
+                        "SSL_CERT_FILE" to "${prefix.absolutePath}/etc/tls/cert.pem",
+                        "CURL_CA_BUNDLE" to "${prefix.absolutePath}/etc/tls/cert.pem"
                     )
                     val session = ShellSession(bootstrapHome, arrayOf(bash.absolutePath, "-l"), env, "bash (Termux bootstrap)")
                     if (session.survivedStartup()) return session


### PR DESCRIPTION
## Summary
On-device: `apt update` reached the network (confirming the shebang/`apt.conf` fixes from the last PR worked) but every fetch failed TLS verification - "No system certificates available. Try installing ca-certificates."

The bootstrap zip already ships a real CA bundle at `etc/tls/cert.pem` (119 certs, extracted like any other regular file - nothing wrong with the file itself). On a genuine Termux install, that bundle only becomes what TLS actually consults once the `ca-certificates` package's own postinst runs `trust extract` to activate it - a dpkg step this raw zip extraction never runs, so the bundle just sits there unused. Rather than chasing that activation machinery (p11-kit, trust stores), this points apt and curl straight at the raw bundle, which both already know how to do:
- `apt.conf` now sets `Acquire::https::CaInfo` at the exact path `DistroManager` already extracts the bundle to.
- `ShellSession` sets `SSL_CERT_FILE`/`CURL_CA_BUNDLE` for every other bootstrap-tier tool that talks TLS (curl, wget, ...).

Still can't be verified end-to-end without a physical device.

## Test plan
- [x] `:shared:compileKotlinMetadata`, `:shared:compileAndroidMain`, `:composeApp:detekt`, `:shared:detektMetadataMain`, `:shared:detektAndroidMain` - clean
- [x] `:composeApp:assembleDebug` - succeeds
- [ ] On-device: `apt update`/`pkg upgrade` actually complete without TLS errors (needs a physical device)


---
_Generated by [Claude Code](https://claude.ai/code/session_018X7LN1wZoJ15zdAyTu2Riq)_

## Summary by Sourcery

Bug Fixes:
- Configure APT and bootstrap-tier network tools to verify HTTPS using the bundled CA certificate instead of relying on an uninitialized system trust store.