### PR TITLE
Fix intermittent animation runtime bugs and delete duplicate theme

### DIFF
--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillPerimeterReveal.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillPerimeterReveal.kt
@@ -139,7 +139,7 @@ class PerimeterRevealState {
 
     private suspend fun runLeadIn(reverse: Boolean) = try {
         leadInActive = true
-        runLeadInBody(reverse)
+        if (reverse) runLeadInReverse() else runLeadInForward()
     } finally {
         // Runs even if this coroutine is cancelled mid-animation, so leadInActive can never stay
         // stuck true - the standalone lead-in pill it gates would otherwise keep rendering
@@ -147,65 +147,65 @@ class PerimeterRevealState {
         leadInActive = false
     }
 
-    private suspend fun runLeadInBody(reverse: Boolean) {
-        if (!reverse) {
-            stretchWidth.snapTo(1f)
-            flyProgress.snapTo(0f)
-            rockAngle.snapTo(0f)
-            fallProgress.snapTo(0f)
-            coroutineScope {
-                launch {
-                    // Stretch out, then snap thin - the "snap" sub-beat is the tight middle leg.
-                    stretchWidth.animateTo(0.45f, keyframes {
-                        durationMillis = STRETCH_MS
-                        1f at 0 using LinearEasing
-                        1.6f at (STRETCH_MS * 0.35f).toInt() using LinearEasing
-                        0.45f at (STRETCH_MS * 0.55f).toInt() using LEG_EASE
-                    })
-                }
-                launch {
-                    // Stays put through the stretch+snap, then flies for the rest of the beat.
-                    flyProgress.animateTo(1f, keyframes {
-                        durationMillis = STRETCH_MS
-                        0f at 0
-                        0f at (STRETCH_MS * 0.55f).toInt()
-                        1f at STRETCH_MS using LEG_EASE
-                    })
-                }
+    private suspend fun runLeadInForward() {
+        stretchWidth.snapTo(1f)
+        flyProgress.snapTo(0f)
+        rockAngle.snapTo(0f)
+        fallProgress.snapTo(0f)
+        coroutineScope {
+            launch {
+                // Stretch out, then snap thin - the "snap" sub-beat is the tight middle leg.
+                stretchWidth.animateTo(0.45f, keyframes {
+                    durationMillis = STRETCH_MS
+                    1f at 0 using LinearEasing
+                    1.6f at (STRETCH_MS * 0.35f).toInt() using LinearEasing
+                    0.45f at (STRETCH_MS * 0.55f).toInt() using LEG_EASE
+                })
             }
-            rockAngle.animateTo(0f, keyframes {
-                durationMillis = BREAK_MS
-                0f at 0 using LinearEasing
-                14f at (BREAK_MS * 0.25f).toInt() using LinearEasing
-                (-8f) at (BREAK_MS * 0.5f).toInt() using LinearEasing
-                4f at (BREAK_MS * 0.75f).toInt() using LinearEasing
-            })
-            fallProgress.animateTo(1f, tween(FALL_MS, easing = LEG_EASE))
-        } else {
-            fallProgress.animateTo(0f, tween(FALL_MS, easing = LEG_EASE))
-            rockAngle.animateTo(0f, keyframes {
-                durationMillis = BREAK_MS
-                0f at 0 using LinearEasing
-                4f at (BREAK_MS * 0.25f).toInt() using LinearEasing
-                (-8f) at (BREAK_MS * 0.5f).toInt() using LinearEasing
-                14f at (BREAK_MS * 0.75f).toInt() using LinearEasing
-            })
-            coroutineScope {
-                launch {
-                    flyProgress.animateTo(0f, keyframes {
-                        durationMillis = STRETCH_MS
-                        1f at 0 using LEG_EASE
-                        0f at (STRETCH_MS * 0.45f).toInt()
-                    })
-                }
-                launch {
-                    stretchWidth.animateTo(1f, keyframes {
-                        durationMillis = STRETCH_MS
-                        0.45f at 0
-                        0.45f at (STRETCH_MS * 0.45f).toInt() using LEG_EASE
-                        1.6f at (STRETCH_MS * 0.65f).toInt() using LinearEasing
-                    })
-                }
+            launch {
+                // Stays put through the stretch+snap, then flies for the rest of the beat.
+                flyProgress.animateTo(1f, keyframes {
+                    durationMillis = STRETCH_MS
+                    0f at 0
+                    0f at (STRETCH_MS * 0.55f).toInt()
+                    1f at STRETCH_MS using LEG_EASE
+                })
+            }
+        }
+        rockAngle.animateTo(0f, keyframes {
+            durationMillis = BREAK_MS
+            0f at 0 using LinearEasing
+            14f at (BREAK_MS * 0.25f).toInt() using LinearEasing
+            (-8f) at (BREAK_MS * 0.5f).toInt() using LinearEasing
+            4f at (BREAK_MS * 0.75f).toInt() using LinearEasing
+        })
+        fallProgress.animateTo(1f, tween(FALL_MS, easing = LEG_EASE))
+    }
+
+    private suspend fun runLeadInReverse() {
+        fallProgress.animateTo(0f, tween(FALL_MS, easing = LEG_EASE))
+        rockAngle.animateTo(0f, keyframes {
+            durationMillis = BREAK_MS
+            0f at 0 using LinearEasing
+            4f at (BREAK_MS * 0.25f).toInt() using LinearEasing
+            (-8f) at (BREAK_MS * 0.5f).toInt() using LinearEasing
+            14f at (BREAK_MS * 0.75f).toInt() using LinearEasing
+        })
+        coroutineScope {
+            launch {
+                flyProgress.animateTo(0f, keyframes {
+                    durationMillis = STRETCH_MS
+                    1f at 0 using LEG_EASE
+                    0f at (STRETCH_MS * 0.45f).toInt()
+                })
+            }
+            launch {
+                stretchWidth.animateTo(1f, keyframes {
+                    durationMillis = STRETCH_MS
+                    0.45f at 0
+                    0.45f at (STRETCH_MS * 0.45f).toInt() using LEG_EASE
+                    1.6f at (STRETCH_MS * 0.65f).toInt() using LinearEasing
+                })
             }
         }
     }


### PR DESCRIPTION
## Summary

First of a series of PRs working through the implementation audit ("Where the code and the guide disagree", tree `251c4ce`) in its own recommended order. This one is the audit's own first step: "sweep every LaunchedEffect for values read but not keyed, and every Dp.value used as pixels... four one-line fixes, and they resolve the intermittent animation failures that keep coming back," plus deleting the duplicate theme.

**Runtime bugs (all state-dependent, so they present as intermittent):**
- `StackPill`'s `offset` `Animatable` was seeded from `entering` inside a bare `remember`, which evaluates once — a pill first composed while already resting froze it at `0f` forever, making its own slide a permanent no-op. Now seeded at rest, with `entering`'s value applied via `snapTo` inside the effect.
- `StackPill`'s `lift` `LaunchedEffect` was keyed only on `entering`, not on `row`/`pitchPx` which it also reads — a stack rebuild handing a surviving pill a new row left it animating to (or stuck at) its old one.
- `ChildPill`'s cascade `LaunchedEffect` was keyed only on `node.id`, not `localIndex` — a band re-sort changes every subsequent delay without changing any id, so the cascade kept the old ordering.
- `hasScrolled`/`offsetPx` in `rememberStackScroll` lived in the call site's own `remember` scope rather than the current stack's, for the root stack specifically (a child band's call was already correctly scoped via its own `key(anchor.id)` wrapper). Added a `resetKey` parameter and a token that bumps each time the root stack returns to browsing.
- Both `PillWrapReveal` and `PillPerimeterReveal` ran their `open()`/`close()` sequences without resetting every animatable up front and without guarding `leadInActive` against cancellation — a coroutine cancelled mid-sequence (back press, phase change) could leave a half-drawn overlay, or a lead-in flag stuck `true` with nothing left animating it.

One audited item (`HostPill`'s drop allegedly seeding pixels from a stripped `Dp` value) I checked and found already fixed pre-audit — `git blame` shows the `* density` multiply predates the audit's own reference tree, so no change was needed there.

**Duplicate theme:** deletes `ui/theme/Theme.kt` and `ui/theme/Color.kt` — a forced-dark, pre-Azphalt `HG2GuiTheme` with no relationship to any current design token, entirely unused (grepped clean; every real call site imports the ground-aware `ui/Theme.kt` version instead). Kept `ui/theme/Typography.kt`, which the real theme still depends on. Also cleaned up the two now-stale detekt baseline entries pointing at the deleted file.

## Test plan

- [ ] Manual: open a menu category, scroll it, close it, open a different category, confirm row 0 doesn't render primed on the fresh stack.
- [ ] Manual: reorder/filter a child band and confirm the cascade restages in the new order.
- Could not run a full Gradle build in this sandbox (no network access to fetch the Android Gradle Plugin) — changes are narrowly scoped `LaunchedEffect` key additions, an `Animatable` seed-value swap, and two straightforward file deletions with no remaining references; please confirm in CI.


---
_Generated by [Claude Code](https://claude.ai/code/session_01PZLT87WXJ6kEiX1kAGEcKK)_

## Summary by Sourcery

Bug Fixes:
- Prevent perimeter reveal animations from remaining partially drawn or leaving lead-in state active after cancellation by resetting animation state and cleaning up reliably.