### PR TITLE
Fix keyboard covering input row and pkg install path resolution

### DIFF
--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/DistroManager.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/DistroManager.kt
@@ -258,18 +258,23 @@ object DistroManager {
     // check fails before bash (or whatever's named) ever runs - a real command extractBootstrap
     // never touches otherwise, since only the ~330 manifest-covered ELF files need the
     // exec-exemption trick; a plain script just needs its own first line to name a real path.
-    // Only the first line is ever touched - nothing else about the file's content changes.
+    //
+    // The shebang isn't the only hardcoded reference a script can carry, though - `pkg` itself
+    // also calls other bootstrap tools (termux-setup-package-manager among them) by the same
+    // ITS-package absolute path, not by $PREFIX or a bare command name that PATH would resolve,
+    // so those calls failed with "No such file or directory" even once the shebang fix alone let
+    // the script start running at all. Once a file is confirmed to be a script (shebang-gated,
+    // same as before - never touches the ~330 manifest-covered ELF files, and never risks
+    // corrupting a byte sequence inside a real binary that only coincidentally matches this
+    // text), every occurrence of the hardcoded prefix throughout its whole body is rewritten, not
+    // just the first line.
     private fun rewriteShebangIfNeeded(file: File, prefix: File) {
         if (file.length() < 3) return
         val bytes = file.readBytes()
         if (bytes.size < 2 || bytes[0] != '#'.code.toByte() || bytes[1] != '!'.code.toByte()) return
-        val newlineIndex = bytes.indexOf('\n'.code.toByte())
-        val firstLineEnd = if (newlineIndex < 0) bytes.size else newlineIndex
-        val firstLine = String(bytes, 0, firstLineEnd, Charsets.UTF_8)
-        if (!firstLine.contains(HARDCODED_TERMUX_PREFIX)) return
-        val patchedLine = firstLine.replace(HARDCODED_TERMUX_PREFIX, prefix.absolutePath)
-        val rest = if (newlineIndex < 0) ByteArray(0) else bytes.copyOfRange(newlineIndex, bytes.size)
-        file.writeBytes(patchedLine.toByteArray(Charsets.UTF_8) + rest)
+        val text = String(bytes, Charsets.UTF_8)
+        if (!text.contains(HARDCODED_TERMUX_PREFIX)) return
+        file.writeBytes(text.replace(HARDCODED_TERMUX_PREFIX, prefix.absolutePath).toByteArray(Charsets.UTF_8))
     }
 
     // apt's own Dir::* settings (where it looks for apt.conf.d, sources.list, its package cache,

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
@@ -193,6 +193,12 @@ fun TerminalScreen(
             .fillMaxSize()
             .background(Azphalt.currentGround.pageBrush())
             .then(if (fullscreen) Modifier else Modifier.windowInsetsPadding(WindowInsets.systemBars))
+            // The command line and modifier keys are pinned at the bottom, below the weighted
+            // PillMenu/buffer above them - with no IME inset, the keyboard just overlaid the
+            // screen on top of them instead of the layout making room. imePadding() shrinks this
+            // Column's own height by the keyboard's, so the weighted content above eats the
+            // difference and the input row stays above the keyboard rather than under it.
+            .imePadding()
     ) {
 
         SessionTabs(


### PR DESCRIPTION
## Summary

Two bugs reported from live-testing the built app (screenshot with two circled issues):

- **Keyboard covers the command input/buttons.** `TerminalScreen`'s outer `Column` had no IME inset, so the on-screen keyboard just overlaid the pinned command-input/modifier-key row instead of the layout making room for it. Added `.imePadding()` so the Column shrinks by the keyboard's height and the weighted content above (PillMenu/buffer) absorbs the difference, keeping the input row above the keyboard.
- **`pkg install git` fails** with `bash: .../termux-setup-package-manager: No such file or directory`. `DistroManager.rewriteShebangIfNeeded` only rewrote the hardcoded Termux install-path (`/data/data/com.termux/files/usr`) on a script's first (shebang) line. But `pkg` itself calls other bootstrap tools by that same hardcoded absolute path elsewhere in its body, not via `$PREFIX` or a bare command name PATH would resolve — so those calls kept failing even once the shebang fix let the script start. Generalized the rewrite to cover every occurrence throughout the whole script body, still gated behind the same shebang-detection precondition so the ~330 manifest-covered ELF binaries are never touched.

## Test plan

- [ ] CI: confirm `detekt` and `android-debug / build` pass.
- Could not run a full Gradle build or launch the app in this sandbox — please confirm both fixes on-device (retry `pkg install git`, and confirm the input row stays visible above the keyboard).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZLT87WXJ6kEiX1kAGEcKK)_

## Summary by Sourcery

Fix terminal keyboard insets and rewrite package-manager paths throughout compatible bootstrap scripts.

Bug Fixes:
- Keep the terminal command input and modifier-key row visible above the on-screen keyboard.
- Resolve hardcoded package-manager tool paths throughout bootstrap scripts so commands such as `pkg install git` work correctly.