### PR TITLE
Fix Files/VFS state-desync bugs

### DIFF
--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FilesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FilesScreen.kt
@@ -235,6 +235,27 @@ fun FilesScreen(
         }
     }
 
+    // Rename/delete/move on a folder currently sitting in openChain used to leave that entry -
+    // and everything drilled in beneath it - pointing at a path that's since changed or vanished;
+    // the panel kept re-fetching the stale path, showed "NOTHING HERE" under a header still
+    // reading the old name, and currentTargetDir kept resolving to a directory that no longer
+    // existed. Deleting/moving the source out from under an open level closes it (and whatever
+    // was drilled in deeper, since a path nested under a gone folder is meaningless); renaming it
+    // updates that one level in place and closes anything drilled in deeper - LaunchedEffect above
+    // re-fetches every surviving level fresh the moment openChain itself changes, so there's
+    // nothing else to keep in sync by hand.
+    fun closeChainIfAffected(paths: Set<String>) {
+        val idx = openChain.indexOfFirst { it.path in paths }
+        if (idx >= 0) openChain = openChain.take(idx)
+    }
+
+    fun renameChainIfAffected(oldPath: String, newName: String) {
+        val idx = openChain.indexOfFirst { it.path == oldPath }
+        if (idx < 0) return
+        val renamed = openChain[idx].copy(name = newName, path = vfsChildPath(vfsParentPath(oldPath), newName))
+        openChain = openChain.take(idx) + renamed
+    }
+
     fun recordSearch(query: String) {
         val trimmed = query.trim()
         if (trimmed.isEmpty()) return
@@ -264,8 +285,13 @@ fun FilesScreen(
             when {
                 creating != null -> { creating = null; createInput = "" }
                 renameTarget != null -> { renameTarget = null }
-                screen != FMScreen.Browse -> { screen = FMScreen.Browse }
+                // Checked ahead of the generic `screen != Browse` branch below: typing a query
+                // flips `screen` to Search as a side effect (see onValueChange above), but the
+                // content area is gated on `searchActive` alone - resetting only `screen` here
+                // left the visible search results on screen with nothing to show for the back
+                // press, requiring a second one to actually leave search.
                 searchActive -> { searchActive = false; searchQuery = ""; screen = FMScreen.Browse }
+                screen != FMScreen.Browse -> { screen = FMScreen.Browse }
                 selectMode -> { selectMode = false; selected = emptySet() }
                 openChain.isNotEmpty() -> { openChain = openChain.dropLast(1) }
             }
@@ -284,8 +310,11 @@ fun FilesScreen(
             confirmLabel = if (isMove) "MOVE" else "COPY",
             onConfirm = {
                 scope.launch {
-                    val failed = paths.count { path -> !(if (isMove) onMove(path, target) else onCopy(path, target)) }
-                    opError = if (failed > 0) "$failed of ${paths.size} didn't ${if (isMove) "move" else "copy"}." else null
+                    val failed = paths.filterNot { path -> if (isMove) onMove(path, target) else onCopy(path, target) }.toSet()
+                    opError = if (failed.isNotEmpty()) "${failed.size} of ${paths.size} didn't ${if (isMove) "move" else "copy"}." else null
+                    // Only a move actually removes the source - a copy leaves the open folder
+                    // right where it was.
+                    if (isMove) closeChainIfAffected(paths - failed)
                     selected = emptySet()
                     selectMode = false
                     refresh()
@@ -310,8 +339,9 @@ fun FilesScreen(
                         screen = FMScreen.Browse
                         pendingBatchOverwrite = Triple(selected, target, isMove)
                     } else {
-                        val failed = selected.count { path -> !(if (isMove) onMove(path, target) else onCopy(path, target)) }
-                        opError = if (failed > 0) "$failed of ${selected.size} didn't ${if (isMove) "move" else "copy"}." else null
+                        val failed = selected.filterNot { path -> if (isMove) onMove(path, target) else onCopy(path, target) }.toSet()
+                        opError = if (failed.isNotEmpty()) "${failed.size} of ${selected.size} didn't ${if (isMove) "move" else "copy"}." else null
+                        if (isMove) closeChainIfAffected(selected - failed)
                         selected = emptySet()
                         selectMode = false
                         screen = FMScreen.Browse
@@ -336,6 +366,8 @@ fun FilesScreen(
             },
             onBack = { screen = FMScreen.Browse },
             fullscreen = fullscreen,
+            errorMessage = opError,
+            onErrorDismiss = { opError = null },
             modifier = modifier
         )
         return
@@ -584,7 +616,9 @@ fun FilesScreen(
                                 if (name in siblingNames) {
                                     pendingRenameOverwrite = target to name
                                 } else {
-                                    opError = if (!onRename(target.path, name)) "Couldn't rename that." else null
+                                    val ok = onRename(target.path, name)
+                                    opError = if (!ok) "Couldn't rename that." else null
+                                    if (ok) renameChainIfAffected(target.path, name)
                                     refresh()
                                 }
                             }
@@ -604,7 +638,9 @@ fun FilesScreen(
                 confirmLabel = "OVERWRITE",
                 onConfirm = {
                     scope.launch {
-                        opError = if (!onRename(target.path, newName)) "Couldn't rename that." else null
+                        val ok = onRename(target.path, newName)
+                        opError = if (!ok) "Couldn't rename that." else null
+                        if (ok) renameChainIfAffected(target.path, newName)
                         refresh()
                     }
                     pendingRenameOverwrite = null
@@ -649,7 +685,9 @@ fun FilesScreen(
                 confirmLabel = "DELETE",
                 onConfirm = {
                     scope.launch {
-                        opError = if (!onDelete(entry.path)) "Couldn't delete ${entry.name}." else null
+                        val ok = onDelete(entry.path)
+                        opError = if (!ok) "Couldn't delete ${entry.name}." else null
+                        if (ok) closeChainIfAffected(setOf(entry.path))
                         refresh()
                     }
                     deleteTarget = null
@@ -666,8 +704,9 @@ fun FilesScreen(
                 confirmLabel = "DELETE",
                 onConfirm = {
                     scope.launch {
-                        val failed = selected.count { !onDelete(it) }
-                        opError = if (failed > 0) "$failed of ${selected.size} didn't delete." else null
+                        val failed = selected.filterNot { onDelete(it) }.toSet()
+                        opError = if (failed.isNotEmpty()) "${failed.size} of ${selected.size} didn't delete." else null
+                        closeChainIfAffected(selected - failed)
                         selected = emptySet(); selectMode = false; refresh()
                     }
                     batchDeleteConfirm = false
@@ -896,7 +935,7 @@ private fun FileRows(
                             .clip(RoundedCornerShape(7.dp))
                             // The tile's own hue never changes on selection - only the mark does.
                             .background(Azphalt.hues[Azphalt.hueOf(img.path)])
-                            .clickable { onTap(img) }
+                            .combinedClickable(onClick = { onTap(img) }, onLongClick = { onLongPress(img) })
                     ) {
                         Text(
                             img.name, color = Azphalt.White.copy(alpha = .8f), fontSize = 7.sp,

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/StorageScreen.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/StorageScreen.kt
@@ -50,6 +50,13 @@ fun StorageScreen(
     onBack: () -> Unit,
     fullscreen: Boolean,
     onFreeUpSpace: () -> Unit = {},
+    // A failed delete used to have nowhere to show up while this screen was the one on screen -
+    // FilesScreen's own opError banner lives in a Column this screen's caller returns out of
+    // reaching, so the failure only surfaced later, disconnected from the tap, if the user
+    // happened to navigate back to Browse first. This screen now owns its own copy of that banner
+    // instead of relying on a parent Column it may never actually be composed inside of.
+    errorMessage: String? = null,
+    onErrorDismiss: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     var tab by remember { mutableStateOf(StorageTab.BY_TYPE) }
@@ -70,6 +77,20 @@ fun StorageScreen(
             // byCategory is this fixed 5-entry taxonomy (StorageCategory), not a count of where
             // things live - "N PLACES" read as the latter while counting the former.
             Chip("${stats?.byCategory?.size ?: 0} CATEGORIES", filled = false, clickable = false)
+        }
+
+        errorMessage?.let { message ->
+            Row(
+                Modifier
+                    .fillMaxWidth()
+                    .padding(start = 20.dp, end = 20.dp, top = 8.dp)
+                    .clip(RoundedCornerShape(percent = 50))
+                    .background(Azphalt.hues[6])
+                    .clickable(onClick = onErrorDismiss)
+                    .padding(horizontal = 16.dp, vertical = 10.dp)
+            ) {
+                Text(message, color = Azphalt.White, fontSize = 10.sp, fontWeight = FontWeight.ExtraBold)
+            }
         }
 
         if (stats == null) {


### PR DESCRIPTION
## Summary

Second fix out of the fleet audit report. Addresses four BROKEN findings from the Files/VFS audit, all reachable through ordinary one-handed use:

- **Search-back swallowed on first press.** Typing a query flips `screen` to `Search` as a side effect, but the content area is gated on `searchActive` alone. `stepBack`'s `when` checked `screen != Browse` first and only reset `screen`, so the visible search results didn't change until a second back press. Fixed by checking `searchActive` first.
- **`openChain` desync on rename/delete/move of the open folder.** Renaming, deleting, or moving the folder currently drilled into left that entry — and everything nested under it — pointing at a stale/vanished path: "NOTHING HERE" under a header still showing the old name, and "+ NEW FOLDER" silently targeting a directory that no longer exists. Added `closeChainIfAffected()`/`renameChainIfAffected()`, wired into every rename/delete/move confirm handler (single and batch, plus the overwrite-collision variants). Copy is excluded since it doesn't remove the source.
- **Silent delete-failure on Storage.** The error banner lived in a `Column` that `StorageScreen`'s early return skipped entirely, so a failed delete on that screen gave no feedback until the user happened to navigate back to Browse. Gave `StorageScreen` its own error banner.
- **Long-press-to-select missing on photo tiles.** Every other row type wires `onLongClick` via `combinedClickable`; the photo grid used a plain `.clickable` that dropped `onLongPress` even though it was in scope.

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlin` — compiles clean.
- [x] `./gradlew detekt` — clean, no baseline changes needed.
- [ ] Could not verify visually in this sandbox (no device/emulator) — please spot-check on-device: search then back-out in one press; rename/delete the folder you're standing inside; trigger a failed delete from Storage → Largest; long-press a photo in a folder with 3+ images.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZLT87WXJ6kEiX1kAGEcKK)_

## Summary by Sourcery

Prevent Files and Storage UI state from becoming stale or unresponsive after navigation and file operations.

Bug Fixes:
- Fix one-press back navigation from search results.
- Keep open folder navigation synchronized after successful rename, deletion, and move operations.
- Display delete errors immediately on Storage screens.
- Restore long-press selection for photo tiles.