### PR TITLE
Fix inverted pill-stack scroll bounds; bring core docs up to date

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,23 @@ Inspired by the *Hitchhiker's Guide to the Galaxy* (2005) aesthetic and built on
     bookkeeping, and grouped into a category (Package management, Network, Development, …) —
     `pkg install python` and it shows up as a pill the next time a command finishes, no restart
     needed. Hyphenated command families (`apt-get`, `apt-key`, `apt-mark`, …) nest under one
-    shared parent pill instead of cluttering the list as unrelated flat entries.
+    shared parent pill instead of cluttering the list as unrelated flat entries. Beyond a small
+    hand-curated set, every real binary on PATH also gets its own `--help` output probed once in
+    the background and parsed into tappable flag pills, so typing a flag from memory is the
+    exception, not the rule.
+*   **Browse what's installable, don't type it blind.** The `install` pill under `apt`/`apt-get`/
+    `pkg` drills into a categorized, scrollable catalog parsed from `apt update`'s own downloaded
+    package index — Libraries, Networking, Python, Development headers, and so on — instead of
+    demanding a package name you already have to know.
 *   **A graphical file picker.** Any command that takes a file argument gets a `file…` pill that
     opens a graphical Select File/Folder screen from the settled pill crumb — no typing a path by
     hand.
-*   **Interactive prompts, answered graphically.** A command that stops mid-run to ask a
-    yes/no question gets a dedicated **Answer** stack (`YES`/`NO`) instead of leaving you to
-    type a blind reply; anything else falls back to the input field, whose Run button becomes
+*   **Interactive prompts, answered graphically.** A command that stops mid-run to ask something
+    gets a tap-only reply whenever the shape of the question allows it: a yes/no question gets a
+    dedicated **Answer** stack (`YES`/`NO`), a `select`-style numbered menu gets one pill per
+    option (labelled, not just numbered), and a bracketed/comma-separated choice list (dpkg's own
+    conffile prompt, git's interactive add, …) gets one pill per token. A password prompt masks
+    the input field instead; anything else falls back to a plain field, whose Run button becomes
     Send.
 *   **Kotlin-native suggestions.** Autosuggestion (from history), "did you mean" (after a failed
     command), and alias hints (`gs` for `git status`, and friends) surface as ordinary pills,
@@ -45,6 +55,25 @@ Inspired by the *Hitchhiker's Guide to the Galaxy* (2005) aesthetic and built on
 *   **The Guide.** A chaptered glossary of real commands paired with invented, Hitchhiker's-
     Guide-style definitions, reachable from the command picker — reading material, not another
     way to run something.
+*   **SSH presets.** The `ssh` pill (under Network) opens saved connections plus a **new…**
+    wizard that collects host/user/port/key one step at a time and drops the assembled command
+    on the line to review. Host-key and password prompts reuse the same interactive-prompt
+    machinery every other command gets.
+*   **Workflows.** Save a command template with `{placeholder}` slots; running it asks for each
+    placeholder's value, then drops the assembled command on the line — nothing runs on its own.
+*   **AI chat.** A natural-language-to-command suggestion screen (your own Anthropic API key,
+    set in Settings). It proposes, optionally with a per-flag breakdown; a **USE ▸** pill is the
+    only thing that ever puts a suggestion on the command line.
+*   **The Store.** A browser for [azphalt.store](https://azphalt.store)'s `.azp` package
+    registry — skills, MCP-server headers, code, packs, companion apps, scripts. Every install is
+    path-contained, SHA-256-checked against its manifest, and Ed25519-signature-verified.
+*   **MCP server.** An optional, loopback-only, explicit-start server (Settings → MCP SERVER) a
+    paired external AI agent can use to read/write this app's sandboxed files. Running real shell
+    commands through it is a second, biometric-gated switch, off by default.
+*   **An experimental real pseudoterminal.** Off by default (Settings → Real pseudoterminal):
+    swaps the plain-pipe shell backend for the app's own bundled native pty bridge, so full-screen
+    tools (`vim`, `top`, `less`, an interactive REPL) can draw a real screen instead of breaking.
+    Unverified on real hardware — the always-worked plain pipe stays the default.
 
 ## Interface
 
@@ -55,51 +84,62 @@ cascades its children upward from it. Output arrives in a record tile, not a scr
 
 ## Project structure
 
-Kotlin Multiplatform (Compose) for the UI and execution layer. There is no separate command
-framework: the eleven built-ins are a fixed dispatch table (`terminal/Builtins.kt`), not a
+Kotlin Multiplatform (Compose): `:composeApp` is a thin Android entry point, and the actual UI
+and execution layer live in a separate `:shared` module. There is no separate command framework:
+the eleven built-ins are a fixed dispatch table (`terminal/Builtins.kt`), not a
 reflection-discovered plugin system.
 
-*   `composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/`
+*   `shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/`
     *   `terminal/ShellSession.kt` — the `expect` shell-session contract, plus
-        `ShellAliases.kt` — Kotlin-native alias expansion, history autosuggestion and "did you
-        mean", implemented here rather than as a shell plugin because there's no live PTY for a
-        real shell line editor to attach to.
+        `ShellAliases.kt` — Kotlin-native alias expansion, history autosuggestion, "did you
+        mean", and interactive-prompt shape detection (yes/no, bracketed choice, numbered menu,
+        password), implemented here rather than as a shell plugin because there's no live PTY by
+        default for a real shell line editor to attach to.
     *   `util/CalculationEngine.kt` — the expression parser behind `calc`.
     *   `ui/` — Compose UI. `TerminalScreen.kt` (the terminal), `SessionUiState.kt` (per-session
         state, including the pending-prompt hand-off for interactive commands), `ui/editor/` (the
-        `edit` command's text editor screen), `ui/files/` (the `vfs` sandbox's file manager —
-        `FilesScreen.kt`'s nested-accordion browser, `FolderPicker.kt`'s tile/rod/panel Move/Copy
-        destination picker, `StorageScreen.kt`), `ui/guide/` (`CommandGuideScreen.kt`'s command
-        picker, nesting `GuideReaderScreen.kt` and its content in `GuideContent.kt`).
+        `edit` command's text editor screen), `ui/files/` (the `vfs` sandbox's file manager),
+        `ui/guide/` (the command glossary reader), `ui/ssh/` (the ssh connection wizard),
+        `ui/ai/` (the AI chat screen), `ui/azp/` (the Store browser).
     *   `ui/menu/PillMenu.kt` — the suggestion tree and its choreography. `MenuNode` supports
         lazily-resolved children (`resolveChildren`) for live data, like a directory listing.
-*   `composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/`
-    *   `TerminalActivity.kt` — the entry point. `EditorActivity.kt` — hosts the `edit` screen,
-        and is also the target of another app's VIEW/EDIT intent on a text file.
+*   `shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/`
     *   `terminal/` — execution. `ShellSession.kt` (the `actual` implementation: a long-lived
         shell framed by a sentinel that reports exit status and working directory, with
-        idle-based detection of a stalled interactive prompt), `TerminalEngine.kt` (routes a
-        line to a built-in, the bootstrap installer, or the shell), `Builtins.kt` (the eleven
-        built-ins: system toggles, `call`/`contacts`, `vfs`, `calc`, `edit`), `DistroManager.kt`
-        (downloads and extracts the real Termux bootstrap), `DpkgCatalog.kt` (reads dpkg's own
-        bookkeeping for which package owns a given binary — Termux's packages carry no Debian
-        Section field to read a category from directly, so `CommandTree`'s own hand-curated map
-        turns package into category).
+        idle-based detection of a stalled interactive prompt — plain pipe by default, an
+        experimental real pty behind a Settings toggle), `TerminalEngine.kt` (routes a line to a
+        built-in, the bootstrap installer, or the shell), `Builtins.kt` (the eleven built-ins:
+        system toggles, `call`/`contacts`, `vfs`, `calc`, `edit`), `DistroManager.kt` (downloads
+        and extracts the real Termux bootstrap), `DpkgCatalog.kt` (which package owns an
+        installed binary, from dpkg's own bookkeeping), `AptCatalog.kt` (everything `apt install`
+        could install, parsed from `apt update`'s own downloaded index, for the browsable install
+        catalog), `HelpCatalog.kt` (background-probes each binary's own `--help` output for flag
+        hints beyond the hand-curated list).
     *   `ui/menu/CommandTree.kt` — builds the tree: the eleven built-ins into Device / Apps & nav /
         Features, real PATH binaries by category (Package management, Network, Development, …)
         with hyphenated command families (`apt-get`/`apt-key`/…) nested under their shared
         parent.
     *   `ui/menu/FileBrowser.kt` — the in-stack graphical file picker.
+    *   `ai/AiClient.kt` — the AI chat's Anthropic API client. `azp/` — the azphalt Store client
+        (search, download, signature verification, dependency-resolving script installs).
+    *   `mcp/` — the MCP server's JSON-RPC protocol and tool registry (`vfs.*`/`shell.*`).
     *   `managers/` — `ContactManager.kt` (contacts, for `call`/`contacts`), `VfsManager.kt` (the
-        sandboxed filesystem `vfs` and the Files screen operate on), `flashlight/` (the torch
-        implementation behind `flash`).
+        sandboxed filesystem `vfs` and the Files screen operate on), `SshPresets.kt`/
+        `WorkflowStore.kt`/`AzpLibrary.kt` (flat-`SharedPreferences` stores), `PtyPreference.kt`
+        (the real-pty toggle), `flashlight/` (the torch implementation behind `flash`).
     *   `util/` — the handful of shared helpers (logging, crash reporting, the interactive-shell
         wrapper, `GenericFileProvider`) still in use.
-*   `composeApp/src/androidMain/res/` — resources. Jost lives in `res/font/`.
-*   `terminal-emulator/` — the headless VT100 parser used to normalize shell output. Shell
-    processes still use ordinary `ProcessBuilder` pipes, not a PTY.
-*   `termux-shared/` — the Android library shared with the app for Termux-compatible filesystem,
-    process, and terminal utilities; it depends on `terminal-emulator`.
+*   `composeApp/src/main/kotlin/com/hereliesaz/hg2gui/` — `TerminalActivity.kt` (the entry point
+    and all top-level screen/state wiring), `EditorActivity.kt` (hosts the `edit` screen, and is
+    also the target of another app's VIEW/EDIT intent on a text file), `mcp/McpServerService.kt`
+    (the MCP server's foreground `Service`).
+*   `composeApp/src/main/res/` — resources. Jost lives in `res/font/`.
+*   `terminal-emulator/` — a vendored VT100 parser plus a native pty JNI bridge
+    (`JNI.kt`/`jni/termux.c`, the same one upstream Termux's own `TerminalSession` uses). The
+    VT100 parser flattens shell output on every command regardless of backend; the pty bridge
+    itself is only live when the experimental real-pty setting is on.
+*   `termux-shared/` — a vendored Termux-compatible Android utility library; present as a build
+    dependency but not currently called by any HG2Gui-authored code.
 
 ## Build
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,10 +1,12 @@
 # Architecture
 
-**Current version:** 0.6.50.211
+**Current version:** 0.7.28 build 299 (`version.properties`)
 
 HG2Gui is an Android **terminal application** — not a launcher. The UI and execution layer are
 Kotlin Multiplatform (Compose); there is no separate reflection-based command framework. Built-in
-commands are a fixed dispatch table in `terminal/Builtins.kt`.
+commands are a fixed dispatch table in `terminal/Builtins.kt`. `:shared` currently builds for
+Android only (no other KMP targets are declared) — "multiplatform" here names the tooling/module
+split (a thin `:composeApp` entry point over shared UI/logic), not a live cross-platform target.
 
 ## Core Components
 
@@ -20,21 +22,35 @@ The entry point.
 
 ### 2. Execution layer (`terminal/`)
 *   `ShellSession.kt` — an `expect`/`actual` pair (`commonMain`/`androidMain`). The Android
-    `actual` picks the best of three shell tiers in order: a bundled static `zsh` binary, a real
-    Termux bootstrap (see `DistroManager` below) if one is installed, or bare `/system/bin/sh`
-    as the last resort. Whichever wins is kept alive for the life of the session so `cd` and
-    exported variables persist. Commands are framed by a sentinel the shell echoes after each
-    line, carrying `$?` and `$PWD`. Output is read as a raw buffer, not line-by-line — a real
-    prompt (`Overwrite file? [y/N] `) never prints its own trailing newline while it waits, so
-    an idle gap with an unterminated tail is treated as a live prompt and surfaced through
-    `stream`'s `onNeedInput` callback rather than blocking forever. There is still no pty: no
-    job control, no cursor addressing, and full-screen programs will not behave — which is
-    exactly why `edit` exists as a separate Compose screen rather than trying to run `nano`
-    through this.
+    `actual` prefers a real Termux bootstrap (see `DistroManager` below) if one is installed,
+    falling back to bare `/system/bin/sh` as the last resort. Whichever wins is kept alive for
+    the life of the session so `cd` and exported variables persist. Commands are framed by a
+    sentinel the shell echoes after each line, carrying `$?` and `$PWD`. Output is read as a raw
+    buffer, not line-by-line — a real prompt (`Overwrite file? [y/N] `) never prints its own
+    trailing newline while it waits, so an idle gap with an unterminated tail is treated as a
+    live prompt and surfaced through `stream`'s `onNeedInput` callback rather than blocking
+    forever. The default backend is a plain `ProcessBuilder` pipe: no job control, no cursor
+    addressing, full-screen programs will not behave — which is exactly why `edit` exists as a
+    separate Compose screen rather than trying to run `nano` through this. An experimental,
+    off-by-default Settings toggle (`PtyPreference`) swaps this for the app's own bundled native
+    pty bridge (`:terminal-emulator`'s `JNI.kt`) instead; unverified on real hardware, so the
+    pipe stays the default.
 *   `DistroManager.kt` (`androidMain`) — downloads and extracts the real Termux bootstrap: the
     same rootfs zip archive the official Termux app installs, giving genuine `bash`, `apt`/
     `pkg`, and coreutils. Runs automatically on first launch (see `TerminalActivity`) and can
-    also be triggered by hand via the `bootstrap` verb.
+    also be triggered by hand via the `bootstrap` verb. Also symlinks the bootstrap's main-repo
+    APT keyring, writes a custom `apt.conf` pointing every `Dir::*` setting at this app's real
+    prefix, rewrites hardcoded-Termux-package shebangs, and writes a bash-function wrapper
+    profile so bootstrap-shipped shell scripts (which can't use Android's exec-exemption trick)
+    still run via `source`.
+*   `AptCatalog.kt` (`androidMain`) — everything `apt install` could install, not just what's on
+    disk: parsed from `apt update`'s own downloaded `var/lib/apt/lists/*_Packages` index and
+    heuristically categorized by name/description (Termux's repo carries no Section/Tag
+    metadata). Backs the `install` pill's browsable catalog under `apt`/`apt-get`/`pkg`.
+*   `HelpCatalog.kt` (`androidMain`) — background-probes each real binary on PATH with
+    `<binary> --help` (bounded timeout, cached in `SharedPreferences`) to discover flag hints
+    beyond `CommandTree`'s hand-curated `SHELL_HINTS` list. Read-only and synchronous at
+    pill-composition time; the actual probing runs off-thread.
 *   `Builtins.kt` — the eleven commands the real shell has no path to: `wifi`, `bluetooth`,
     `airplane`, `flash`, `volume`, `brightness` (system toggles with no shell binary behind
     them), `call`/`contacts` (via `ContactManager`), `vfs` (the sandboxed filesystem, see below),
@@ -48,9 +64,13 @@ The entry point.
     already runs on a background dispatcher.
 *   `ShellAliases.kt` (`commonMain`) — Kotlin-native replacements for what a live shell line
     editor would offer (autosuggestion, "did you mean", alias hints), since `ShellSession` sends
-    one complete line at a time and reads one complete result back — there's no live PTY for a
-    real line editor to attach to. Surfaced through `TerminalScreen` as an ordinary `MenuNode`
-    host+children, rendered by the same `PillMenu` every other command uses.
+    one complete line at a time and reads one complete result back by default — there's no live
+    PTY for a real line editor to attach to unless the experimental pty setting is on. Also
+    detects the *shape* of a stalled interactive prompt (yes/no, a bracketed/comma-separated
+    choice list, a `select`-style numbered menu, a password field) so `TerminalScreen` can offer
+    a tap-only reply instead of a text field wherever the shape allows it. Surfaced through
+    `TerminalScreen` as an ordinary `MenuNode` host+children, rendered by the same `PillMenu`
+    every other command uses.
 
 Sessions are one `ShellSession` + `TerminalEngine` pair each, so scrollback, command history and
 working directory never leak between tabs. `TerminalActivity` owns the list and switches which
@@ -109,28 +129,44 @@ Compose. A screen is a function of state; there is no view-hierarchy manager cla
 
 ## Package Structure (`com.hereliesaz.hg2gui`)
 
-*   **root**: `TerminalActivity`, `EditorActivity` — the only two activities.
-*   **`ui/`**: Compose UI and the pill menu, `ui/editor/`, `ui/files/`.
+*   **`composeApp` root**: `TerminalActivity`, `EditorActivity` — the only two activities — plus
+    `mcp/McpServerService.kt`, the MCP server's foreground `Service`. Everything else below lives
+    in the separate `:shared` module (`commonMain`/`androidMain`).
+*   **`ui/`**: Compose UI and the pill menu, `ui/editor/`, `ui/files/`, `ui/guide/` (the command
+    glossary), `ui/ssh/` (the ssh connection wizard), `ui/ai/` (the AI chat screen), `ui/azp/`
+    (the Store browser).
 *   **`managers/`**: `ContactManager` (contacts, backs `call`/`contacts`), `VfsManager` (a
     sandboxed file layer rooted at `filesDir/vfs`; normal operations stay confined to app-private
     storage, while the explicit root-only `vfs mount` command can bind-mount it into the real
-    filesystem), `flashlight/` (the torch implementation behind `flash`).
+    filesystem), `SshPresets`/`WorkflowStore`/`AzpLibrary` (flat-`SharedPreferences` stores),
+    `PtyPreference` (the real-pty Settings toggle), `flashlight/` (the torch implementation
+    behind `flash`).
 *   **`terminal/`**: `ShellSession`, `TerminalEngine`, `Builtins` (the eleven built-in commands),
     `DistroManager` (the Termux bootstrap installer), `DpkgCatalog` (reads dpkg's own bookkeeping
-    for which package owns a binary — `CommandTree`'s hand-curated map turns that into a
-    category).
+    for which package owns an installed binary), `AptCatalog` (everything `apt install` could
+    install, for the browsable install catalog), `HelpCatalog` (background `--help`-flag
+    discovery) — `CommandTree`'s hand-curated map turns package ownership into a category.
+*   **`ai/`**: the AI chat's Anthropic API client. **`azp/`**: the azphalt Store client (search,
+    download, Ed25519 signature verification, dependency-resolving script installs). **`mcp/`**:
+    the MCP server's JSON-RPC protocol and tool registry.
 *   **`util/`**: `CalculationEngine` (the `calc` expression parser, `commonMain`), plus a handful
     of Android-only helpers still in use — logging/crash reporting, the interactive-shell wrapper
     `vfs mount` needs for `su`, `GenericFileProvider`.
 
 ## Gradle Module Boundaries
 
-*   **`:composeApp`** — the Android application and Kotlin Multiplatform Compose UI, orchestration,
-    terminal routing, managers, and platform integrations.
-*   **`:terminal-emulator`** — a headless VT100 output parser. It does not provide a PTY; the shell
-    remains a `ProcessBuilder` process connected through ordinary streams.
-*   **`:termux-shared`** — reusable Termux-compatible Android utilities consumed by `:composeApp`;
-    depends on `:terminal-emulator`.
+*   **`:composeApp`** — the thin Android entry point: the two activities, the MCP foreground
+    service, resources, product flavor config. No terminal/UI logic of its own.
+*   **`:shared`** — the Kotlin Multiplatform module (Android-only today; no other targets are
+    declared) holding the actual Compose UI, terminal routing, managers, and platform
+    integrations described above.
+*   **`:terminal-emulator`** — a vendored VT100 output parser plus a native pty JNI bridge
+    (`JNI.kt`/`jni/termux.c`). The parser is used unconditionally to flatten shell output for
+    display; the pty bridge itself is only live when `PtyPreference`'s experimental setting is
+    on — the default shell backend is still a `ProcessBuilder` process over ordinary streams.
+*   **`:termux-shared`** — a vendored Termux-compatible Android utility library, declared as a
+    dependency of both `:composeApp` and `:shared` but not currently called by any
+    HG2Gui-authored code.
 
 ## Product Subsystems
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,15 +8,25 @@ behaviour — app drawers, widget grids, a `category.HOME` filter, launcher life
 are out of scope.
 
 ## Project Structure
-*   **Kotlin shared across platforms:** `composeApp/src/commonMain/kotlin/com/hereliesaz/hg2gui/`
+HG2Gui is a Kotlin Multiplatform project: `:composeApp` is now just the thin Android entry point
+(`TerminalActivity.kt`, `EditorActivity.kt`, `mcp/McpServerService.kt`); the actual UI and
+execution logic lives in the separate `:shared` module.
+*   **Kotlin shared across platforms:** `shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/`
     — Compose UI (`ui/`), the `ShellSession` contract and `ShellAliases` (`terminal/`), the
-    `calc` expression parser (`util/CalculationEngine.kt`).
-*   **Kotlin, Android-specific:** `composeApp/src/androidMain/kotlin/com/hereliesaz/hg2gui/`
+    `calc` expression parser (`util/CalculationEngine.kt`), plus `managers/`/`mcp/` code that
+    doesn't need an Android-specific API.
+*   **Kotlin, Android-specific:** `shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/`
     — the `ShellSession`/`DistroManager`/`TerminalEngine`/`Builtins` implementations
-    (`terminal/`), `ContactManager`/`VfsManager`/`flashlight/` (`managers/`), a handful of
-    shared helpers (`util/`), and the Android-only parts of the UI (`ui/menu/CommandTree.kt`,
-    `ui/menu/FileBrowser.kt`, `ui/editor/`).
-*   **Resources:** `composeApp/src/androidMain/res/`
+    (`terminal/`), `ContactManager`/`VfsManager`/`flashlight/` (`managers/`), the AI chat client
+    (`ai/`) and the azphalt Store client (`azp/`), a handful of shared helpers (`util/`), and the
+    Android-only parts of the UI (`ui/menu/CommandTree.kt`, `ui/menu/FileBrowser.kt`,
+    `ui/editor/`).
+*   **`:terminal-emulator`**: a vendored VT100 parser plus the native pty JNI bridge
+    (`JNI.kt`/`jni/termux.c`) — used by default only to normalize shell output; the real pty
+    path is wired in but off by default (Settings → Real pseudoterminal).
+*   **`:termux-shared`**: Termux-compatible Android filesystem/process/terminal utilities;
+    depends on `:terminal-emulator`.
+*   **Resources:** `composeApp/src/main/res/`
 
 ## Coding Standards
 *   **Language:** Kotlin for everything, old and new. There is no separate legacy engine to

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -63,10 +63,11 @@ scrolling one to row 0 doesn't substitute for that tap. This only ever kicks in 
 drag or fling - whichever pill happens to start out at row 0 before any input never goes ink on
 its own, so nothing reads as pre-selected the instant a stack first appears.
 
-Scrolling isn't bounded to the stack's own content either: a drag or a fling can carry the stack
-past its first or last row, leaving blank space above the top or below the bottom. Nothing
-snaps it back - it stays wherever the gesture leaves it, the same as a settled fling stays on
-whatever row it lands on.
+Scrolling is bounded to the stack's own content on both ends: a drag or a fling stops dead the
+instant the closest-to-breadcrumb pill would cross row 0 in one direction, or the far pill would
+in the other - never past either, never leaving blank space above the top or below the bottom
+(`rememberStackScroll`'s `rowMin`/`rowMax`-derived `coerceIn`). Short of those two limits it
+behaves the same as ever - a settled fling stays on whatever row it lands on.
 
 ## 4a. The trail
 

--- a/docs/PRIVACY_POLICY.md
+++ b/docs/PRIVACY_POLICY.md
@@ -32,6 +32,17 @@ If the Project includes an optional telemetry or crash-reporting feature, it wil
 
 HG2Gui may include or rely on third-party open-source libraries and tools. These components may have their own privacy practices. When included in releases, those components are governed by their respective licenses and policies. You should consult the documentation of any bundled third-party services for specific details.
 
+5a. Network Requests This App Makes
+
+None of these happen passively or in the background without you taking the corresponding action first:
+
+- Termux bootstrap download: on first launch (or when you run `bootstrap` by hand), the app downloads the real Termux bootstrap archive from GitHub Releases (`github.com/termux/termux-packages`) to give you a real shell.
+- Package management: `apt`/`apt-get`/`pkg` talk to Termux's own package mirror (`packages-cf.termux.dev`) exactly as they would in the official Termux app, whenever you run an update/install/search yourself.
+- The Store (azphalt.store): the **Store** pill's search and install actions talk to the `azphalt.store` package registry. Nothing here runs without an explicit search or install tap.
+- AI chat: only if you've set an API key in Settings → AI SETTINGS, the **AI** pill's chat sends your typed question to the Anthropic API to get a suggested command. No key, no requests. The key itself is stored locally on-device (unencrypted `SharedPreferences`, same as every other local setting here) and is never sent anywhere but Anthropic's API.
+- MCP server: if you start it from Settings → MCP SERVER, it listens on `127.0.0.1` only (loopback) — it never accepts a connection from the network, only from this same device.
+- Any other shell command you run (`curl`, `wget`, `ssh`, `git`, …) talks to whatever you point it at, exactly like it would in a real terminal — the app itself isn't a party to that traffic.
+
 6. Sharing Data (User Actions)
 
 If you choose to open an issue, create a pull request, or contact maintainers via GitHub and include logs, stack traces, or other debugging information, that information will become part of the public issue or PR and therefore public. Do not paste secrets, credentials, or personal data into issues or PRs.

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -57,19 +57,47 @@ the menu *is* the interface. Every command, subcommand and argument is a pill yo
         from shell plugins — autosuggestion, "did you mean", alias hints, a graphical file
         picker, graphical yes/no answers to an interactive prompt — are implemented natively as
         pills instead.
+-   [x] **Installable-package browsing.** The `install` pill under `apt`/`apt-get`/`pkg` no
+        longer requires typing a package name blind — it drills into a categorized, browsable
+        catalog parsed from `apt update`'s own downloaded index (`AptCatalog`), the same
+        "menu is the interface" premise applied to the one place it was still missing.
+-   [x] **Auto-discovered command flags.** Beyond the hand-curated hint list, every real binary
+        on PATH gets its `--help` output probed once in the background and parsed into tappable
+        flag pills (`HelpCatalog`) — narrowing, not replacing, how much of "anything Termux
+        handles" still requires typing a flag from memory.
 -   [ ] **Scripting:** A custom scripting language or deeper Python integration for
         automating tasks within the terminal.
 
 ### Phase 3: Connectivity
--   **SSH Client:** A full SSH client in the terminal, remote servers managed with the same
-    point-and-click convenience — the tree populates from the remote host's own completions.
--   **Plugin System:** Community-created command menus (JSON/YAML) imported to extend the
-    suggestion tree for `kubectl`, `aws`, and the rest.
+-   [x] **SSH Client** *(landed narrower than originally scoped)*: saved connection presets plus
+        a **new…** wizard that collects host/user/port/key and drops the assembled command on
+        the line — not the original "tree populates from the remote host's own completions"
+        vision, which would need a live connection to introspect. Host-key and password prompts
+        reuse the same tap-only interactive-prompt machinery every other command gets.
+-   [x] **Context switching:** a lighter-weight take on remote-host awareness than a live
+        completions feed — the **Context** pill offers a static reference tree
+        (package/service manager, `git`/`ls`/`ssh`) for `ubuntu`/`macos`/`windows`, for working
+        over an active `ssh` session into that kind of host.
+-   [ ] **Plugin System:** Community-created command menus (JSON/YAML) imported to extend the
+        suggestion tree for `kubectl`, `aws`, and the rest. Not built as originally scoped; the
+        **Store** below covers an adjacent but different need (installing whole packages, not
+        authoring new menu branches for an existing binary).
+-   [x] **The Store (azphalt.store).** Not in the original roadmap at all: a **Store** pill
+        browses [azphalt.store](https://azphalt.store)'s package registry for `.azp`
+        extensions — assets, sandboxed code, packs, companion apps, MCP-server headers, and
+        AI-skill bundles — each install path-contained, SHA-256-checked, and Ed25519-signature-
+        verified.
+-   [x] **MCP server.** Also outside the original roadmap: an optional, loopback-only,
+        explicit-start JSON-RPC server (Settings → MCP SERVER) a paired external AI agent can
+        use to read/write the app's sandboxed files; running real shell commands through it is a
+        second, biometric-gated switch, off by default.
 
 ### Phase 4: AI Integration
--   **LLM Assistant:** A local or API-based model that writes commands from natural language
-    ("How do I untar a file?"). It proposes; it never runs. The proposed command arrives as
-    editable pills, and you press Run.
+-   [x] **LLM Assistant:** a chat screen (the **AI** pill, an Anthropic API key you supply
+        yourself) turns a plain-English request into a suggested shell command, optionally with
+        a per-flag "what each part does" breakdown. It proposes; it never runs — the reply's
+        **USE ▸** pill drops the command onto the input line for you to review and press Run,
+        same as every wizard-produced command in the app.
 
 ## Non-goals
 -   Being a home screen. The launcher lineage is where this came from, not where it is going.

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -291,21 +291,25 @@ private fun rememberStackScroll(rowMin: Int, rowMax: Int): StackScroll {
     var offsetPx by remember { mutableStateOf(0f) }
     var hasScrolled by remember { mutableStateOf(false) }
     // [offsetPx] is added on top of every pill's own already-correct resting `lift` (row R rests
-    // at -pitchPx*R, so translationY = -pitchPx*R + offsetPx). Bounded on BOTH ends now, each end
-    // named for the one pill it would otherwise let cross the breadcrumb (row 0, translationY 0 -
-    // shared with the root stack's own front row, or a child band's trail below it):
-    //  - upper bound (+pitchPx*rowMin): the closest pill to the breadcrumb (the bottom-most one)
-    //    reaching translationY 0 exactly - any more and it, and everything above it, would drag
-    //    down past the breadcrumb it shares that row with.
-    //  - lower bound (-pitchPx*(rowMax-rowMin)): the point where the whole rigid stack has
-    //    shifted up by exactly its own span - the top-most pill has moved as far as the
-    //    bottom-most pill's own resting spot ever gets to move, so going further would only ever
-    //    reveal blank space past the top-most pill, never another real row.
+    // at -pitchPx*R, so translationY = -pitchPx*R + offsetPx; row R lands exactly on the
+    // breadcrumb, translationY 0, when offsetPx == +pitchPx*R - always non-negative, since every
+    // row index is). A scroll is really the whole rigid stack sliding through that one fixed
+    // breadcrumb slot: which row currently sits there changes continuously as offsetPx sweeps
+    // from one end to the other, in row order - a pill passing *through* translationY 0 on its
+    // way past is normal scrolling, not something to prevent. What must stay bounded is only the
+    // two ends of the real content:
+    //  - the closest-to-breadcrumb pill (rowMin) at the breadcrumb (offsetPx == pitchPx*rowMin,
+    //    0 for the root stack, one pitch for a child band) - the smallest offsetPx worth
+    //    reaching, since going lower would show nothing but blank space below where a real row
+    //    ever sits.
+    //  - the furthest-from-breadcrumb pill (rowMax) at the breadcrumb (offsetPx ==
+    //    pitchPx*rowMax) - the largest offsetPx worth reaching, past which there's no further
+    //    row to bring into that slot either.
     // Both ends stop dead at their pill, matching the "no bounce, no self-correcting" house rule
     // the settle already follows - unverified on a real device, since none was available while
     // building this; a backwards feel is a one-line sign flip, not a structural fix.
-    val maxOffsetPx = pitchPx * rowMin
-    val minOffsetPx = -pitchPx * (rowMax - rowMin)
+    val minOffsetPx = pitchPx * rowMin
+    val maxOffsetPx = pitchPx * rowMax
     val scrollState = rememberScrollableState { delta ->
         hasScrolled = true
         val next = (offsetPx + delta).coerceIn(minOffsetPx, maxOffsetPx)


### PR DESCRIPTION
## Summary

- **Fixes a regression from the previous scroll-bounds PR (#163).** That fix bounded the wrong pair of values: it capped positive `offsetPx` at the *near* pill's own breadcrumb position (already the rest state) and let the opposite direction go unbounded-negative — the wrong sign entirely, since reaching the *far* pill's breadcrumb position needs a larger *positive* `offsetPx`, never a negative one. Net effect (confirmed by user screenshots): scrolling toward the far end of a stack refused to move at all, stopping dead at the near pill every time. Corrected range is `[pitchPx*rowMin, pitchPx*rowMax]` — the near pill at the breadcrumb is the floor, the far pill at the breadcrumb is the ceiling; a pill passing through the breadcrumb slot in between is normal scrolling, not something to prevent.
- **Brings README/ARCHITECTURE/CONTRIBUTING/DESIGN/VISION/PRIVACY_POLICY up to date** with everything shipped this session that they hadn't caught up to yet: the `composeApp`/`shared` module split, the browsable install catalog (`AptCatalog`), background `--help` flag discovery (`HelpCatalog`), tap-only answers for numbered-menu and bracketed-choice prompts (not just yes/no), the experimental real-pty toggle (`PtyPreference`), the apt keyring/script-wrapper fixes, and the corrected two-sided scroll bound. VISION.md checks off roadmap items that had actually shipped but were never marked (SSH presets, Context switching, the Store, MCP server, AI chat). PRIVACY_POLICY gains the network-requests section its own structure implied but never filled in.

## Test plan

- [x] `:shared:detektMetadataMain` clean
- [x] `:composeApp:assembleDebug` builds
- [ ] Manual verification on-device that the stack now scrolls all the way to the far pill in both directions and stops exactly there (not verified — no device available in this environment)


---
_Generated by [Claude Code](https://claude.ai/code/session_018X7LN1wZoJ15zdAyTu2Riq)_

## Summary by Sourcery

Correct pill-stack scroll limits and refresh project documentation to match the shipped product.

Bug Fixes:
- Correct pill-stack scrolling bounds so stacks can scroll from the near-content limit to the far-content limit without stopping prematurely or overscrolling.

Enhancements:
- Update the project documentation to reflect the current module structure, shell capabilities, interactive prompt handling, package and help catalogs, experimental pty support, and shipped product features.

Documentation:
- Bring the README, architecture, contributing, design, vision, and privacy-policy documentation up to date with current behavior, roadmap status, and network requests.