### PR TITLE
Guard Files/PathPicker reveal-animation races

### DIFF
--- a/composeApp/src/main/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/main/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -94,6 +94,7 @@ import com.hereliesaz.hg2gui.ui.ssh.SshFlow
 import java.io.File
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -267,17 +268,33 @@ class TerminalActivity : FragmentActivity() {
             val filesWrap = remember { PillWrapRevealState() }
             var filesOrigin by remember { mutableStateOf(Rect.Zero) }
             val filesHue = remember { Azphalt.hues[Azphalt.hueOf("/")] }
+            // Tracks whichever of open()/close() is currently driving filesWrap's Animatables, so
+            // the other one can be cancelled before a new run starts instead of both racing the
+            // same Animatable objects - a second run's animateTo()/snapTo() call silently steals
+            // control from whichever run got there first, and if that first run was the one still
+            // due to flip `active`/`screen` back, neither ever happens and the Files overlay is
+            // stuck on screen. Paired with the active-guards below, which also stop a re-tap on an
+            // already-open (or already-opening) Files pill from restarting the reveal from scratch.
+            var filesJob by remember { mutableStateOf<Job?>(null) }
             fun openFiles() {
+                if (filesWrap.active) return
+                filesWrap.active = true
                 filesWrap.origin = filesOrigin
                 screen = Screen.Files
-                scope.launch {
+                filesJob = scope.launch {
                     filesWrap.open(revealFullWidthPx, revealFullHeightPx, revealDefaultBaseWidthPx, revealMinThicknessPx)
                 }
             }
             fun closeFiles() {
-                scope.launch {
+                if (!filesWrap.active) return
+                filesJob?.cancel()
+                filesJob = scope.launch {
                     filesWrap.close(revealFullWidthPx, revealFullHeightPx, revealDefaultBaseWidthPx, revealMinThicknessPx)
-                    screen = Screen.Terminal
+                    // Only this run's own screen, not whatever the user may have navigated to
+                    // since - closeFiles() can now only ever be reached while Files is still the
+                    // active screen (see the excluded when-branch below), but this stays a
+                    // conditional reset rather than unconditional out of caution.
+                    if (screen == Screen.Files) screen = Screen.Terminal
                 }
             }
 
@@ -289,9 +306,13 @@ class TerminalActivity : FragmentActivity() {
             var pathPickerRoot by remember { mutableStateOf("") }
             val pathPickerHue = remember { Azphalt.hues[Azphalt.hueOf(FileBrowser.WIZARD_PREFIX)] }
             val crumbRects = remember { mutableStateMapOf<String, Rect>() }
+            // Same open()/close() race guard as filesJob above - see its comment.
+            var pathPickerJob by remember { mutableStateOf<Job?>(null) }
 
             fun closePathPicker() {
-                scope.launch {
+                if (!pathPickerState.active) return
+                pathPickerJob?.cancel()
+                pathPickerJob = scope.launch {
                     pathPickerState.close(revealFullWidthPx, revealFullHeightPx, revealDefaultBaseWidthPx, revealMinThicknessPx)
                 }
             }
@@ -673,6 +694,17 @@ class TerminalActivity : FragmentActivity() {
                         backStep = guideBackStep
                     )
 
+                    // Files/PathPicker's own reveal takes ~1-2s to run (see openFiles()/the
+                    // wizard-pill dispatch above), and neither is a real screen change - `screen`
+                    // itself only flips to Files synchronously, never for the picker. Without this
+                    // branch, TerminalScreen (the catch-all below) would keep rendering - and
+                    // staying fully interactive, since PillWrapReveal/PillPerimeterReveal draw no
+                    // touch-blocking scrim of their own - underneath the growing reveal for that
+                    // whole window, letting a wizard pill tapped through it start a real navigation
+                    // (`screen = Screen.Ai`, etc.) while the reveal is still mid-flight and stack
+                    // its own overlay on top of wherever that navigation lands.
+                    screen == Screen.Files || filesWrap.active || pathPickerState.active -> {}
+
                     sessions.isNotEmpty() && currentTree != null -> TerminalScreen(
                         tree = currentTree,
                         sessions = sessions.map { it.ui },
@@ -755,12 +787,13 @@ class TerminalActivity : FragmentActivity() {
                                         tree = withContext(Dispatchers.IO) { CommandTree.from(this@TerminalActivity) }
                                     }
                                 }
-                                wizardId.startsWith(FileBrowser.WIZARD_PREFIX) -> {
+                                wizardId.startsWith(FileBrowser.WIZARD_PREFIX) -> if (!pathPickerState.active) {
                                     val crumbId = wizardId.removePrefix(FileBrowser.WIZARD_PREFIX)
                                     pathPickerRoot = session?.ui?.cwd?.takeIf { it.isNotBlank() }
                                         ?: CommandTree.pickerRoot(this@TerminalActivity).absolutePath
+                                    pathPickerState.active = true
                                     pathPickerState.origin = crumbRects[crumbId] ?: Rect.Zero
-                                    scope.launch {
+                                    pathPickerJob = scope.launch {
                                         pathPickerState.open(
                                             revealFullWidthPx,
                                             revealFullHeightPx,


### PR DESCRIPTION
## Summary

First fix out of the fleet audit report (39 findings across 6 adversarial `glee` passes over the app's UI/design/UX). This addresses the highest-severity cross-cutting theme two independent audits converged on: the Files/PathPicker reveal machinery racing itself.

- `openFiles()`/`closeFiles()` and the path-picker's open callsite had no re-entry guard and launched uncoordinated coroutines against the same `PillWrapReveal`/`PillPerimeterReveal` `Animatable`s. Compose silently cancels whichever `animateTo()` was already running on a given `Animatable` when a new one starts — with no `try/finally` anywhere in the three motion files, the losing coroutine could die before reaching its own `active = false` / `screen` reset, stranding the overlay on screen through every subsequent Back press.
  - Fixed by tracking each reveal's current `Job` and cancelling it before a new run starts, plus an `active`-gated guard on `openFiles()`, `closeFiles()`, and the path-picker's open callsite so only one run is ever in flight — the same shape as the existing guard in `PillMenu.openHost()`.
- The same guard incidentally fixes double-tapping the Files pill restarting its reveal from scratch, since a second `openFiles()` call while already active is now a no-op.
- Neither `PillWrapReveal` nor `PillPerimeterReveal` draws a touch-blocking scrim, and the main screen's `when` block never excluded `Screen.Files` or an active picker, so `TerminalScreen` kept rendering — and stayed fully tappable — underneath the ~1–2s reveal. A wizard pill tapped through it could trigger a real navigation while the reveal was still running, letting it finish painting over whatever screen the user had already navigated to.
  - Fixed by excluding `TerminalScreen`'s fallback branch while a reveal is active, closing off the escape path rather than papering over its effect.

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlin` — compiles clean.
- [x] `./gradlew detekt` — clean, no baseline changes needed.
- [ ] Could not verify visually in this sandbox (no device/emulator) — please spot-check on-device: open Files, tap Back mid-reveal (should close cleanly, not freeze); double-tap the Files pill quickly (should not visibly restart the reveal); tap a wizard pill (e.g. AI chat) while Files is still opening (should be unreachable — no tap response — until the reveal finishes or is backed out of).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZLT87WXJ6kEiX1kAGEcKK)_

## Summary by Sourcery

Prevent Files and PathPicker reveal animations from racing and interacting with the underlying terminal UI.

Bug Fixes:
- Prevent Files and PathPicker reveal animations from racing or restarting, avoiding overlays becoming stuck after interrupted navigation or Back actions.
- Block underlying terminal interactions while Files or PathPicker reveals are active, preventing accidental navigation beneath the animation.

Enhancements:
- Add guarded lifecycle handling for Files and PathPicker reveal operations, including conditional screen restoration after closing Files.