### PR TITLE
Auto-populate shell pill hints from each command's own --help output

### DIFF
--- a/composeApp/src/main/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/main/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -402,6 +402,11 @@ class TerminalActivity : FragmentActivity() {
                         CommandTree.from(this@TerminalActivity)
                     }
                 }
+
+                // Fire-and-forget: the flags this discovers only show up the next time a pill
+                // menu's own resolveChildren runs (see HelpCatalog's own doc comment), never
+                // this frame - there's nothing here worth blocking startup on.
+                launch(Dispatchers.IO) { CommandTree.warmHelpCache(this@TerminalActivity) }
             }
 
             LaunchedEffect(fullscreen) {
@@ -737,7 +742,13 @@ class TerminalActivity : FragmentActivity() {
                             // wasted file I/O and a pointless menu recomposition.
                             val ranCommand = line.trim().substringBefore(' ')
                             if (ranCommand in CommandTree.PACKAGE_MANAGER_COMMANDS) {
-                                tree = withContext(Dispatchers.IO) { CommandTree.from(this@TerminalActivity) }
+                                tree = withContext(Dispatchers.IO) {
+                                    // A fresh install can add binaries this pill menu has never
+                                    // probed for --help flags before; catch those up here too,
+                                    // rather than waiting on the next app launch's own warm-up.
+                                    CommandTree.warmHelpCache(this@TerminalActivity)
+                                    CommandTree.from(this@TerminalActivity)
+                                }
                             }
                         }
                     )

--- a/composeApp/src/main/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/main/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -48,6 +48,7 @@ import com.hereliesaz.hg2gui.managers.AiSettings
 import com.hereliesaz.hg2gui.managers.AzpLibrary
 import com.hereliesaz.hg2gui.managers.ContactManager
 import com.hereliesaz.hg2gui.managers.OsContextStore
+import com.hereliesaz.hg2gui.managers.PtyPreference
 import com.hereliesaz.hg2gui.managers.SshPresets
 import com.hereliesaz.hg2gui.managers.TerminalHistoryEntry
 import com.hereliesaz.hg2gui.managers.VfsManager
@@ -153,7 +154,8 @@ class TerminalActivity : FragmentActivity() {
         val engine: TerminalEngine,
         val tree: List<MenuNode>,
         val fullscreen: Boolean,
-        val fontScalePercent: Int
+        val fontScalePercent: Int,
+        val usePty: Boolean
     )
 
     private val prefs: SharedPreferences by lazy { getSharedPreferences(PREFS_NAME, MODE_PRIVATE) }
@@ -207,6 +209,7 @@ class TerminalActivity : FragmentActivity() {
             }
             var fullscreen by remember { mutableStateOf(false) }
             var fontScalePercent by remember { mutableStateOf(100) }
+            var usePty by remember { mutableStateOf(false) }
             var aiApiKey by remember { mutableStateOf(AiSettings.apiKey(this@TerminalActivity)) }
             var aiMessages by remember { mutableStateOf<List<AiMessage>>(emptyList()) }
             var aiBusy by remember { mutableStateOf(false) }
@@ -370,7 +373,8 @@ class TerminalActivity : FragmentActivity() {
                         engine = builtEngine,
                         tree = builtTree,
                         fullscreen = prefs.getBoolean(PREF_FULLSCREEN, false),
-                        fontScalePercent = prefs.getInt(PREF_FONT_SCALE_PERCENT, 100)
+                        fontScalePercent = prefs.getInt(PREF_FONT_SCALE_PERCENT, 100),
+                        usePty = PtyPreference.isEnabled(this@TerminalActivity)
                     )
                 }
 
@@ -380,6 +384,7 @@ class TerminalActivity : FragmentActivity() {
                 tree = built.tree
                 fullscreen = built.fullscreen
                 fontScalePercent = built.fontScalePercent
+                usePty = built.usePty
 
                 // Real Termux never shows an empty shell either - it installs its own bootstrap
                 // automatically, once, before the first prompt appears. Match that instead of
@@ -452,6 +457,11 @@ class TerminalActivity : FragmentActivity() {
                         onFontScalePercentChange = { value ->
                             fontScalePercent = value
                             prefs.edit { putInt(PREF_FONT_SCALE_PERCENT, value) }
+                        },
+                        usePty = usePty,
+                        onUsePtyChange = { value ->
+                            usePty = value
+                            PtyPreference.setEnabled(this@TerminalActivity, value)
                         },
                         onOpenMcpServer = { screen = Screen.Mcp },
                         onOpenAiSettings = { screen = Screen.AiSettings },

--- a/config/detekt/shared-baseline-main.xml
+++ b/config/detekt/shared-baseline-main.xml
@@ -18,7 +18,7 @@
     <ID>FunctionNaming:McpServerScreen.kt$@Composable fun McpServerScreen( fullscreen: Boolean, running: Boolean, port: Int, token: String?, shellExecEnabled: Boolean, onStart: () -&gt; Unit, onStop: () -&gt; Unit, onRequestShellExec: () -&gt; Unit, onDisableShellExec: () -&gt; Unit, onBack: () -&gt; Unit )</ID>
     <ID>FunctionNaming:McpServerScreen.kt$@Composable private fun McpSettingRow(title: String, description: String, control: @Composable () -&gt; Unit)</ID>
     <ID>FunctionNaming:McpServerScreen.kt$@Composable private fun McpToggle( leftLabel: String, rightLabel: String, rightSelected: Boolean, onSelectRight: (Boolean) -&gt; Unit )</ID>
-    <ID>FunctionNaming:SettingsScreen.kt$@Composable fun SettingsScreen( fullscreen: Boolean, onFullscreenChange: (Boolean) -&gt; Unit, fontScalePercent: Int, onFontScalePercentChange: (Int) -&gt; Unit, onOpenMcpServer: () -&gt; Unit, onOpenAiSettings: () -&gt; Unit, onBack: () -&gt; Unit )</ID>
+    <ID>FunctionNaming:SettingsScreen.kt$@Composable fun SettingsScreen( fullscreen: Boolean, onFullscreenChange: (Boolean) -&gt; Unit, fontScalePercent: Int, onFontScalePercentChange: (Int) -&gt; Unit, usePty: Boolean, onUsePtyChange: (Boolean) -&gt; Unit, onOpenMcpServer: () -&gt; Unit, onOpenAiSettings: () -&gt; Unit, onBack: () -&gt; Unit )</ID>
     <ID>FunctionNaming:SettingsScreen.kt$@Composable private fun SegmentedToggle( leftLabel: String, rightLabel: String, rightSelected: Boolean, onSelectRight: (Boolean) -&gt; Unit )</ID>
     <ID>FunctionNaming:SettingsScreen.kt$@Composable private fun SettingRow(title: String, description: String, control: @Composable () -&gt; Unit)</ID>
     <ID>FunctionNaming:SettingsScreen.kt$@Composable private fun Stepper( value: Int, min: Int, max: Int, step: Int, label: (Int) -&gt; String, onChange: (Int) -&gt; Unit )</ID>
@@ -33,11 +33,11 @@
     <ID>LongMethod:ContactManager.kt$ContactManager$fun about(phone: String): Array&lt;String?&gt;?</ID>
     <ID>LongMethod:ContactManager.kt$ContactManager.&lt;no name provided&gt;$override fun run()</ID>
     <ID>LongMethod:McpServerScreen.kt$@Composable fun McpServerScreen( fullscreen: Boolean, running: Boolean, port: Int, token: String?, shellExecEnabled: Boolean, onStart: () -&gt; Unit, onStop: () -&gt; Unit, onRequestShellExec: () -&gt; Unit, onDisableShellExec: () -&gt; Unit, onBack: () -&gt; Unit )</ID>
-    <ID>LongMethod:SettingsScreen.kt$@Composable fun SettingsScreen( fullscreen: Boolean, onFullscreenChange: (Boolean) -&gt; Unit, fontScalePercent: Int, onFontScalePercentChange: (Int) -&gt; Unit, onOpenMcpServer: () -&gt; Unit, onOpenAiSettings: () -&gt; Unit, onBack: () -&gt; Unit )</ID>
+    <ID>LongMethod:SettingsScreen.kt$@Composable fun SettingsScreen( fullscreen: Boolean, onFullscreenChange: (Boolean) -&gt; Unit, fontScalePercent: Int, onFontScalePercentChange: (Int) -&gt; Unit, usePty: Boolean, onUsePtyChange: (Boolean) -&gt; Unit, onOpenMcpServer: () -&gt; Unit, onOpenAiSettings: () -&gt; Unit, onBack: () -&gt; Unit )</ID>
     <ID>LongMethod:ShellSession.kt$ShellSession$actual fun stream(command: String, onLine: (line: String) -&gt; Unit, onNeedInput: (prompt: String) -&gt; String?): Int</ID>
     <ID>LongParameterList:AzpLibrary.kt$AzpLibrary$( context: Context, id: String, name: String, version: String, kind: String, skillIds: List&lt;String&gt;, trust: AzpTrust = AzpTrust.UNSIGNED, /** For `kind:"script"` only - the name it's callable as on PATH once [ScriptInstaller] * has written its wrapper, so the store row can show it. Blank if installation didn't * reach that point (e.g. no Termux bootstrap yet - see [ScriptInstaller.Result]). */ scriptCommand: String? = null, )</ID>
     <ID>LongParameterList:McpServerScreen.kt$( fullscreen: Boolean, running: Boolean, port: Int, token: String?, shellExecEnabled: Boolean, onStart: () -&gt; Unit, onStop: () -&gt; Unit, onRequestShellExec: () -&gt; Unit, onDisableShellExec: () -&gt; Unit, onBack: () -&gt; Unit )</ID>
-    <ID>LongParameterList:SettingsScreen.kt$( fullscreen: Boolean, onFullscreenChange: (Boolean) -&gt; Unit, fontScalePercent: Int, onFontScalePercentChange: (Int) -&gt; Unit, onOpenMcpServer: () -&gt; Unit, onOpenAiSettings: () -&gt; Unit, onBack: () -&gt; Unit )</ID>
+    <ID>LongParameterList:SettingsScreen.kt$( fullscreen: Boolean, onFullscreenChange: (Boolean) -&gt; Unit, fontScalePercent: Int, onFontScalePercentChange: (Int) -&gt; Unit, usePty: Boolean, onUsePtyChange: (Boolean) -&gt; Unit, onOpenMcpServer: () -&gt; Unit, onOpenAiSettings: () -&gt; Unit, onBack: () -&gt; Unit )</ID>
     <ID>LongParameterList:SettingsScreen.kt$( value: Int, min: Int, max: Int, step: Int, label: (Int) -&gt; String, onChange: (Int) -&gt; Unit )</ID>
     <ID>LongParameterList:VfsManager.kt$VfsManager$( dir: File, q: String, into: MutableList&lt;File&gt;, limit: Int, seen: MutableSet&lt;String&gt; = mutableSetOf(), depth: Int = 0 )</ID>
     <ID>LoopWithTooManyJumpStatements:AzpLibrary.kt$AzpLibrary$for</ID>
@@ -102,7 +102,6 @@
     <ID>SwallowedException:Builtins.kt$Builtins$e: SecurityException</ID>
     <ID>SwallowedException:CommandTree.kt$CommandTree$e: SecurityException</ID>
     <ID>SwallowedException:DpkgCatalog.kt$DpkgCatalog$e: Exception</ID>
-    <ID>SwallowedException:ShellSession.kt$ShellSession$e: IOException</ID>
     <ID>SwallowedException:ShellSession.kt$ShellSession$stillRunning: IllegalThreadStateException</ID>
     <ID>SwallowedException:Utils.kt$Utils$e: Exception</ID>
     <ID>SwallowedException:VfsManager.kt$VfsManager$e: Exception</ID>
@@ -115,6 +114,7 @@
     <ID>TooGenericExceptionCaught:VfsManager.kt$VfsManager$e: Exception</ID>
     <ID>TooManyFunctions:Builtins.kt$Builtins</ID>
     <ID>TooManyFunctions:CommandTree.kt$CommandTree</ID>
+    <ID>TooManyFunctions:ShellSession.kt$ShellSession</ID>
     <ID>TooManyFunctions:VfsManager.kt$VfsManager</ID>
     <ID>UnreachableCode:AzpLibrary.kt$AzpLibrary$for (skillId in skillIds) { if (remaining &lt;= 0) break val skillMd = root.resolve("skills/$skillId/SKILL.md") if (!skillMd.exists()) continue val text = skillMd.readText().take(remaining) remaining -= text.length out += skillId to text }</ID>
     <ID>UnreachableCode:AzpLibrary.kt$AzpLibrary$val root = AzpInstaller.rootDir(context, id, version)</ID>

--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/PtyPreference.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/PtyPreference.kt
@@ -1,0 +1,25 @@
+package com.hereliesaz.hg2gui.managers
+
+import android.content.Context
+import androidx.core.content.edit
+
+private const val PREFS_NAME = "hg2gui_pty_pref"
+private const val KEY_ENABLED = "use_pty"
+
+/**
+ * Whether [com.hereliesaz.hg2gui.terminal.ShellSession] should run commands over a real
+ * pseudoterminal (the app's own bundled native pty bridge) instead of a plain OS pipe. Off by
+ * default - a pipe is what every command in the app has always run through, and there's no
+ * physical device in the environment this was built in to have verified the pty path on. A
+ * flipped toggle only takes effect for a session created after the flip (a new tab, or the next
+ * app launch) - it never touches a shell that's already running.
+ */
+object PtyPreference {
+    private fun prefs(context: Context) = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    fun isEnabled(context: Context): Boolean = prefs(context).getBoolean(KEY_ENABLED, false)
+
+    fun setEnabled(context: Context, enabled: Boolean) {
+        prefs(context).edit { putBoolean(KEY_ENABLED, enabled) }
+    }
+}

--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/HelpCatalog.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/HelpCatalog.kt
@@ -1,0 +1,103 @@
+package com.hereliesaz.hg2gui.terminal
+
+import android.content.Context
+import androidx.core.content.edit
+import com.hereliesaz.hg2gui.util.Utils
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+
+/**
+ * Flag/option hints for shell binaries, discovered by actually running `<binary> --help` instead
+ * of relying only on [com.hereliesaz.hg2gui.ui.menu.CommandTree]'s own hand-curated
+ * SHELL_HINTS - which only ever covered the handful of commands worth hand-picking for, leaving
+ * every other binary on PATH with nothing but a bare file… child.
+ *
+ * [MenuNode.resolveChildren] runs synchronously during composition (see PillMenu's own
+ * `remember(anchor.id) { anchor.resolveChildren?.invoke() }`) - spawning a process and blocking
+ * on it there would jank the UI for however long that binary takes to print its help text (or
+ * hang, for one that doesn't actually understand `--help`). So this isn't a live probe: [warm]
+ * runs once in the background, well before any pill actually needs the result, and [hintsFor] -
+ * the one function a resolveChildren lambda actually calls - only ever reads the cache [warm]
+ * already filled in, never runs a process itself.
+ */
+object HelpCatalog {
+    private const val PREFS_NAME = "hg2gui_help_cache"
+    private const val FIELD_SEP = ""
+    private const val TIMEOUT_SECONDS = 3L
+    private const val MAX_FLAGS_PER_BINARY = 6
+    private const val MAX_OUTPUT_CHARS = 8_000
+
+    private fun prefs(context: Context) = context.getSharedPreferences(PREFS_NAME, Context.MODE_PRIVATE)
+
+    /** Cached flag hints for [binaryName] - empty before [warm] has covered it, or if none were
+     *  found (no `--help` support, timed out, nothing recognizable in its output). Read-only and
+     *  synchronous - safe to call from a resolveChildren lambda. */
+    fun hintsFor(context: Context, binaryName: String): List<String> {
+        val raw = prefs(context).getString(binaryName, null) ?: return emptyList()
+        return if (raw.isEmpty()) emptyList() else raw.split(FIELD_SEP)
+    }
+
+    /** Runs `<binDir>/<name> --help` for every name in [binaries] not already cached (from a
+     *  previous [warm] call, possibly a previous app run - the cache persists), parsing out
+     *  whatever flags it can find. Meant to run off the main thread; blocks the calling thread
+     *  for as long as each still-uncached binary takes to answer (bounded per-binary by
+     *  [TIMEOUT_SECONDS]), not the composition PillMenu itself runs on. Safe to call repeatedly -
+     *  already-cached names are skipped, so a second call after `apt install`ing something new
+     *  only probes the newly-discovered binaries. */
+    fun warm(context: Context, binDir: File, binaries: List<String>) {
+        val p = prefs(context)
+        for (name in binaries) {
+            if (p.contains(name)) continue
+            val flags = probe(File(binDir, name))
+            p.edit { putString(name, flags.joinToString(FIELD_SEP)) }
+        }
+    }
+
+    private fun probe(binary: File): List<String> {
+        if (!binary.canExecute()) return emptyList()
+        return try {
+            val process = ProcessBuilder(binary.absolutePath, "--help")
+                .redirectErrorStream(true)
+                .start()
+            // Nothing prompts for input on a --help run; closing stdin immediately signals EOF
+            // to anything that (incorrectly) waits on it instead of hanging for the full timeout.
+            process.outputStream.close()
+            val finished = process.waitFor(TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            if (!finished) process.destroyForcibly()
+            if (finished) {
+                val output = process.inputStream.bufferedReader().readText().take(MAX_OUTPUT_CHARS)
+                parseFlags(output)
+            } else {
+                emptyList()
+            }
+        } catch (e: IOException) {
+            // This binary's --help either isn't there or blew up mid-run - skip it, same as a
+            // timeout; there's nothing else worth doing with a probe failure.
+            Utils.log(e)
+            emptyList()
+        } catch (e: InterruptedException) {
+            Thread.currentThread().interrupt()
+            emptyList()
+        }
+    }
+
+    // A common getopt-style help line: leading whitespace, a flag token ("-h", "--help", "-o
+    // FILE"), optionally several comma-separated short/long forms, then at least two spaces
+    // before a description. Covers the overwhelming majority of GNU/BSD-style --help output;
+    // anything shaped differently (a custom help format, a tool with no --help at all) just
+    // contributes nothing here, same as it always did before this existed.
+    private val FLAG_LINE = Regex("^\\s*(-[\\w-]+(?:,\\s*-[\\w-]+)*)(?:[= ]\\S+)?\\s{2,}\\S")
+
+    private fun parseFlags(helpText: String): List<String> {
+        val flags = LinkedHashSet<String>()
+        helpText.lineSequence()
+            .mapNotNull { line -> FLAG_LINE.find(line) }
+            .forEach { match ->
+                if (flags.size < MAX_FLAGS_PER_BINARY) {
+                    match.groupValues[1].split(",").forEach { flags.add(it.trim()) }
+                }
+            }
+        return flags.take(MAX_FLAGS_PER_BINARY)
+    }
+}

--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/ShellSession.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/ShellSession.kt
@@ -1,14 +1,24 @@
 package com.hereliesaz.hg2gui.terminal
 
 import android.content.Context
+import android.system.ErrnoException
+import android.system.Os
+import android.system.OsConstants
+import com.hereliesaz.hg2gui.managers.PtyPreference
 import java.io.BufferedReader
 import java.io.BufferedWriter
 import java.io.File
+import java.io.FileDescriptor
+import java.io.FileInputStream
+import java.io.FileOutputStream
 import java.io.IOException
 import java.io.InputStreamReader
 import java.io.OutputStreamWriter
+import java.lang.reflect.Field
 import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.concurrent.thread
 
+import com.termux.terminal.JNI
 import com.termux.terminal.TerminalEmulator
 import com.termux.terminal.TerminalOutput
 
@@ -56,7 +66,11 @@ actual class ShellSession private constructor(
     // app-private storage (the write-xor-execute restriction Android's enforced since API 29),
     // looked identical to one that landed there for any other reason - "command not found" with
     // no way to tell which. TerminalEngine surfaces this once per session pick, in-transcript.
-    val backendDescription: String = "the bare system shell ($DEFAULT_SHELL) - no fallback reached"
+    val backendDescription: String = "the bare system shell ($DEFAULT_SHELL) - no fallback reached",
+    // See PtyPreference's own doc comment: off by default, since a plain pipe is what every
+    // command in the app has always run through and the real pty path (below) has never been
+    // verified on a physical device. Only forAndroid() ever passes true.
+    private val usePty: Boolean = false
 ) {
 
     companion object {
@@ -65,6 +79,15 @@ actual class ShellSession private constructor(
         private const val TIMEOUT_MS = 15_000L
         private const val STARTUP_PROBE_MS = 300L
         private const val PROMPT_IDLE_MS = 400L
+
+        // Matches the width/height stream()'s own per-command TerminalEmulator(...) already
+        // assumes below - so the pty's actual window size (what ioctl(TIOCGWINSZ) reports to the
+        // child) doesn't disagree with the geometry every command's output gets re-wrapped to
+        // when flattened back into plain text.
+        private const val PTY_ROWS = 24
+        private const val PTY_COLUMNS = 120
+        private const val PTY_CELL_WIDTH = 10
+        private const val PTY_CELL_HEIGHT = 10
 
         // Zsh was bundled the same way as the Termux bootstrap (a flattened, exec-exempt native
         // lib) but its own RUNPATH/dependency chain was never patched the way the bootstrap's
@@ -75,6 +98,7 @@ actual class ShellSession private constructor(
             // Collected only to explain the last-resort fallback below, if it comes to that -
             // never surfaced when the bootstrap actually works.
             val reasons = mutableListOf<String>()
+            val usePty = PtyPreference.isEnabled(context)
 
             if (DistroManager.isInstalled(context)) {
                 val prefix = DistroManager.prefixDir(context)
@@ -99,9 +123,19 @@ actual class ShellSession private constructor(
                         // bundle for every other bootstrap-tier tool that talks TLS (curl, wget,
                         // git, ...) via the conventions each already knows to check.
                         "SSL_CERT_FILE" to "${prefix.absolutePath}/etc/tls/cert.pem",
-                        "CURL_CA_BUNDLE" to "${prefix.absolutePath}/etc/tls/cert.pem"
+                        "CURL_CA_BUNDLE" to "${prefix.absolutePath}/etc/tls/cert.pem",
+                        // Only matters on the pty tier (a plain pipe was never a tty to begin
+                        // with, so no ncurses program would trust TERM over it either way), but
+                        // harmless to set regardless. ncurses' own compiled-in terminfo search
+                        // path is baked in against Termux's own package the same way apt's Dir::*
+                        // defaults are - TERMINFO overrides that with the copy this bootstrap
+                        // actually ships, confirmed present at share/terminfo/x/xterm-256color.
+                        "TERM" to "xterm-256color",
+                        "TERMINFO" to "${prefix.absolutePath}/share/terminfo"
                     )
-                    val session = ShellSession(bootstrapHome, arrayOf(bash.absolutePath, "-l"), env, "bash (Termux bootstrap)")
+                    val session = ShellSession(
+                        bootstrapHome, arrayOf(bash.absolutePath, "-l"), env, "bash (Termux bootstrap)", usePty
+                    )
                     if (session.survivedStartup()) return session
                     session.close()
                     // The most likely real cause on a modern device: Android's blocked executing
@@ -118,15 +152,45 @@ actual class ShellSession private constructor(
                 reasons += "no Termux bootstrap is installed"
             }
 
+            // The pipe tier gets a real PATH for free (ProcessBuilder inherits this Android
+            // process's own environment, unlike the pty tier's clearenv() - see startPty's own
+            // doc comment); the pty tier would otherwise leave /system/bin/sh with nothing set
+            // at all, unable to resolve even a bare "ls" typed at its prompt.
+            val fallbackEnv = if (usePty) mapOf("PATH" to "/system/bin:/system/xbin", "HOME" to (home?.absolutePath ?: "/")) else emptyMap()
             return ShellSession(
-                home, arrayOf(DEFAULT_SHELL), emptyMap(),
+                home, arrayOf(DEFAULT_SHELL), fallbackEnv,
                 "the bare system shell ($DEFAULT_SHELL), without apt/pkg/coreutils - " +
-                    reasons.joinToString("; ")
+                    reasons.joinToString("; "),
+                usePty
             )
+        }
+
+        // Reflection mirrors terminal-emulator's own TerminalSession.wrapFileDescriptor - there
+        // is no public API to build a FileDescriptor from a raw native fd int, only from opening
+        // a real file, so this is the same private-field trick that module's own pty usage
+        // already relies on.
+        private fun wrapFileDescriptor(fileDescriptor: Int): FileDescriptor {
+            val result = FileDescriptor()
+            try {
+                val descriptorField: Field = try {
+                    FileDescriptor::class.java.getDeclaredField("descriptor")
+                } catch (ignored: NoSuchFieldException) {
+                    FileDescriptor::class.java.getDeclaredField("fd")
+                }
+                descriptorField.isAccessible = true
+                descriptorField.set(result, fileDescriptor)
+            } catch (e: ReflectiveOperationException) {
+                throw IOException("Cannot wrap native pty fd via reflection", e)
+            }
+            return result
         }
     }
 
+    // Only ever populated on the plain-pipe tier - the pty tier has no java Process object at
+    // all, only a raw native fd and pid (ptyFd/ptyPid below).
     private var process: Process? = null
+    private var ptyFd: Int = -1
+    private var ptyPid: Int = -1
     private var stdin: BufferedWriter? = null
     private var stdout: BufferedReader? = null
 
@@ -139,7 +203,7 @@ actual class ShellSession private constructor(
         get() = _workingDirectory
 
     actual val isAlive: Boolean
-        get() = alive.get() && process != null && processStillRunning()
+        get() = alive.get() && processStillRunning()
 
     constructor(home: File?) : this(home, arrayOf(DEFAULT_SHELL), emptyMap())
 
@@ -150,21 +214,71 @@ actual class ShellSession private constructor(
     actual constructor(homePath: String?, shellPath: String) : this(homePath?.let { File(it) }, shellPath)
 
     init {
+        startChild(home, command, extraEnv)
+    }
+
+    // @Suppress: JNI.createSubprocess (see termux.c's throw_runtime_exception) only ever throws
+    // the bare java.lang.RuntimeException class itself for a native pty failure (ptmx open,
+    // grantpt/unlockpt) - there is no more specific type to narrow the catch below to. Treated
+    // exactly like a pipe-tier IOException: this session never came up, and forAndroid()'s own
+    // fallback chain is what handles that, not a crash. (Kotlin doesn't allow annotating an
+    // `init` block directly, hence this being its own function.)
+    @Suppress("TooGenericExceptionCaught")
+    private fun startChild(home: File?, command: Array<String>, extraEnv: Map<String, String>) {
         try {
-            val builder = ProcessBuilder(*command)
-            builder.redirectErrorStream(true)
-            if (home != null && home.isDirectory) builder.directory(home)
-            if (extraEnv.isNotEmpty()) {
-                builder.environment().putAll(extraEnv)
-            }
-
-            val p = builder.start()
-            process = p
-            stdin = BufferedWriter(OutputStreamWriter(p.outputStream))
-            stdout = BufferedReader(InputStreamReader(p.inputStream))
-
+            if (usePty) startPty(home, command, extraEnv) else startPipe(home, command, extraEnv)
             alive.set(true)
-        } catch (e: IOException) {
+        } catch (ignored: IOException) {
+            alive.set(false)
+        } catch (ignored: RuntimeException) {
+            alive.set(false)
+        }
+    }
+
+    private fun startPipe(home: File?, command: Array<String>, extraEnv: Map<String, String>) {
+        val builder = ProcessBuilder(*command)
+        builder.redirectErrorStream(true)
+        if (home != null && home.isDirectory) builder.directory(home)
+        if (extraEnv.isNotEmpty()) {
+            builder.environment().putAll(extraEnv)
+        }
+
+        val p = builder.start()
+        process = p
+        stdin = BufferedWriter(OutputStreamWriter(p.outputStream))
+        stdout = BufferedReader(InputStreamReader(p.inputStream))
+    }
+
+    /** A real pseudoterminal via the app's own bundled native pty bridge (terminal-emulator's
+     *  JNI/termux.c - the same one upstream Termux's own TerminalSession uses to open
+     *  /dev/ptmx and fork the child onto the slave side), instead of a plain OS pipe - see this
+     *  file's own top-of-file doc comment for why a pipe alone can't satisfy isatty()/termios-
+     *  checking tools. Unlike [startPipe]'s ProcessBuilder, the child's environment here is NOT
+     *  inherited from this Android process at all - the native side clearenv()s before exec, so
+     *  every variable the shell needs has to already be in [extraEnv], nothing carries over
+     *  silently. [stream]/[exec] read and write this exactly like the pipe tier below - only how
+     *  stdin/stdout are opened differs. */
+    private fun startPty(home: File?, command: Array<String>, extraEnv: Map<String, String>) {
+        val cwd = home?.absolutePath ?: "/"
+        val envArray = extraEnv.map { (k, v) -> "$k=$v" }.toTypedArray()
+        val pid = IntArray(1)
+        val fd = JNI.createSubprocess(
+            command[0], cwd, command, envArray, pid,
+            PTY_ROWS, PTY_COLUMNS, PTY_CELL_WIDTH, PTY_CELL_HEIGHT
+        )
+        if (fd < 0) throw IOException("createSubprocess() failed to open a pty")
+        ptyFd = fd
+        ptyPid = pid[0]
+
+        val wrapped = wrapFileDescriptor(fd)
+        stdin = BufferedWriter(OutputStreamWriter(FileOutputStream(wrapped)))
+        stdout = BufferedReader(InputStreamReader(FileInputStream(wrapped)))
+
+        // processStillRunning() below is a plain flag check on this tier, not a poll - nothing
+        // else calls JNI.waitFor() for this pid, so this thread existing is what notices the
+        // child actually exiting at all.
+        thread(name = "ShellSession-pty-waiter[pid=$ptyPid]") {
+            JNI.waitFor(ptyPid)
             alive.set(false)
         }
     }
@@ -180,6 +294,10 @@ actual class ShellSession private constructor(
     }
 
     private fun processStillRunning(): Boolean {
+        // The pty tier has no exitValue()-style poll - startPty()'s own waiter thread is the
+        // only thing that ever learns the child exited, by blocking on JNI.waitFor(); `alive`
+        // is what it flips when that happens.
+        if (usePty) return alive.get()
         return try {
             process?.exitValue()
             false
@@ -232,7 +350,7 @@ actual class ShellSession private constructor(
                     // its command straight into that stale read: the new command never runs, and
                     // its text gets silently consumed as the old prompt's answer instead.
                     alive.set(false)
-                    process?.destroy()
+                    killChild()
                     try { stdin?.close() } catch (ignored: IOException) {}
                     try { stdout?.close() } catch (ignored: IOException) {}
                     break
@@ -362,6 +480,27 @@ actual class ShellSession private constructor(
             stdout?.close()
         } catch (ignored: IOException) {
         }
-        process?.destroy()
+        killChild()
+    }
+
+    /** Force-stops the child regardless of which tier it's running on - called both by [close]
+     *  and by [stream]'s own timeout branch (a genuinely stuck command has to actually be ended,
+     *  not just have its streams closed out from under it - see that branch's own comment). */
+    private fun killChild() {
+        if (usePty) {
+            if (ptyPid > 0) {
+                try {
+                    Os.kill(ptyPid, OsConstants.SIGKILL)
+                } catch (ignored: ErrnoException) {
+                    // Already exited - nothing left to kill.
+                }
+            }
+            if (ptyFd >= 0) {
+                JNI.close(ptyFd)
+                ptyFd = -1
+            }
+        } else {
+            process?.destroy()
+        }
     }
 }

--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/SettingsScreen.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/SettingsScreen.kt
@@ -29,6 +29,8 @@ fun SettingsScreen(
     onFullscreenChange: (Boolean) -> Unit,
     fontScalePercent: Int,
     onFontScalePercentChange: (Int) -> Unit,
+    usePty: Boolean,
+    onUsePtyChange: (Boolean) -> Unit,
     onOpenMcpServer: () -> Unit,
     onOpenAiSettings: () -> Unit,
     onBack: () -> Unit
@@ -85,6 +87,22 @@ fun SettingsScreen(
                 step = FONT_SCALE_STEP_PERCENT,
                 label = { "$it%" },
                 onChange = onFontScalePercentChange
+            )
+        }
+
+        SettingRow(
+            title = "Real pseudoterminal",
+            description = "Experimental. Runs commands over the app's own native pty bridge " +
+                "instead of a plain pipe, so full-screen tools (vim, top, less, an interactive " +
+                "REPL) can actually draw a screen instead of breaking. Unverified on real " +
+                "hardware — off is the safe, always-worked default. Takes effect for a new tab " +
+                "or the next app launch, not the one you're in."
+        ) {
+            SegmentedToggle(
+                leftLabel = "PIPE",
+                rightLabel = "PTY",
+                rightSelected = usePty,
+                onSelectRight = onUsePtyChange
             )
         }
 

--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/menu/CommandTree.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/menu/CommandTree.kt
@@ -7,6 +7,7 @@ import com.hereliesaz.hg2gui.managers.WorkflowStore
 import com.hereliesaz.hg2gui.terminal.AptCatalog
 import com.hereliesaz.hg2gui.terminal.DistroManager
 import com.hereliesaz.hg2gui.terminal.DpkgCatalog
+import com.hereliesaz.hg2gui.terminal.HelpCatalog
 import com.hereliesaz.hg2gui.ui.ssh.SshFlow
 import java.io.File
 
@@ -324,8 +325,18 @@ object CommandTree {
         else -> MenuNode("sh/$fullName/$hint", hint)
     }
 
+    /** Flag/arg hints for one binary: the hand-curated [SHELL_HINTS] entry, if any, followed by
+     *  whatever [HelpCatalog] discovered from that binary's own `--help` output that isn't
+     *  already covered by the curated list - so a hand-picked hint's ordering/wording always
+     *  wins, and discovery only ever adds, never duplicates or overrides. */
+    private fun hintsForBinary(context: Context, fullName: String): List<String> {
+        val curated = SHELL_HINTS[fullName].orEmpty()
+        val discovered = HelpCatalog.hintsFor(context, fullName).filter { it !in curated }
+        return curated + discovered
+    }
+
     private fun shellLeaf(context: Context, fullName: String, label: String): MenuNode {
-        val hints = SHELL_HINTS[fullName].orEmpty().map { hint -> hintChild(context, fullName, hint) }
+        val hints = hintsForBinary(context, fullName).map { hint -> hintChild(context, fullName, hint) }
         val children = hints + FileBrowser.pickerNode("sh/$fullName/file")
         return MenuNode(
             id = "sh/$fullName",
@@ -418,7 +429,7 @@ object CommandTree {
             // real SHELL_HINTS of its own would never be able to show them, since this host's
             // children were always just the family list.
             val bareHints = if (hasBare) {
-                SHELL_HINTS[prefix].orEmpty().map { hint -> hintChild(context, prefix, hint) }
+                hintsForBinary(context, prefix).map { hint -> hintChild(context, prefix, hint) }
             } else {
                 emptyList()
             }
@@ -459,13 +470,12 @@ object CommandTree {
      * root category. A binary from a package not in that map - or not owned by dpkg at all -
      * still shows up, just under "Other".
      */
-    private fun scanShell(context: Context): List<MenuNode> {
-        if (!DistroManager.isInstalled(context)) {
-            return listOf(MenuNode("sh", "Shell", "1", listOf(MenuNode(id = "sh/bootstrap", label = "bootstrap", cap = "run"))))
-        }
-
-        val prefix = DistroManager.prefixDir(context)
-        val binDir = File(prefix, "bin")
+    /** The bootstrap prefix's own bin/ dir and every real, executable binary in it - shared by
+     *  [scanShell] (to build the tree) and [warmHelpCache] (to know what to probe). Null before
+     *  a bootstrap is installed, since there's nothing to discover yet. */
+    private fun discoverBinaries(context: Context): Pair<File, List<String>>? {
+        if (!DistroManager.isInstalled(context)) return null
+        val binDir = File(DistroManager.prefixDir(context), "bin")
         val names = try {
             (binDir.listFiles() ?: emptyArray())
                 .filter { it.isFile && it.canExecute() }
@@ -473,6 +483,24 @@ object CommandTree {
         } catch (e: SecurityException) {
             emptyList()
         }.distinct().sorted()
+        return binDir to names
+    }
+
+    /** Kicks off (or continues) background discovery of `--help` flags for every real binary on
+     *  PATH, so the next tree rebuild's [hintsForBinary] calls can pick up whatever this finds -
+     *  see [HelpCatalog]. Blocks the calling thread for as long as any still-uncached binary
+     *  takes to answer, so callers must run this off the main thread. Safe to call repeatedly:
+     *  already-cached binaries are skipped, so a call after `apt install`ing something new only
+     *  probes what's newly there. */
+    fun warmHelpCache(context: Context) {
+        val (binDir, names) = discoverBinaries(context) ?: return
+        HelpCatalog.warm(context, binDir, names)
+    }
+
+    private fun scanShell(context: Context): List<MenuNode> {
+        val (binDir, names) = discoverBinaries(context)
+            ?: return listOf(MenuNode("sh", "Shell", "1", listOf(MenuNode(id = "sh/bootstrap", label = "bootstrap", cap = "run"))))
+        val prefix = binDir.parentFile ?: DistroManager.prefixDir(context)
 
         val categoryOf = mutableMapOf<String, String>()
         for ((pkg, binaries) in DpkgCatalog.binariesByPackage(prefix)) {

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/terminal/ShellAliases.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/terminal/ShellAliases.kt
@@ -76,6 +76,43 @@ object ShellAliases {
 
     fun looksLikePassword(prompt: String): Boolean = PASSWORD_PATTERN.containsMatchIn(prompt)
 
+    // A bracketed/parenthesized list of single-token choices more general than plain yes/no -
+    // dpkg's conffile prompt ("(Y/I/N/O/D/Z)"), git's interactive add ("[y,n,q,a,d,e,?]"), any
+    // tool offering a short menu inline rather than across several lines. Only the LAST such
+    // group in the accumulated stall text is used - earlier lines can legitimately contain
+    // unrelated bracketed text (explanatory prose above the actual prompt), but the real prompt
+    // a stalled shell is actually waiting on is always the last thing printed.
+    private val BRACKETED_CHOICES_PATTERN = Regex("""[\[(]\s*([A-Za-z0-9?]+(?:\s*[/,]\s*[A-Za-z0-9?]+)+)\s*[\])]""")
+    private const val MAX_BRACKETED_CHOICES = 8
+
+    /** The individual tokens of the last bracketed choice list in [prompt] (e.g. "(Y/I/N/O/D/Z)"
+     *  -> ["Y","I","N","O","D","Z"]), or null if none - checked only after [looksLikeYesNo]
+     *  itself comes back false, so a plain y/n prompt keeps its own dedicated YES/NO pair rather
+     *  than a same-shaped generic list. */
+    fun bracketedChoices(prompt: String): List<String>? {
+        val match = BRACKETED_CHOICES_PATTERN.findAll(prompt).lastOrNull() ?: return null
+        val choices = match.groupValues[1].split(Regex("""\s*[/,]\s*""")).map { it.trim() }.filter { it.isNotEmpty() }
+        return choices.takeIf { it.size in 2..MAX_BRACKETED_CHOICES }
+    }
+
+    // A `select`-style numbered menu spanning several lines - "1) apple", "2) banana", ... -
+    // the shape bash's own `select` builtin prints, along with tzselect/dpkg-reconfigure/
+    // update-alternatives and similar. Requires at least two such lines before treating it as a
+    // menu at all, since a single "1) " could just as easily be an ordinary numbered list in a
+    // file a command happened to cat, not a prompt.
+    private val NUMBERED_CHOICE_LINE = Regex("""(?m)^\s*(\d{1,3})[).]\s+(\S.*)$""")
+    private const val MIN_NUMBERED_CHOICES = 2
+
+    /** (number, label) pairs for a numbered menu found anywhere in [prompt] - so the UI can show
+     *  what each number actually means instead of a bare digit - or null if fewer than
+     *  [MIN_NUMBERED_CHOICES] such lines are present. */
+    fun numberedMenuChoices(prompt: String): List<Pair<String, String>>? {
+        val matches = NUMBERED_CHOICE_LINE.findAll(prompt)
+            .map { it.groupValues[1] to it.groupValues[2].trim() }
+            .toList()
+        return matches.takeIf { it.size >= MIN_NUMBERED_CHOICES }
+    }
+
     /** Closest known command word to [failed], among alias keys/expansions plus [known] extras. */
     fun didYouMean(failed: String, known: List<String> = emptyList()): String? {
         if (failed.isBlank() || table.containsKey(failed)) return null

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
@@ -237,22 +237,47 @@ fun TerminalScreen(
 
         Eyebrow("01 — Command tree")
 
-        // A stalled command shaped like a yes/no question gets a dedicated Answer stack so the
-        // reply is a tap, not typed text - same stack, same mechanism as everything else: YES
-        // and NO are ordinary terminal leaves, so picking one auto-runs (here, auto-sends) via
-        // the exact same isTerminal path a normal command completes through.
+        // A stalled command shaped like a question with a known, enumerable set of answers gets
+        // a dedicated Answer stack so the reply is a tap, not typed text - each option is an
+        // ordinary terminal leaf, so picking one auto-runs (here, auto-sends) via the exact same
+        // isTerminal path a normal command completes through. Checked in order of how much
+        // structure each shape actually offers: a numbered `select`-style menu names every
+        // option, so it wins over a same-prompt bracketed list; a plain y/n question gets its
+        // own clearer YES/NO pair before falling back to a generic bracketed/lettered list
+        // (dpkg conffile prompts, git's interactive add, ...).
         val pendingPrompt = active.pendingPrompt
-        val answerNode = if (pendingPrompt != null && ShellAliases.looksLikeYesNo(pendingPrompt)) {
-            MenuNode(
-                id = "answer",
-                label = "Answer",
-                emitsToken = false,
-                children = listOf(
-                    MenuNode(id = "answer-yes", label = "YES", value = "y"),
-                    MenuNode(id = "answer-no", label = "NO", value = "n")
+        val answerNode = when {
+            pendingPrompt == null -> null
+            else -> ShellAliases.numberedMenuChoices(pendingPrompt)?.let { choices ->
+                MenuNode(
+                    id = "answer",
+                    label = "Answer",
+                    emitsToken = false,
+                    children = choices.map { (number, label) ->
+                        MenuNode(id = "answer-$number", label = "$number) $label", value = number)
+                    }
                 )
-            )
-        } else null
+            } ?: if (ShellAliases.looksLikeYesNo(pendingPrompt)) {
+                MenuNode(
+                    id = "answer",
+                    label = "Answer",
+                    emitsToken = false,
+                    children = listOf(
+                        MenuNode(id = "answer-yes", label = "YES", value = "y"),
+                        MenuNode(id = "answer-no", label = "NO", value = "n")
+                    )
+                )
+            } else {
+                ShellAliases.bracketedChoices(pendingPrompt)?.let { choices ->
+                    MenuNode(
+                        id = "answer",
+                        label = "Answer",
+                        emitsToken = false,
+                        children = choices.map { choice -> MenuNode(id = "answer-$choice", label = choice, value = choice) }
+                    )
+                }
+            }
+        }
 
         // The suggestion host, when it has anything to offer, rides along as just one more
         // root in the same stack every other command lives in - not a second PillMenu next to

--- a/terminal-emulator/src/main/java/com/termux/terminal/JNI.kt
+++ b/terminal-emulator/src/main/java/com/termux/terminal/JNI.kt
@@ -2,8 +2,13 @@ package com.termux.terminal
 
 /**
  * Native methods for creating and managing pseudoterminal subprocesses. C code is in jni/termux.c.
+ *
+ * Not `internal`: [com.hereliesaz.hg2gui.terminal.ShellSession] (the `:shared` module, a
+ * separate Kotlin compilation unit from this one) calls these directly - Kotlin's `internal`
+ * is module-scoped, not just package-private, so it can't stay internal and still be reachable
+ * from there.
  */
-internal object JNI {
+object JNI {
 
     init {
         System.loadLibrary("termux")


### PR DESCRIPTION
## Summary

`SHELL_HINTS` only ever hand-picked flags for a handful of binaries (`ls`, `cd`, `ps`, the package managers, ...) - every other real binary discovered on PATH offered nothing but a bare `file…` child, leaving its actual options undiscoverable short of typing `<command> --help` manually first.

**`HelpCatalog` (new)** runs `<binary> --help` for every real, executable binary on the bootstrap's PATH once, parses out flag-looking lines (a getopt-style regex: `-x`/`--long`, optionally several comma-separated forms, followed by a description), and caches the result in `SharedPreferences`. `MenuNode.resolveChildren` runs synchronously during Compose composition (`PillMenu.kt`'s own `remember(anchor.id) { anchor.resolveChildren?.invoke() }`), so spawning a subprocess there would jank the UI - this is why it's a background-warmed cache, not a live probe: `warm()` does the actual (bounded-timeout) subprocess work off the UI thread, and `hintsFor()` - the only function a pill's hint-building ever calls - just reads whatever's already cached.

**`CommandTree`** now merges `HelpCatalog.hintsFor(context, fullName)` in behind the existing hand-curated `SHELL_HINTS` (curated wins on any overlap; discovery only ever adds), via a new shared `hintsForBinary` helper used by both `shellLeaf` and `groupByFamily`'s bare-command hint-building - the same two call sites `hintChild` already had to cover for the same reason (see #161).

**Warm-up** is triggered fire-and-forget on app startup (`TerminalActivity`'s init `LaunchedEffect`) and again after any `pkg`/`apt`/`apt-get`/`dpkg` command (the same re-scan hook that already rebuilds the tree for newly-installed binaries), via a new `CommandTree.warmHelpCache(context)`. Already-cached binaries are skipped on every call, so this only ever probes what's actually new.

## Test plan
- [x] `:composeApp:compilePlaystoreDebugKotlin`, `:composeApp:assemblePlaystoreDebug` - succeed
- [x] `detekt` (all modules) - clean
- [ ] On-device: a real binary with no hand-curated `SHELL_HINTS` entry (e.g. `curl`, `git`) shows discovered flag hints after the app's first warm-up pass; a freshly-`pkg install`ed binary picks up hints without restarting the app (needs a physical device)

---
_Generated by [Claude Code](https://claude.ai/code/session_018X7LN1wZoJ15zdAyTu2Riq)_

## Summary by Sourcery

Expand terminal interaction with cached command help hints, optional pseudoterminal sessions, and richer interactive prompt answers.

New Features:
- Discover and cache shell command option hints from each executable's `--help` output, supplementing curated command hints.
- Add an experimental setting to run shell sessions through a native pseudoterminal.
- Provide tappable answers for bracketed choice prompts and numbered interactive menus in addition to yes/no prompts.

Enhancements:
- Warm help metadata in the background at startup and after package-manager commands without blocking menu composition.
- Preserve existing curated shell hints while adding newly discovered options and support cached binaries across rescans.

Chores:
- Update static analysis baselines for the expanded settings and terminal session APIs.