### PR TITLE
Deal entrance: start genuinely offscreen, per updated design docs

### DIFF
--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/menu/PillMenu.kt
@@ -846,8 +846,10 @@ private const val DROP_SHORT_FRACTION = 0.04f // of a row pitch, short of the re
 private const val DROP_SETTLE_MS = 60
 private const val CASCADE_TURN_DEG = 360f
 private const val DEAL_STEP_MS = 90
-private const val DEAL_START_X_FRACTION = 0.5f
-private const val DEAL_START_Y_MULTIPLIER = 2f
+// Genuinely offscreen: past the tile's own bottom-right corner, not a small nudge - the arrival
+// has to read as "from outside the frame" (docs/HG2Gui Stack Entrances.dc.html).
+private const val DEAL_START_X_FRACTION = 2.6f
+private const val DEAL_START_Y_MULTIPLIER = 6f
 private const val DEAL_TILT_DEG = 18f
 private const val TELESCOPE_STEP_MS = 120
 private const val EXTEND_ANCHOR_START_FRACTION = 0.62f


### PR DESCRIPTION
## Summary

Design docs in `docs/` were updated (Motion Sheet, Stack Entrances, Termux Coverage). Audited the whole batch against the actual code:

- **Stack Entrances** — the `Deal` entrance's starting offset was widened (`0.5x`/`2x` pitch → `2.6x`/`6x` pitch) so the pill genuinely starts past the tile's own corner, reading as arriving from outside the frame, instead of a small nudge. Applied to `DEAL_START_X_FRACTION`/`DEAL_START_Y_MULTIPLIER` in `PillMenu.kt` — the only line item in this doc batch that was actually out of sync with the code.
- **Motion Sheet** — the "Flood" direction text changed (swipe up-from-bottom → down-from-top), but the real `PillPerimeterReveal.kt` already clips top-down (`clipRect(bottom = size.height * flood.value)`); only the doc's own standalone JS demo was wrong. The new "Implementation — Kotlin Compose" reference section documents already-shipped code verbatim — constants (`SLIDE=140`, `SWING=173`, `UNFOLD=420`, `LIFT_FRACTION=0.9`) and function names (`wobbleAmplitude`, `wobble`) match exactly what's in `PillMenu.kt`/`PillWobble.kt` today.
- **Termux Coverage** — reframed around a new "touch-native equivalent counts as covered" standard, and split the old S1 into a narrower S1 (only things needing a live/moving screen genuinely require a terminal) plus a new S2b (a visible stop control on a running record). Checked both against the code: S2b is already wired (`BlockActionPill("STOP", onStop)` in `TerminalScreen.kt` → `onInterrupt` → `ShellSession.interrupt()`, the real signal-delivery path from earlier work), and the doc's own "worth confirming" package-list item already exists (`pkg`/`apt`'s `list-installed` hint in `CommandTree.kt`'s `SHELL_HINTS`). No code changes needed for either.

## Test plan

- [x] `:shared:compileAndroidMain` compiles clean
- [x] Full CI detekt gate (`:composeApp:detekt :shared:detektMetadataMain :shared:detektAndroidMain`) passes clean
- [x] Cross-checked every other doc delta in this batch against the actual source before concluding no further code change was needed


---
_Generated by [Claude Code](https://claude.ai/code/session_01PZLT87WXJ6kEiX1kAGEcKK)_

## Summary by Sourcery

Bug Fixes:
- Adjust the Deal entrance animation so the pill begins genuinely offscreen and arrives from outside the frame.