### PR TITLE
Add the real eight-step type scale and the two soft surfaces

### DIFF
--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/Theme.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/ui/Theme.kt
@@ -16,7 +16,9 @@ import androidx.compose.ui.unit.em
 import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
 import com.hereliesaz.hg2gui.ui.menu.onPage
+import com.hereliesaz.hg2gui.ui.theme.LocalAzphaltType
 import com.hereliesaz.hg2gui.ui.theme.appTypography
+import com.hereliesaz.hg2gui.ui.theme.azphaltType
 
 @Composable
 fun HG2GuiTheme(scale: Float = 1f, content: @Composable () -> Unit) {
@@ -45,7 +47,8 @@ fun HG2GuiTheme(scale: Float = 1f, content: @Composable () -> Unit) {
             // sets no `color` at all - fell back to Compose's own hardcoded LocalContentColor
             // default (plain black) regardless of ground, the same "assumes the light Mustard
             // page" bug this whole fix exists to kill, just one level removed from onBackground.
-            LocalContentColor provides ground.onPage
+            LocalContentColor provides ground.onPage,
+            LocalAzphaltType provides azphaltType()
         ) {
             content()
         }

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/ai/AiChatScreen.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/ai/AiChatScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
 import com.hereliesaz.hg2gui.ui.menu.onPage
 import com.hereliesaz.hg2gui.ui.menu.pageBrush
+import com.hereliesaz.hg2gui.ui.theme.AzphaltSurface
 
 /** [parts] is a flag-by-flag "what each part does" breakdown for a command reply - see
  *  HG2Gui_Redesign.dc.html's "Phase 4" concept. Empty when the model didn't include one. */
@@ -177,7 +178,7 @@ private fun AiBubble(message: AiMessage, onUseCommand: (String) -> Unit) {
     Column(
         Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
+            .clip(AzphaltSurface.recordTile) // a message IS a record
             .background(Azphalt.Ink.copy(alpha = if (message.fromUser) .10f else .05f))
             .padding(12.dp)
     ) {
@@ -205,7 +206,7 @@ private fun AiBubble(message: AiMessage, onUseCommand: (String) -> Unit) {
             Column(
                 Modifier
                     .fillMaxWidth()
-                    .clip(RoundedCornerShape(14.dp))
+                    .clip(AzphaltSurface.note)
                     .background(Azphalt.Ink.copy(alpha = .09f))
                     .padding(12.dp),
                 verticalArrangement = Arrangement.spacedBy(8.dp)

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/azp/AzpStoreScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
 import com.hereliesaz.hg2gui.ui.menu.onPage
 import com.hereliesaz.hg2gui.ui.menu.pageBrush
+import com.hereliesaz.hg2gui.ui.theme.AzphaltSurface
 
 /** A search result row, or an already-installed package - shared shape for the list.
  *  [trust] mirrors androidMain's `AzpTrust` enum by name (commonMain can't reference it directly,
@@ -181,7 +182,7 @@ private fun AzpRow(listing: AzpListing, installing: Boolean, onInstall: (AzpList
     Row(
         Modifier
             .fillMaxWidth()
-            .clip(RoundedCornerShape(12.dp))
+            .clip(AzphaltSurface.recordTile)
             .background(Azphalt.Ink.copy(alpha = .05f))
             .padding(12.dp),
         verticalAlignment = Alignment.CenterVertically

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideReaderScreen.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/guide/GuideReaderScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.unit.sp
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
 import com.hereliesaz.hg2gui.ui.menu.onPage
 import com.hereliesaz.hg2gui.ui.menu.pageBrush
+import com.hereliesaz.hg2gui.ui.theme.AzphaltSurface
 import kotlinx.coroutines.delay
 
 /*
@@ -313,7 +314,7 @@ private fun ColumnScope.GuideEntryReader(
                     Column(
                         Modifier
                             .fillMaxWidth()
-                            .clip(RoundedCornerShape(18.dp))
+                            .clip(AzphaltSurface.note)
                             .background(Azphalt.Ink.copy(alpha = .06f))
                             .padding(16.dp)
                     ) {

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/theme/AzphaltSurface.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/theme/AzphaltSurface.kt
@@ -1,0 +1,13 @@
+package com.hereliesaz.hg2gui.ui.theme
+
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.ui.unit.dp
+
+// Two soft surfaces exist. Everything else is 999px - see the style guide's "09 - Surfaces"
+// section, "There are no cards". Declared once so a screen reaching for a mid-range radius has
+// a named shape to reach for instead of inventing one.
+object AzphaltSurface {
+    val recordTile = RoundedCornerShape(26.dp)
+    val note = RoundedCornerShape(20.dp)
+    val capsule = RoundedCornerShape(percent = 50)
+}

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/theme/Typography.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/theme/Typography.kt
@@ -2,11 +2,14 @@ package com.hereliesaz.hg2gui.ui.theme
 
 import androidx.compose.material3.Typography
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.staticCompositionLocalOf
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.em
+import androidx.compose.ui.unit.sp
 import hg2gui.shared.generated.resources.Res
 import hg2gui.shared.generated.resources.jost_black
-import hg2gui.shared.generated.resources.jost_medium
 import hg2gui.shared.generated.resources.jost_semibold
 import hg2gui.shared.generated.resources.jost_extrabold
 import org.jetbrains.compose.resources.Font
@@ -14,13 +17,61 @@ import org.jetbrains.compose.resources.Font
 @Composable
 fun jostFontFamily() = FontFamily(
     Font(Res.font.jost_black, FontWeight.Black),
-    Font(Res.font.jost_medium, FontWeight.Medium),
     Font(Res.font.jost_semibold, FontWeight.SemiBold),
     Font(Res.font.jost_extrabold, FontWeight.ExtraBold)
 )
 
+/**
+ * The eight steps of the HG2Gui scale. One family; weight and tracking do the rest.
+ * Everything is uppercase except [body], the only lowercase in the system.
+ * Call sites uppercase their own strings - a TextStyle cannot do it.
+ */
 @Composable
-fun appTypography() = Typography().let { 
+fun azphaltType(): AzphaltType {
+    val f = jostFontFamily()
+    return AzphaltType(
+        hero = TextStyle(
+            fontFamily = f, fontWeight = FontWeight.Black,
+            fontSize = 58.sp, lineHeight = 49.sp, letterSpacing = (-0.03).em
+        ),
+        section = TextStyle(
+            fontFamily = f, fontWeight = FontWeight.Black,
+            fontSize = 40.sp, lineHeight = 40.sp, letterSpacing = (-0.02).em
+        ),
+        lead = TextStyle(fontFamily = f, fontWeight = FontWeight.SemiBold, fontSize = 25.sp, lineHeight = 32.sp),
+        // only lowercase
+        body = TextStyle(fontFamily = f, fontWeight = FontWeight.SemiBold, fontSize = 17.sp, lineHeight = 25.5.sp),
+        capsule = TextStyle(
+            fontFamily = f, fontWeight = FontWeight.ExtraBold,
+            fontSize = 15.sp, lineHeight = 15.sp, letterSpacing = 0.09.em
+        ),
+        eyebrow = TextStyle(
+            fontFamily = f, fontWeight = FontWeight.ExtraBold,
+            fontSize = 11.sp, lineHeight = 11.sp, letterSpacing = 0.28.em
+        ),
+        endCap = TextStyle(
+            fontFamily = f, fontWeight = FontWeight.ExtraBold,
+            fontSize = 10.sp, lineHeight = 10.sp, letterSpacing = 0.10.em
+        ),
+        micro = TextStyle(
+            fontFamily = f, fontWeight = FontWeight.ExtraBold,
+            fontSize = 9.sp, lineHeight = 9.sp, letterSpacing = 0.18.em
+        )
+    )
+}
+
+data class AzphaltType(
+    val hero: TextStyle, val section: TextStyle, val lead: TextStyle, val body: TextStyle,
+    val capsule: TextStyle, val eyebrow: TextStyle, val endCap: TextStyle, val micro: TextStyle
+)
+
+val LocalAzphaltType = staticCompositionLocalOf<AzphaltType> { error("No AzphaltType") }
+
+// Provided alongside LocalContentColor in ui/Theme.kt's existing CompositionLocalProvider.
+// Keep appTypography() below for the Material components that demand a Typography, but no
+// HG2Gui screen should read MaterialTheme.typography directly once migration is done.
+@Composable
+fun appTypography() = Typography().let {
     val family = jostFontFamily()
     it.copy(
         displayLarge = it.displayLarge.copy(fontFamily = family),


### PR DESCRIPTION
## Summary

Fifth of the series working through the implementation audit. This one is Patches 05 and 06 - the type scale that only ever existed in the guide, and the three screens that grew arbitrary mid-range corner radii.

**Patch 05 — the real type scale (`ui/theme/Typography.kt`):**
- `Typography.kt`'s `appTypography()` used to take stock Material3 `Typography()` and swap in the Jost font family without touching any size, weight, tracking, or casing — so nothing in the guide's actual eight-step scale (900/40px/-.02em section heads, 800/11px/.28em eyebrows, etc.) survived, and every screen ended up improvising its own type.
- Adds `AzphaltType`, the guide's real eight named styles (`hero`/`section`/`lead`/`body`/`capsule`/`eyebrow`/`endCap`/`micro`), built via a new `azphaltType()` composable and provided as `LocalAzphaltType` alongside `LocalContentColor` in `ui/Theme.kt`'s existing `CompositionLocalProvider`.
- `appTypography()` stays, for the Material components that still demand a `Typography` — no HG2Gui screen should read `MaterialTheme.typography` directly once migration to `LocalAzphaltType` happens (this PR only adds the scale itself; migrating every screen's `Text()` calls is separate, much larger scope).
- Drops the `jost_medium` face from `jostFontFamily()`, since none of the eight scale steps use `FontWeight.Medium`. One direct `FontWeight.Medium` reference remains in `GuideReaderScreen.kt` (a note's caption) — it'll fall back to the nearest available weight rather than break; flagging here since it wasn't in the audit's own list.

**Patch 06 — the three stray radii (`ui/theme/AzphaltSurface.kt`, new file):**
- The style guide's own "09 — Surfaces" section is titled "There are no cards": two soft surfaces exist (the record tile, the note) and they're the only places a radius isn't 999px.
- Declares `AzphaltSurface` (`recordTile` = 26dp, `note` = 20dp, `capsule` = 999px) and maps the four sites the audit found onto it:
  - `AiChatScreen.kt`: the message bubble (12dp → `recordTile`) and its "what each part does" breakdown (14dp → `note`)
  - `AzpStoreScreen.kt`: the listing row (12dp → `recordTile`)
  - `GuideReaderScreen.kt`: the animation-candidate block (18dp → `note`)

## Test plan

- [ ] Manual: open the AI chat, AZP store listing, and a guide entry with an animation candidate — confirm the corner radii read as the intended soft-surface shapes, not a regression.
- [ ] Manual: confirm the app still builds and themes correctly with `LocalAzphaltType` provided (nothing currently reads it yet, so this is purely additive).
- Could not run a full Gradle build in this sandbox — please confirm in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZLT87WXJ6kEiX1kAGEcKK)_

## Summary by Sourcery

Establish the guide-defined typography scale and standardize the limited soft-surface shapes across the application.

New Features:
- Add the complete eight-style Azphalt typography scale and expose it through a composition local for future screen migrations.
- Define named record, note, and capsule surface shapes for consistent use across the interface.

Enhancements:
- Replace inconsistent mid-range corner radii in AI chat, AZP store, and guide surfaces with the shared soft-surface shapes.
- Remove the unused medium Jost font face from the theme font family.