### PR TITLE
Fix master: PillPerimeterReveal.kt doesn't compile after #172's merge

### DIFF
--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillPerimeterReveal.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillPerimeterReveal.kt
@@ -133,77 +133,23 @@ class PerimeterRevealState {
         active = false
     }
 
-    private suspend fun runLeadIn(reverse: Boolean) = try {
-        leadInActive = true
-        if (reverse) runLeadInReverse() else runLeadInForward()
-    } finally {
-        // Runs even if this coroutine is cancelled mid-animation, so leadInActive can never stay
-        // stuck true - the standalone lead-in pill it gates would otherwise keep rendering
-        // forever with nothing left animating it.
-        leadInActive = false
-    }
-
-    private suspend fun runLeadInForward() {
-        stretchWidth.snapTo(1f)
-        flyProgress.snapTo(0f)
-        rockAngle.snapTo(0f)
-        fallProgress.snapTo(0f)
-        coroutineScope {
-            launch {
-                // Stretch out, then snap thin - the "snap" sub-beat is the tight middle leg.
-                stretchWidth.animateTo(0.45f, keyframes {
-                    durationMillis = STRETCH_MS
-                    1f at 0 using LinearEasing
-                    1.6f at (STRETCH_MS * 0.35f).toInt() using LinearEasing
-                    0.45f at (STRETCH_MS * 0.55f).toInt() using LEG_EASE
-                })
-            }
-            launch {
-                // Stays put through the stretch+snap, then flies for the rest of the beat.
-                flyProgress.animateTo(1f, keyframes {
-                    durationMillis = STRETCH_MS
-                    0f at 0
-                    0f at (STRETCH_MS * 0.55f).toInt()
-                    1f at STRETCH_MS using LEG_EASE
-                })
-            }
-        }
-        rockAngle.animateTo(0f, keyframes {
-            durationMillis = BREAK_MS
-            0f at 0 using LinearEasing
-            14f at (BREAK_MS * 0.25f).toInt() using LinearEasing
-            (-8f) at (BREAK_MS * 0.5f).toInt() using LinearEasing
-            4f at (BREAK_MS * 0.75f).toInt() using LinearEasing
-        })
-        fallProgress.animateTo(1f, tween(FALL_MS, easing = LEG_EASE))
-    }
-
-    private suspend fun runLeadInReverse() {
-        fallProgress.animateTo(0f, tween(FALL_MS, easing = LEG_EASE))
-        rockAngle.animateTo(0f, keyframes {
-            durationMillis = BREAK_MS
-            0f at 0 using LinearEasing
-            4f at (BREAK_MS * 0.25f).toInt() using LinearEasing
-            (-8f) at (BREAK_MS * 0.5f).toInt() using LinearEasing
-            14f at (BREAK_MS * 0.75f).toInt() using LinearEasing
-        })
-        coroutineScope {
-            launch {
-                flyProgress.animateTo(0f, keyframes {
-                    durationMillis = STRETCH_MS
-                    1f at 0 using LEG_EASE
-                    0f at (STRETCH_MS * 0.45f).toInt()
-                })
-            }
-            launch {
-                stretchWidth.animateTo(1f, keyframes {
-                    durationMillis = STRETCH_MS
-                    0.45f at 0
-                    0.45f at (STRETCH_MS * 0.45f).toInt() using LEG_EASE
-                    1.6f at (STRETCH_MS * 0.65f).toInt() using LinearEasing
-                })
-            }
-        }
+    private fun geometry(
+        fullWidthPx: Float,
+        fullHeightPx: Float,
+        defaultBaseWidthPx: Float,
+        minThicknessPx: Float
+    ): PerimeterBreakFreeGeometry {
+        val thickness = if (origin.height > 0f) origin.height else minThicknessPx
+        val originLeft = if (origin.width > 0f) origin.left else 0f
+        val originTop = if (origin.height > 0f) origin.top else fullHeightPx - thickness
+        val baseWidthPx = if (origin.width > 0f) origin.width else defaultBaseWidthPx
+        // "Distance from the pill's right tip to the right edge of the screen" - the pill's own
+        // RESTING tip, not the stretched one BreakFreeState briefly grows to internally; the few
+        // px that discrepancy leaves short of the literal edge is imperceptible next to a 6%
+        // stretch, and keeping that stretch factor private to PillBreakFree.kt is worth it.
+        val flightPx = (fullWidthPx - EDGE_MARGIN_PX - originLeft - baseWidthPx).coerceAtLeast(0f)
+        val floorPx = (fullHeightPx - thickness - originTop).coerceAtLeast(0f)
+        return PerimeterBreakFreeGeometry(baseWidthPx, flightPx, floorPx)
     }
 }
 


### PR DESCRIPTION
## Summary

**Urgent — `master` currently does not compile.**

While PR #172 was merging, a "Merge branch 'master' into claude/termux-fidelity-fixes" commit (`fe47d3f`) resolved a conflict in `PillPerimeterReveal.kt` by keeping the wrong side: the pre-Patch-03 `runLeadIn`/`runLeadInForward`/`runLeadInReverse` functions (dead code from before #168's `BreakFreeState` rewrite) instead of the `geometry()` function that `open()`/`close()` actually call.

The surviving dead code references properties (`stretchWidth`, `flyProgress`, `rockAngle`, `fallProgress`, `leadInActive`) and constants (`STRETCH_MS`, `BREAK_MS`, `FALL_MS`) that don't exist anywhere in the current file — `:shared:compileAndroidMain` (and any detekt task, which parses the same source) fails immediately.

This PR just restores `geometry()` and drops the orphaned dead code. I diffed every other file this session's PR series touched (across #167-#172) against the current `master` tip and confirmed this corruption was isolated to this one file — everything else matches exactly.

## Test plan

- [ ] CI: confirm `android-debug / build` and `detekt` both go green on `master` once this merges.
- Could not run a full Gradle build in this sandbox — please confirm in CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZLT87WXJ6kEiX1kAGEcKK)_

## Summary by Sourcery

Restore the current perimeter reveal geometry implementation and remove stale code that prevents compilation.

Bug Fixes:
- Restore the perimeter reveal geometry calculation so the shared Android source compiles again.

Enhancements:
- Remove obsolete lead-in animation code left over from the previous state implementation.