### PR TITLE
Fix pill-stack entrance flash on re-arrival, not just first mount

### DIFF
--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -697,7 +697,15 @@ private fun StackPill(
     // (fraction of the pill's OWN width, per offsetByFractionOfParent's own semantics - it runs
     // after fillMaxWidth in this modifier chain, so its `constraints.maxWidth` is already this
     // pill's own target width, not the full screen's).
-    val motion = remember { StackEntranceMotion(initialPoseFor(entering, entrance, row, geometry)) }
+    // Keyed on entranceKey, not left unkeyed: `key(node.id)` above keeps the same root pill's
+    // composable slot alive across an entire open-then-back-to-Browsing cycle, so an unkeyed
+    // remember here only ever seeds StackEntranceMotion's initial pose once, the very first time
+    // this node is ever composed - every later re-arrival (closing an open category back to
+    // Browsing is the everyday case, not a rare one) reused that same instance, already settled
+    // at its previous entrance's rest pose, and depended on the entrance LaunchedEffect's own
+    // async snapTo() to hide it again - reintroducing the exact flash this seeding exists to
+    // prevent, just on every re-arrival after the first instead of on first mount.
+    val motion = remember(entranceKey) { StackEntranceMotion(initialPoseFor(entering, entrance, row, geometry)) }
     val sway = remember { Animatable(0f) } // degrees, additive wobble - see PillWobble.kt
 
     // Keyed on the stack's own arrival identity (entranceKey), not `entering` alone: a pill


### PR DESCRIPTION
## Summary

Follow-up to #178, which reportedly didn't actually fix the pill-stack entrance flash in practice. Root cause of the gap:

#178 fixed the flash on the very first time the root stack is ever composed, by seeding `StackEntranceMotion`'s Animatables with the correct hidden pose at construction instead of relying on an async `LaunchedEffect`'s `snapTo()`. That fix didn't survive **re-arrival**: `StackEntranceMotion` was constructed via a plain `remember { ... }` with no key, and `key(node.id)` around each root pill keeps that same composable slot — and its already-constructed, already-settled-to-rest `StackEntranceMotion` — alive across an entire open-then-back-to-Browsing cycle.

Tapping an open category's host pill to close it back to Browsing — the everyday case, not a rare cold start — bumps `rootArrivalToken` and rolls a fresh entrance, but reuses the same `motion` instance, which is still holding its *previous* entrance's rest values. The flash this file's own entering-pose seeding exists to prevent was still reachable, just one interaction later than the case #178 actually tested (a fresh app launch).

## Fix

Key `remember` for `motion` on `entranceKey` — the same identity the entrance `LaunchedEffect` a few lines below it already keys on, per its own existing comment about exactly this re-arrival case. A fresh `StackEntranceMotion`, seeded with the correct hidden pose for the new entrance, now gets constructed every time a genuinely new arrival happens, not only once ever per node id.

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlin` — compiles clean.
- [x] `./gradlew :composeApp:detekt :shared:detektMetadataMain :shared:detektAndroidMain` — clean, no baseline changes needed.
- [ ] Could not verify visually in this sandbox (no device/emulator) — please spot-check on-device: open a category, tap its open host pill again to close it back to the root stack, and confirm the root pills stay hidden until they swing in — repeat a few times, since this is specifically the *repeated* re-arrival case the original fix missed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZLT87WXJ6kEiX1kAGEcKK)_

## Summary by Sourcery

Bug Fixes:
- Prevent root pill entrance flashes when returning to the browsing stack by recreating entrance motion for each new arrival.