### PR TITLE
Fix stack pills becoming visible before their entrance places them

### DIFF
--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -805,6 +805,7 @@ private fun StackPillVisual(
                     }
                     rotationZ = motion.turn.value + motion.tilt.value + sway.value
                     translationY = ctx.restLift + motion.riseY.value + ctx.scrollOffsetPx
+                    alpha = motion.alpha.value
                 }
                 .clickable(enabled = !ctx.leaving, onClick = onClick)
         )
@@ -840,7 +841,16 @@ private data class StackEntrancePose(
     val riseY: Float = 0f,
     val lenFrac: Float = 1f,
     val turn: Float = 0f,
-    val tilt: Float = 0f
+    val tilt: Float = 0f,
+    // 1f (fully visible) for every variant except Cascade/Telescope: those two are the only ones
+    // that "hide" a waiting row by parking it at the row below's own position rather than off-
+    // canvas or at zero width - a trick that never actually worked, since rotating a full 360°
+    // reads identically to 0° and each row's width cycles (see rootWidthFraction) rather than
+    // shrinking monotonically, so a wider waiting row is never reliably covered by a narrower one
+    // in front of it. Those two variants instead start this at 0 and only raise it to 1 in lockstep
+    // with the same final-lift window that moves the row into its real resting spot, so nothing of
+    // the real pill is ever visible before it is actually being placed there.
+    val alpha: Float = 1f
 )
 
 /**
@@ -865,7 +875,8 @@ private fun initialPoseFor(entering: Boolean, entrance: StackEntrance, row: Int,
         StackEntrance.Drop -> StackEntrancePose(riseY = -pitchPx * DROP_START_MULTIPLIER)
         StackEntrance.Cascade -> StackEntrancePose(
             riseY = pitchPx,
-            turn = if (row % 2 == 0) -CASCADE_TURN_DEG else CASCADE_TURN_DEG
+            turn = if (row % 2 == 0) -CASCADE_TURN_DEG else CASCADE_TURN_DEG,
+            alpha = 0f
         )
         StackEntrance.Deal -> StackEntrancePose(
             offset = DEAL_START_X_FRACTION,
@@ -878,7 +889,11 @@ private fun initialPoseFor(entering: Boolean, entrance: StackEntrance, row: Int,
             lenFrac = HOST_WIDTH / geometry.restWidthFraction
         )
         StackEntrance.Telescope ->
-            if (row == 0) StackEntrancePose(offset = -OFFSCREEN_FRACTION) else StackEntrancePose(riseY = pitchPx * row)
+            if (row == 0) {
+                StackEntrancePose(offset = -OFFSCREEN_FRACTION)
+            } else {
+                StackEntrancePose(riseY = pitchPx * row, alpha = 0f)
+            }
         StackEntrance.Rally -> StackEntrancePose(offset = if (row % 2 == 0) -OFFSCREEN_FRACTION else OFFSCREEN_FRACTION)
     }
 }
@@ -891,6 +906,7 @@ private class StackEntranceMotion(pose: StackEntrancePose) {
     val lenFrac = Animatable(pose.lenFrac) // fraction of the pill's own resting width
     val turn = Animatable(pose.turn) // degrees
     val tilt = Animatable(pose.tilt) // degrees
+    val alpha = Animatable(pose.alpha) // 0..1, see StackEntrancePose's own doc comment
 
     /**
      * The exit never varies - always the same sweep left, whichever entrance brought this pill
@@ -912,6 +928,7 @@ private class StackEntranceMotion(pose: StackEntrancePose) {
             lenFrac.snapTo(1f)
             turn.snapTo(0f)
             tilt.snapTo(0f)
+            alpha.snapTo(1f)
             sway.snapTo(0f)
             offset.animateTo(leaveTarget, tween(Azphalt.SLIDE_MS, easing = LinearEasing))
             return
@@ -982,6 +999,7 @@ private class StackEntranceMotion(pose: StackEntrancePose) {
         val step = stackInterval(Azphalt.SWING_MS, rowCount)
         riseY.snapTo(pitchPx) // stacked on the row below
         turn.snapTo(if (row % 2 == 0) -CASCADE_TURN_DEG else CASCADE_TURN_DEG)
+        alpha.snapTo(0f) // genuinely hidden - see StackEntrancePose's own doc comment
         delay(row * step.toLong())
         coroutineScope {
             launch { turn.animateTo(0f, tween(step, easing = LinearEasing)) }
@@ -992,6 +1010,16 @@ private class StackEntranceMotion(pose: StackEntrancePose) {
                     pitchPx at 0 using LinearEasing
                     pitchPx at (step * Azphalt.LIFT_FRACTION).toInt() using LinearEasing
                     0f at step
+                })
+            }
+            launch {
+                // Alpha rides the same final-tenth window lift does, so the real pill only ever
+                // becomes visible as it lands, never while still rotating in behind its neighbor.
+                alpha.animateTo(1f, keyframes {
+                    durationMillis = step
+                    0f at 0 using LinearEasing
+                    0f at (step * Azphalt.LIFT_FRACTION).toInt() using LinearEasing
+                    1f at step
                 })
             }
         }
@@ -1032,8 +1060,12 @@ private class StackEntranceMotion(pose: StackEntrancePose) {
         } else {
             // Drawn out from behind the row below, already at final length.
             riseY.snapTo(pitchPx * row)
+            alpha.snapTo(0f) // genuinely hidden - see StackEntrancePose's own doc comment
             delay(slide + (row - 1) * step.toLong())
-            riseY.animateTo(0f, tween(step, easing = LinearEasing))
+            coroutineScope {
+                launch { riseY.animateTo(0f, tween(step, easing = LinearEasing)) }
+                launch { alpha.animateTo(1f, tween(step, easing = LinearEasing)) }
+            }
         }
     }
 
@@ -1150,6 +1182,13 @@ private fun ChildPill(
     // the band would visibly drift upward through its held rows instead of sitting invisibly at
     // the one it's hidden behind until the final 10% lift.
     val lift = remember(node.id) { Animatable(-pitchPx * (absoluteRow - 1).coerceAtLeast(BAND_BASE_ROW)) }
+    // Position (lift) alone was never enough to actually hide a pill waiting behind its
+    // predecessor: rotating a full 360° (turn's own starting value below) reads identically to 0°,
+    // and childWidthFraction cycles rather than shrinking monotonically, so a wider waiting row
+    // isn't reliably covered by a narrower one in front of it either. This starts genuinely
+    // invisible and only rises to 1 in the same final-tenth window that lift actually moves the
+    // pill into its resting spot - see the entrance LaunchedEffect below.
+    val pillAlpha = remember(node.id) { Animatable(0f) }
     val leaveOffset = remember(node.id) { Animatable(0f) }
     val scale = remember(node.id) { Animatable(1f) }
     // Only while leaving - a cascading child turns alone, not with a pile, so it has nothing to
@@ -1176,12 +1215,23 @@ private fun ChildPill(
                 (-pitchPx * (absoluteRow - 1).coerceAtLeast(BAND_BASE_ROW)) at (Azphalt.SWING_MS * Azphalt.LIFT_FRACTION).toInt() using LinearEasing
             })
         }
+        launch {
+            // Rides the same final-tenth window lift does, so the real pill only ever becomes
+            // visible as it lands, never while still turning in behind its predecessor.
+            pillAlpha.animateTo(1f, keyframes {
+                durationMillis = Azphalt.SWING_MS
+                0f at (Azphalt.SWING_MS * Azphalt.LIFT_FRACTION).toInt() using LinearEasing
+            })
+        }
     }
 
     // A newly-chosen pill drops to the shared bottom row and grows a little as it settles there;
     // its siblings leave exactly like the root stack's unselected pills do.
     LaunchedEffect(leaving, droppingOut) {
         if (droppingOut) {
+            // A tap can land while this pill is still mid-entrance (still hidden, alpha < 1) -
+            // becoming the host is its own reveal, so it must not stay invisible through it.
+            launch { pillAlpha.animateTo(1f, tween(Azphalt.DROP_MS, easing = LinearEasing)) }
             launch { turn.animateTo(0f, tween(Azphalt.DROP_MS, easing = LinearEasing)) }
             launch { lift.animateTo(0f, tween(Azphalt.DROP_MS, easing = LinearEasing)) }
             launch {
@@ -1217,6 +1267,7 @@ private fun ChildPill(
                     translationY = lift.value + scrollOffsetPx
                     scaleX = scale.value
                     scaleY = scale.value
+                    alpha = pillAlpha.value
                 }
                 .clickable(onClick = onClick)
         )


### PR DESCRIPTION
## Summary

Follow-up to #186. That fix closed the re-arrival gap in *when* an entrance motion gets seeded, but the underlying "hide a waiting row" mechanism itself was broken, and #186 alone didn't fix the regression on-device.

Root cause: Cascade (both the root stack and the child band) and Telescope "hide" a row that hasn't started its own entrance yet by parking it at the position of the row below (`riseY`/`lift` held) and rotating it a full 360° (`turn`/`lift` snapped to ±360). Two things make that not actually hide anything:

- A 360° `rotationZ` renders identically to 0° — there is no visual difference between "rotated a full turn" and "not rotated at all." The rotation contributes nothing to concealment.
- Each row's width cycles (`rootWidthFraction`/`childWidthFraction` step 0/1/2/1/2, not monotonically) rather than shrinking every row further, so a wider waiting row is not reliably covered by the narrower row in front of it either.

The net effect: the real, final pill — full label, full opacity — is visible, mid-rotation, at the wrong (or overlapping) position, well before its own entrance animation ever places it where it belongs.

## Fix

Adds an explicit `alpha` channel to these three entrance paths (root Cascade, root Telescope, child-band Cascade) that starts genuinely invisible (`0f`) and only rises to `1` in lockstep with the same final window that actually moves the row into its resting spot — so nothing of the real pill is ever shown ahead of its own placement, regardless of rotation or width coincidences. Also guards the child-band case where a tap can land on a still-hidden pill mid-entrance (picking it as the new host), so becoming the host reveals it rather than leaving it invisible.

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlin` — compiles clean.
- [x] `./gradlew :composeApp:detekt :shared:detektMetadataMain :shared:detektAndroidMain` — clean, no baseline changes needed.
- [ ] Could not verify visually in this sandbox (no device/emulator) — please spot-check on-device: open a category using the Cascade or Telescope entrance (and the child band, which always cascades) and confirm no pill's real content/position is visible before its own turn arrives.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZLT87WXJ6kEiX1kAGEcKK)_

## Summary by Sourcery

Hide waiting pills until their entrance placement completes, while revealing any pill that becomes the active host mid-entrance.

Bug Fixes:
- Prevent stack and child pills from becoming visible before their entrance animations place them in their resting positions.
- Ensure child pills selected as hosts during entrance are revealed correctly.

Enhancements:
- Add coordinated visibility handling to Cascade and Telescope entrance animations across root and child stacks.