### PR TITLE
Fix child-cascade lift drift and reconcile pill-menu doc with the code

### DIFF
--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -35,9 +35,12 @@ of the screen**, `rowsBelow × pitch`, and stays pinned there.
 
 ## 4. Children cascade upward
 
-Children cascade **upward** from the host, all the same size (34% wide, starting at 30% —
-just inside the host's right end). Row 0 is reserved for the host and its own trail of picks,
-so the first child fans out from row 1, one pitch above the host - not sharing its row.
+Children cascade **upward** from the host, starting at 30% — just inside the host's right end —
+and 34% wide at most: the same row-to-row width cycling rule 01 gives the root stack (§6) applies
+here too, so a band isn't every pill at one identical width but cycles down in 2% steps every
+five rows (`childWidthFraction` in `PillMenu.kt`), the same "so the stack reads as a stack"
+reasoning. Row 0 is reserved for the host and its own trail of picks, so the first child fans out
+from row 1, one pitch above the host - not sharing its row.
 
 Arguments repeat this exact choreography, one level at a time, however deep the tree goes.
 Tapping a pill with its own children makes it the new anchor: its siblings **leave**, the same
@@ -72,10 +75,14 @@ behaves the same as ever - a settled fling stays on whatever row it lands on.
 ## 4a. The trail
 
 A picked child doesn't just cascade its own children in — it also drops out of the band and
-settles beside the host as a **trail crumb**, the record of what's been picked so far. The
-trail starts at 38.3% of the frame, just clear of the host's right end, and runs left to right
-in pick order. Unlike every other pill (sized as a fraction of the screen), a crumb is sized by
-its own content, with a 56dp floor so a short label like `ls` doesn't shrink-wrap smaller than
+settles beside the host as a **trail crumb**, the record of what's been picked so far. The trail
+starts at 32.8% of the frame — just *before* the host's right end (36.3%), not clear of it - the
+same shingled overlap every crumb-to-crumb seam already gets (`TRAIL_LEFT_OF_FULL` in
+`PillMenu.kt`, itself `HOST_WIDTH × HOST_RIGHT_EDGE` minus one crumb-overlap's worth), so the
+host-to-first-crumb joint fans the same way as the rest of the chain instead of being the one
+seam in it with a plain gap. Runs left to right in pick order. Unlike every other pill (sized as
+a fraction of the screen), a crumb is sized by its own content, with a 56dp floor so a short
+label like `ls` doesn't shrink-wrap smaller than
 everything around it. Each crumb overlaps the one after it by 14dp - a fanned, shingled read
 (the same overlap/bleed language the rest of the menu already uses) rather than a plain row of
 gapped pills; the earlier crumb draws on top, so it's the later one that visibly tucks under.
@@ -92,8 +99,8 @@ level is its own fresh cascade, never more pills piled onto the one before it.
 | Lift | final 10% of the turn |
 | Cascade | strictly sequential — 173ms per step |
 | Host rests at | 36.3% of the frame |
-| Child pill | 34% wide, 30% in |
-| Trail starts at | 38.3% of the frame |
+| Child pill | 30% in, 34% wide at most, cycling down in 2% steps every five rows |
+| Trail starts at | 32.8% of the frame |
 | Trail crumb | content-sized, 56dp floor, 14dp overlap |
 | Overhang | 62dp past the left edge |
 | Row pitch | 20dp |

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -756,11 +756,12 @@ private fun ChildPill(
     val aligned = absoluteRow == alignedRow && !leaving && !droppingOut
 
     val turn = remember(node.id) { Animatable(if (localIndex % 2 == 0) -360f else 360f) }
-    // Every pill in a band rises from the same place: the anchor's own row, exactly where
-    // HostPill (or the parent pill that opened this band) already rests. That shared origin is
-    // what makes it read as pills flying up out of the anchor into a stack, rather than each one
-    // nudging up off the pill before it.
-    val lift = remember(node.id) { Animatable(-pitchPx * BAND_BASE_ROW) }
+    // A child begins exactly behind the pill before it - the first one row above the host (row 0
+    // belongs to the host's own trail), every later one behind wherever its predecessor lands -
+    // matching the keyframe's own 90%-hold target below exactly, or a pill three or more deep in
+    // the band would visibly drift upward through its held rows instead of sitting invisibly at
+    // the one it's hidden behind until the final 10% lift.
+    val lift = remember(node.id) { Animatable(-pitchPx * (absoluteRow - 1).coerceAtLeast(BAND_BASE_ROW)) }
     val leaveOffset = remember(node.id) { Animatable(0f) }
     val scale = remember(node.id) { Animatable(1f) }
 


### PR DESCRIPTION
## Summary

Audited `docs/DESIGN.md` (the pill menu's own stated source of truth) against the actual `ui/menu/PillMenu.kt` implementation and found one real animation bug plus two places the doc had drifted from the code:

- **Bug (fixed in code):** `ChildPill`'s `lift` `Animatable` was always seeded from `-pitchPx * BAND_BASE_ROW`, but its own keyframe holds at `-pitchPx * (absoluteRow - 1).coerceAtLeast(BAND_BASE_ROW)` for the first 90% of the cascade arc. Those two only coincide for the first two children in a band. Any child three or more deep in a band visibly drifted upward through its intermediate rows during what should have been a static "hidden behind the pill in front of it" hold, instead of staying pinned until the final 10% lift — noticeable in any category with more than two entries.
- **Doc was stale:** §4 described child pills as "all the same size (34% wide)" — the code has since gained the same row-to-row width cycling the root stack uses (`childWidthFraction`), so a band's pills are no longer uniform width. Updated the prose.
- **Doc was stale:** §4a / §5's "trail starts at 38.3% of the frame, just clear of the host's right end" doesn't match `TRAIL_LEFT_OF_FULL`'s actual math, which lands at 32.8% — *before*, not after, the host's right edge, matching the same shingled crumb-to-crumb overlap used everywhere else in the trail. Updated the number and the "just clear of" language that contradicted the code's own deliberate overlap.

## Test plan

- [ ] Manual: open a menu category with 3+ children and confirm the third+ pill no longer visibly rises through intermediate rows before its cascade turn.
- Could not run a full Gradle build in this sandbox (Android Gradle Plugin 9.3.1 isn't cached and the environment has no network access to fetch it) — the Kotlin change is a single-expression edit using identifiers (`pitchPx`, `absoluteRow`, `BAND_BASE_ROW`) already in scope and used identically elsewhere in the same function, so it should compile cleanly; please run a normal build/lint pass in CI to confirm.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PZLT87WXJ6kEiX1kAGEcKK)_

## Summary by Sourcery

Prevent deeper child pills from drifting during cascade holds and reconcile the pill-menu design documentation with the current behavior.

Bug Fixes:
- Fix child-pill cascade animation drift by initializing each child at the position held during the first phase of its lift.

Enhancements:
- Align the pill-menu design documentation with the implemented child-width cycling and shingled trail positioning.

Documentation:
- Update pill-menu documentation to describe width cycling and the trail's actual starting position and overlap behavior.