### PR TITLE
Fix bootstrap re-downloading on every app update

### DIFF
--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/DistroManager.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/terminal/DistroManager.kt
@@ -63,9 +63,35 @@ object DistroManager {
     // bootstrap shell at all, so a command picked from such a tree fell through to the bare
     // /system/bin/sh fallback and failed with its "inaccessible or not found" instead of
     // whatever apt/coreutils would have actually said.
+    //
+    // bin/bash not executing is the one failure this repairs before giving up on it: it's also
+    // exactly what a stale exec-exempt link looks like (see repairExecLinks's own doc comment) -
+    // a routine app update, not a corrupted or missing install - so a single cheap relink pass is
+    // tried here before this reports "not installed" and TerminalActivity's own onCreate falls
+    // back to wiping the prefix and re-downloading the whole multi-megabyte archive from scratch.
     fun isInstalled(context: Context): Boolean {
         val usrDir = prefixDir(context)
-        return usrDir.isDirectory && File(usrDir, "bin").isDirectory && File(usrDir, "bin/bash").canExecute()
+        if (!usrDir.isDirectory || !File(usrDir, "bin").isDirectory) return false
+        val bash = File(usrDir, "bin/bash")
+        if (bash.canExecute()) return true
+        repairExecLinks(context)
+        return bash.canExecute()
+    }
+
+    /**
+     * Re-links every manifest-covered exec-exempt binary/library (see [BootstrapManifest]) against
+     * the CURRENT [Context.getApplicationInfo]`.nativeLibraryDir`. Android assigns that directory a
+     * new path on every reinstall or update of this APK - even though the rest of a bootstrap
+     * install ([prefixDir], extracted once) is completely unaffected by that - so the links
+     * [extractBootstrap] created against the PREVIOUS install's nativeLibraryDir go stale purely
+     * from updating the app, with nothing actually wrong in the extracted rootfs itself. A no-op
+     * when [prefixDir] doesn't exist yet (nothing to repair before a first bootstrap) and equally a
+     * no-op once every link already resolves, so safe to call unconditionally.
+     */
+    private fun repairExecLinks(context: Context) {
+        val prefix = prefixDir(context)
+        if (!prefix.isDirectory) return
+        linkManifestEntries(prefix, context.applicationInfo.nativeLibraryDir)
     }
 
     fun bootstrap(context: Context, client: OkHttpClient): Flow<String> = flow {
@@ -203,8 +229,15 @@ object DistroManager {
             }
         }
         linkMainRepoKeyring(prefix)
+        linkManifestEntries(prefix, nativeLibraryDir)
+        writeAptConf(prefix)
+    }
 
-        for ((realPath, flatName) in manifest) {
+    // Shared by extractBootstrap (fresh install) and repairExecLinks (an existing install whose
+    // links now point at a previous, no-longer-valid nativeLibraryDir) - see repairExecLinks's own
+    // doc comment for why that happens on nothing more than a routine app update.
+    private fun linkManifestEntries(prefix: File, nativeLibraryDir: String) {
+        for ((realPath, flatName) in BootstrapManifest.ENTRIES) {
             val linkFile = File(prefix, realPath)
             linkFile.parentFile?.mkdirs()
             linkFile.delete()
@@ -226,8 +259,6 @@ object DistroManager {
                 }
             }
         }
-
-        writeAptConf(prefix)
     }
 
     // The bootstrap zip's own SYMLINKS.txt wires every *community* keyring under


### PR DESCRIPTION
## Summary

Reported as "why does the app download the bootstrap stuff every time" — happening on every app launch, not just a genuine reinstall-after-uninstall.

`DistroManager.isInstalled()` gates entirely on `bin/bash.canExecute()`. But `bash` (and the ~330 other `BootstrapManifest`-covered binaries/libraries) aren't real extracted files — Android's write-xor-execute policy means a plain extracted file can't be executed from app-private storage, so `extractBootstrap` hard-links (falling back to symlinks) each of them against `context.applicationInfo.nativeLibraryDir` instead, the app's own native-lib directory.

That directory's path isn't stable — Android reassigns it on every reinstall/update of the APK. The extracted rootfs itself (`context.filesDir/usr`) is completely unaffected by an update, but the moment `nativeLibraryDir` moves, every one of those links goes stale, `bin/bash.canExecute()` starts returning false, `isInstalled()` reports "not installed", and `TerminalActivity`'s `onCreate` wipes the whole prefix and re-downloads the multi-megabyte bootstrap archive from scratch — on every update, not just a real loss of the install.

## Fix

`isInstalled()` now tries a cheap repair before giving up: when `bin/bash` isn't executable, it re-runs the same manifest-linking pass `extractBootstrap` already does for a fresh install (pulled out into a shared `linkManifestEntries` helper) against the *current* `nativeLibraryDir`, then rechecks. A no-op in the common case where nothing's stale, and far cheaper than a full re-download when something is.

## Test plan
- [x] `./gradlew :shared:compileAndroidMain` — compiles clean
- [x] `./gradlew :shared:detektAndroidMain` — no new findings (this file is already excluded from detekt's androidMain pass for an unrelated pre-existing detekt NPE bug — see the comment in the root `build.gradle.kts`)
- [ ] Not unit-tested: `isInstalled`/`repairExecLinks`/`linkManifestEntries` all need a real `Context` and touch `Os.symlink`/`Files.createLink`/`ApplicationInfo.nativeLibraryDir` — same category of code this module's existing tests (e.g. `ScriptInstallerTest`) explicitly call out as "needs a real Context/Termux prefix, exercised manually rather than here." No Robolectric/instrumented harness exists for this module to add one.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZLT87WXJ6kEiX1kAGEcKK)_

## Summary by Sourcery

Repair bootstrap links against the current app native-library directory before treating an existing installation as missing.

Bug Fixes:
- Repair stale bootstrap executable and library links after an app update so existing installations are recognized without re-downloading the bootstrap archive.

Enhancements:
- Share manifest-linking logic between fresh bootstrap extraction and installation repair.