### PR TITLE
Add per-line copy on terminal output (W2)

### DIFF
--- a/config/detekt/shared-baseline.xml
+++ b/config/detekt/shared-baseline.xml
@@ -64,11 +64,11 @@
     <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun BlockActionPill(label: String, onClick: () -&gt; Unit)</ID>
     <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun BufferEntry( entry: TerminalHistoryEntry, onCopy: (String) -&gt; Unit, onShare: (String) -&gt; Unit, onRerun: (String) -&gt; Unit, onStop: () -&gt; Unit )</ID>
     <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun ClassificationTogglePill(kind: OutputKind, showRaw: Boolean, onToggle: () -&gt; Unit)</ID>
-    <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun ClassifiedOutput(kind: OutputKind, entry: TerminalHistoryEntry, onPage: Color, showRaw: Boolean)</ID>
+    <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun ClassifiedOutput( kind: OutputKind, entry: TerminalHistoryEntry, onPage: Color, showRaw: Boolean, onCopyLine: (String) -&gt; Unit )</ID>
     <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun CommandLine( tokens: List&lt;String&gt;, inputText: String, onInputTextChange: (String) -&gt; Unit, hint: String, enabled: Boolean, onRun: () -&gt; Unit, runLabel: String = "RUN", masked: Boolean = false )</ID>
     <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun ModifierKeys( keys: List&lt;String&gt; = listOf("ctrl", "alt", "esc", "tab", "↑", "↓"), onKeyClick: (String) -&gt; Unit = {} )</ID>
-    <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun OutputLines(entry: TerminalHistoryEntry)</ID>
-    <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun OutputWipeLine(seq: Int, spans: List&lt;StyledSpan&gt;)</ID>
+    <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun OutputLines(entry: TerminalHistoryEntry, onCopyLine: (String) -&gt; Unit)</ID>
+    <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun OutputWipeLine(seq: Int, spans: List&lt;StyledSpan&gt;, onCopyLine: (String) -&gt; Unit)</ID>
     <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun SessionTabs( sessions: List&lt;SessionUiState&gt;, activeId: String, onOpenSettings: () -&gt; Unit, onOpenGuide: () -&gt; Unit, onOpenFiles: () -&gt; Unit, onFilesButtonPositioned: (Rect) -&gt; Unit, onPick: (String) -&gt; Unit, onNew: () -&gt; Unit, onClose: (String) -&gt; Unit )</ID>
     <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun StatusDot(entry: TerminalHistoryEntry)</ID>
     <ID>FunctionNaming:TerminalScreen.kt$@Composable private fun StderrBlock(text: String)</ID>

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/TerminalScreen.kt
@@ -456,7 +456,7 @@ private fun BufferEntry(
         }
         if (entry.output.isNotEmpty()) {
             Spacer(Modifier.height(4.dp))
-            ClassifiedOutput(kind, entry, onPage, showRaw)
+            ClassifiedOutput(kind, entry, onPage, showRaw, onCopy)
         }
         if (entry.stderr.isNotEmpty()) {
             Spacer(Modifier.height(4.dp))
@@ -479,7 +479,13 @@ private fun BufferEntry(
 // complexity budget - see [OutputKind]'s own doc comment for why this is one classification
 // rather than a chain of independent booleans.
 @Composable
-private fun ClassifiedOutput(kind: OutputKind, entry: TerminalHistoryEntry, onPage: Color, showRaw: Boolean) {
+private fun ClassifiedOutput(
+    kind: OutputKind,
+    entry: TerminalHistoryEntry,
+    onPage: Color,
+    showRaw: Boolean,
+    onCopyLine: (String) -> Unit
+) {
     when {
         kind == OutputKind.BINARY && !showRaw -> {
             // D6: "refused with an explanation rather than rendered" - garbled bytes typeset as
@@ -513,7 +519,7 @@ private fun ClassifiedOutput(kind: OutputKind, entry: TerminalHistoryEntry, onPa
             // "Output sets, not echoes" (RATTLE 5G / OUTPUT SETS): raw output reveals line by
             // line via a clip-wipe + slight slide, the same idiom GuideReaderScreen's WipeItem
             // uses for its own reveals, rather than the whole block appearing instantly.
-            OutputLines(entry)
+            OutputLines(entry, onCopyLine)
         }
     }
 }
@@ -572,7 +578,7 @@ private fun buildStyledLine(spans: List<StyledSpan>, onPage: Color): AnnotatedSt
 }
 
 @Composable
-private fun OutputLines(entry: TerminalHistoryEntry) {
+private fun OutputLines(entry: TerminalHistoryEntry, onCopyLine: (String) -> Unit) {
     // D4: this used to short-circuit to a flat, unanimated Text while entry.isRunning was true,
     // and only mount the per-line wipe below once the command finished - so a slow command (an
     // install, a build) sat there looking frozen for its entire run, then dumped its whole
@@ -600,7 +606,7 @@ private fun OutputLines(entry: TerminalHistoryEntry) {
         // costing real composition/layout work for content nobody's watching wipe on anyway. The
         // remaining tail renders as a single joined block instead.
         lines.take(OUTPUT_WIPE_STAGGER_CAP).forEachIndexed { index, spans ->
-            OutputWipeLine(seq = index, spans = spans)
+            OutputWipeLine(seq = index, spans = spans, onCopyLine = onCopyLine)
         }
         if (lines.size > OUTPUT_WIPE_STAGGER_CAP) {
             val onPage = Azphalt.currentGround.onPage
@@ -618,7 +624,7 @@ private fun OutputLines(entry: TerminalHistoryEntry) {
 }
 
 @Composable
-private fun OutputWipeLine(seq: Int, spans: List<StyledSpan>) {
+private fun OutputWipeLine(seq: Int, spans: List<StyledSpan>, onCopyLine: (String) -> Unit) {
     val progress = remember { Animatable(0f) }
     LaunchedEffect(Unit) {
         // D4: seq is this line's absolute index into the whole transcript, which keeps growing
@@ -632,13 +638,19 @@ private fun OutputWipeLine(seq: Int, spans: List<StyledSpan>) {
         progress.animateTo(1f, tween(OUTPUT_WIPE_MS, easing = OUTPUT_WIPE_EASE))
     }
     val onPage = Azphalt.currentGround.onPage
+    // W2: one commit hash out of a `git log`, one path out of a `find` - copying the whole block
+    // to get at a single line was the only option before this. Only offered on this animated
+    // prefix, not the joined tail block below it (see that block's own comment for why splitting
+    // *that* per-line isn't free) - the common case (most output is well under the stagger cap)
+    // gets it, a pathologically long one still has the whole-entry COPY action.
     Text(
         buildStyledLine(spans, onPage),
         modifier = Modifier
             .drawWithContent {
                 clipRect(right = size.width * progress.value) { this@drawWithContent.drawContent() }
             }
-            .graphicsLayer { translationX = -14.dp.toPx() * (1f - progress.value) },
+            .graphicsLayer { translationX = -14.dp.toPx() * (1f - progress.value) }
+            .clickable { onCopyLine(spans.joinToString("") { it.text }) },
         style = MaterialTheme.typography.bodyMedium.copy(fontFamily = FontFamily.Monospace, fontSize = 12.sp)
     )
 }


### PR DESCRIPTION
## Summary

Termux Coverage audit **W2**: "Output can only be copied whole." There was no way to grab the one commit hash out of a `git log`, or the one path out of a `find`, without copying the entire block and hunting through it somewhere else.

## What changed

- Each output line inside the animated prefix (`OutputWipeLine`, bounded by `OUTPUT_WIPE_STAGGER_CAP`) is now individually tap-to-copy, reusing the record's own existing `onCopy` callback — no new plumbing to the clipboard, just a finer-grained source for the same action.
- Deliberately **not** extended to the joined tail block that very long output falls back to — that block is one `Text` node on purpose (see its own existing comment on the composition cost of a node per line at that scale), so per-line copy there would reintroduce exactly the perf regression that code was written to avoid. Those outputs still have the whole-entry COPY action.

## Test plan

- [x] `./gradlew :composeApp:compilePlaystoreDebugKotlin` — compiles clean.
- [x] `./gradlew :composeApp:detekt :shared:detektMetadataMain :shared:detektAndroidMain` — clean, baseline updated for the three changed function signatures only.
- [x] `./gradlew :shared:testAndroidHostTest` — no new failures (2 pre-existing, unrelated `TypesetOutputTest` failures reproduce identically on unmodified `master`).
- [ ] Not visually verified in this sandbox (no device/emulator) — please spot-check on-device: run a command with multi-line output, tap a single line, confirm it copies just that line (and that tapping the command row still toggles COPY/RE-RUN/SHARE as before).

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZLT87WXJ6kEiX1kAGEcKK)_

## Summary by Sourcery

Add per-line copying to the animated portion of terminal output while retaining whole-entry copying for very long output.

New Features:
- Enable copying individual lines of typical multi-line terminal output by tapping the line.

Enhancements:
- Preserve whole-entry copying for output beyond the per-line rendering limit to avoid excessive composition and layout costs.