### PR TITLE
Replace permanent file deletion with a recoverable trash

### DIFF
--- a/composeApp/src/main/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
+++ b/composeApp/src/main/kotlin/com/hereliesaz/hg2gui/TerminalActivity.kt
@@ -91,6 +91,7 @@ import com.hereliesaz.hg2gui.ui.files.StorageCategoryStat
 import com.hereliesaz.hg2gui.ui.files.StorageStats
 import com.hereliesaz.hg2gui.ui.files.VfsEntry
 import com.hereliesaz.hg2gui.ui.files.VfsSearchResult
+import com.hereliesaz.hg2gui.ui.files.VfsTrashEntry
 import com.hereliesaz.hg2gui.ui.guide.CommandGuideScreen
 import com.hereliesaz.hg2gui.ui.menu.Azphalt
 import com.hereliesaz.hg2gui.ui.menu.CommandTree
@@ -395,8 +396,14 @@ class TerminalActivity : FragmentActivity() {
 
             suspend fun vfsListDir(path: String): List<VfsEntry> = withContext(Dispatchers.IO) {
                 val dir = VfsManager.resolve(this@TerminalActivity, path) ?: return@withContext emptyList()
-                (dir.listFiles() ?: emptyArray())
-                    .sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
+                // TRASH-2: this used to call dir.listFiles() directly, bypassing VfsManager's own
+                // .trash filter entirely - the nested-accordion browser lists whatever File it has
+                // open at each level, which almost never equals the shell's own cwd that
+                // VfsManager.list(context) reads. With Show Hidden on, .trash was a normal,
+                // browsable, movable, deletable folder, and a stray file moved into it (rather
+                // than into one of trash's own id-named slots) had no meta.json - the next
+                // purgeExpiredTrash() sweep would see the orphan and delete it for good, silently.
+                VfsManager.listChildren(dir)
                     .map { f ->
                         VfsEntry(
                             name = f.name,
@@ -458,6 +465,15 @@ class TerminalActivity : FragmentActivity() {
                     usedCapacityBytes = usedBytes
                 )
             }
+
+            suspend fun vfsTrashedItems(): List<VfsTrashEntry> = withContext(Dispatchers.IO) {
+                VfsManager.trashedItems(this@TerminalActivity).map { e ->
+                    VfsTrashEntry(e.id, e.originalPath, e.name, e.isDirectory, e.sizeBytes, e.deletedAtMillis)
+                }
+            }
+
+            fun toManagerEntry(e: VfsTrashEntry) =
+                VfsManager.TrashEntry(e.id, e.originalPath, e.name, e.isDirectory, e.sizeBytes, e.deletedAtMillis)
 
             LaunchedEffect(Unit) {
                 val built = withContext(Dispatchers.Default) {
@@ -1034,11 +1050,24 @@ class TerminalActivity : FragmentActivity() {
                                     VfsManager.resolve(this@TerminalActivity, parentPath)?.let { VfsManager.touch(it, name) } ?: false
                                 }
                             },
+                            // TRASH-1: a delete no longer removes anything outright - it moves
+                            // into VfsManager's trash, recoverable from the Storage screen's own
+                            // TRASH tab. See VfsManager.kt's "Trash" section for the full mechanism.
                             onDelete = { path ->
                                 withContext(Dispatchers.IO) {
-                                    VfsManager.resolve(this@TerminalActivity, path)?.let { VfsManager.delete(it) } ?: false
+                                    VfsManager.resolve(this@TerminalActivity, path)?.let { VfsManager.trash(this@TerminalActivity, it) != null } ?: false
                                 }
                             },
+                            onRestore = { entry ->
+                                withContext(Dispatchers.IO) { VfsManager.restore(this@TerminalActivity, toManagerEntry(entry)) }
+                            },
+                            onPurgeTrash = { entry ->
+                                withContext(Dispatchers.IO) { VfsManager.purgeTrash(this@TerminalActivity, toManagerEntry(entry)) }
+                            },
+                            onEmptyTrash = {
+                                withContext(Dispatchers.IO) { VfsManager.emptyTrash(this@TerminalActivity) }
+                            },
+                            trashedItems = { vfsTrashedItems() },
                             onRename = { path, newName ->
                                 withContext(Dispatchers.IO) {
                                     VfsManager.resolve(this@TerminalActivity, path)?.let { VfsManager.rename(it, newName) } ?: false

--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/VfsManager.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/managers/VfsManager.kt
@@ -2,6 +2,9 @@ package com.hereliesaz.hg2gui.managers
 
 import android.content.Context
 import java.io.File
+import java.util.UUID
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
 
 /**
  * A sandboxed filesystem rooted at the app's private storage, so `mkdir`/`touch`/editing
@@ -65,10 +68,22 @@ object VfsManager {
         }
     }
 
-    fun list(context: Context): List<File> =
-        currentDir(context).listFiles()
+    // TRASH-2: this used to be private logic inlined into list() below, reachable only through
+    // currentDir(context) - the shell's own cwd concept. The GUI browser's nested-accordion view
+    // lists whatever File it already has open at each level, which is a different directory from
+    // the shell cwd almost all the time, so it never went through this filter at all: it called
+    // dir.listFiles() directly (TerminalActivity.kt's vfsListDir), and .trash - along with
+    // whatever a person moved into it while Show Hidden was on - was fully browsable, movable,
+    // and deletable like any other folder. Exposed here so every listing surface, not just the
+    // shell-cwd one, can share the one true filtered view instead of each reimplementing it (and
+    // silently omitting the filter, the way vfsListDir did).
+    fun listChildren(dir: File): List<File> =
+        dir.listFiles()
+            ?.filterNot { it.name == TRASH_DIR_NAME }
             ?.sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
             ?: emptyList()
+
+    fun list(context: Context): List<File> = listChildren(currentDir(context))
 
     fun cd(context: Context, name: String): Boolean {
         val r = init(context)
@@ -180,6 +195,175 @@ object VfsManager {
 
     fun delete(file: File): Boolean = contains(file) && file.deleteRecursively()
 
+    // --- Trash -------------------------------------------------------------------------------
+    // TRASH-1: HG2Gui is a touch-native interface over Termux, whose own `rm` is correctly,
+    // brutally final - that's the right behaviour for a shell. The graphical file manager isn't
+    // a shell, and delete-with-only-a-confirm-dialog is a worse safety net than delete-with-an-
+    // undo: a dialog only ever catches a mis-tap noticed in the same second, never "I didn't
+    // realize I needed that until tomorrow." Trashed items live in a reserved ".trash" folder at
+    // the sandbox root (filtered out of list()/walk()/searchWalk() above, so it never appears as
+    // a browsable folder) and are purged for good after 30 days - the same retention convention
+    // most desktop and photo-library trash cans use - or immediately, via purgeTrash/emptyTrash.
+    //
+    // No locking here, same as move/copy/moveInto/copyInto above: an exists-check followed by a
+    // renameTo is a TOCTOU race if two tabs restore to the same path at the same instant. This
+    // isn't new to trash/restore - it's the pre-existing shape of every write in this object -
+    // and fixing it means locking the whole manager, not just the two functions added here.
+
+    private const val TRASH_DIR_NAME = ".trash"
+    private const val TRASH_RETENTION_MILLIS = 30L * 24 * 60 * 60 * 1000
+
+    private val trashJson = Json { ignoreUnknownKeys = true; encodeDefaults = true }
+
+    @Serializable
+    data class TrashEntry(
+        val id: String,
+        /** Where [restore] puts this back - the vfs-relative path it was deleted from. */
+        val originalPath: String,
+        val name: String,
+        val isDirectory: Boolean,
+        val sizeBytes: Long,
+        val deletedAtMillis: Long
+    )
+
+    private fun trashRoot(context: Context): File = File(init(context), TRASH_DIR_NAME).apply { mkdirs() }
+    private fun trashSlot(context: Context, id: String): File = File(trashRoot(context), id)
+    private fun trashPayload(slot: File): File = File(slot, "payload")
+    private fun trashMeta(slot: File): File = File(slot, "meta.json")
+
+    /** [path]'s own parent, string-only - a local copy of ui/files/VfsEntry.kt's vfsParentPath
+     *  rather than an import across the managers/ui boundary for one two-line op. */
+    private fun parentOfVfsPath(path: String): String {
+        val trimmed = path.trimEnd('/')
+        val slash = trimmed.lastIndexOf('/')
+        return if (slash <= 0) "/" else trimmed.substring(0, slash)
+    }
+
+    private fun dirSize(file: File): Long =
+        if (file.isFile) file.length() else file.listFiles()?.sumOf { dirSize(it) } ?: 0L
+
+    /** [name] with a " (restored)" / " (restored 2)" / ... suffix before the extension - [attempt]
+     *  1 is bare "(restored)", matching how most file managers number their own collision suffix. */
+    private fun restoredName(name: String, attempt: Int): String {
+        val dot = name.lastIndexOf('.')
+        val suffix = if (attempt <= 1) " (restored)" else " (restored $attempt)"
+        return if (dot > 0) "${name.substring(0, dot)}$suffix${name.substring(dot)}" else "$name$suffix"
+    }
+
+    /** Bails a restore loop that's somehow still colliding after this many suffixed attempts -
+     *  never expected to matter, since it would mean 1000 same-named restores already landed in
+     *  one folder, but an unbounded while(true) has no business existing over real I/O. */
+    private const val MAX_RESTORE_ATTEMPTS = 1000
+
+    /**
+     * Moves [file] into the trash instead of deleting it outright. Returns the entry [restore]
+     * needs to put it back, or null if [file] isn't inside the sandbox or the move failed - the
+     * same null-means-refused shape [delete] and every other operation here already use.
+     */
+    fun trash(context: Context, file: File): TrashEntry? {
+        if (!contains(file)) return null
+        val originalPath = pathOf(context, file)
+        // Captured before the move below: File.isDirectory() is a live stat, and once file has
+        // been renamed away, that same File reference stats nothing - it read as false for every
+        // trashed folder, understating a purge confirmation's own "and everything inside it".
+        val wasDirectory = file.isDirectory
+        val size = dirSize(file)
+        val slot = trashSlot(context, UUID.randomUUID().toString())
+        if (!slot.mkdirs()) return null
+        val payload = trashPayload(slot)
+        if (!file.renameTo(payload)) {
+            // Nothing moved yet - the slot is empty and safe to just drop.
+            slot.deleteRecursively()
+            return null
+        }
+        val entry = TrashEntry(slot.name, originalPath, file.name, wasDirectory, size, System.currentTimeMillis())
+        return try {
+            trashMeta(slot).writeText(trashJson.encodeToString(TrashEntry.serializer(), entry))
+            entry
+        } catch (e: Exception) {
+            // The payload really did move - writing its own receipt is what failed. Move it back
+            // rather than deleting it: a missing "moved to trash" confirmation is a far smaller
+            // failure than silently erasing the file trash exists to protect. Only clean up the
+            // slot if that move-back actually succeeded - if it didn't too (the same unlocked
+            // TOCTOU class noted above), deleting the slot now would destroy the payload a second
+            // failure was never supposed to cost. Left alone, purgeExpiredTrash's own meta-first
+            // check above never touches a slot it can't read a receipt for, so the payload
+            // outlives the automatic 30-day sweep - but not an explicit Empty Trash, which nukes
+            // every slot on purpose, orphan or not, because "empty" is not supposed to leave
+            // anything behind. That's the correct behaviour for the action a person actually
+            // asked for; this comment used to promise more durability than that leaves room for.
+            if (payload.renameTo(file)) slot.deleteRecursively()
+            null
+        }
+    }
+
+    /** Puts [entry]'s payload back at [TrashEntry.originalPath]. If something now occupies that
+     *  exact spot - a new file created there since the delete, or another trashed copy already
+     *  restored under a suffix - the restored item gets its own unique " (restored [n])" suffix
+     *  rather than silently clobbering whatever's there now. */
+    fun restore(context: Context, entry: TrashEntry): Boolean {
+        val slot = trashSlot(context, entry.id)
+        val payload = trashPayload(slot)
+        if (!payload.exists()) return false
+        val parent = resolve(context, parentOfVfsPath(entry.originalPath)) ?: return false
+        if (!parent.exists() && !parent.mkdirs()) return false
+        var target = File(parent, entry.name)
+        if (!contains(target)) return false
+        var attempt = 1
+        while (target.exists()) {
+            if (attempt > MAX_RESTORE_ATTEMPTS) return false
+            target = File(parent, restoredName(entry.name, attempt))
+            if (!contains(target)) return false
+            attempt++
+        }
+        if (!payload.renameTo(target)) return false
+        slot.deleteRecursively()
+        return true
+    }
+
+    /** Permanently removes [entry] - the trash's own DELETE, one step past [trash]. */
+    fun purgeTrash(context: Context, entry: TrashEntry): Boolean = trashSlot(context, entry.id).deleteRecursively()
+
+    /** Empties the whole trash at once. Returns how many entries were removed. */
+    fun emptyTrash(context: Context): Int =
+        trashRoot(context).listFiles()?.count { it.deleteRecursively() } ?: 0
+
+    /** Trash older than [TRASH_RETENTION_MILLIS] is purged for good. Called from [trashedItems]
+     *  rather than on a timer - there's no background task infrastructure in this app to run it
+     *  on one, and every real read of the trash is a fine time to sweep it first. */
+    private fun purgeExpiredTrash(context: Context) {
+        val now = System.currentTimeMillis()
+        trashRoot(context).listFiles()?.forEach { slot ->
+            // A slot with no readable meta.json is left alone, not purged. It's more likely a
+            // trash() call caught mid-failure (payload moved, receipt never written or since
+            // moved back) than a genuinely expired entry - the one thing this function must never
+            // do is destroy something it can't positively identify as actually past its window.
+            val entry = readTrashMeta(slot) ?: return@forEach
+            if (now - entry.deletedAtMillis > TRASH_RETENTION_MILLIS) {
+                slot.deleteRecursively()
+            }
+        }
+    }
+
+    private fun readTrashMeta(slot: File): TrashEntry? {
+        val metaFile = trashMeta(slot)
+        if (!metaFile.exists()) return null
+        return try {
+            trashJson.decodeFromString(TrashEntry.serializer(), metaFile.readText())
+        } catch (e: Exception) {
+            null
+        }
+    }
+
+    /** Every entry currently in the trash, most recently deleted first. */
+    fun trashedItems(context: Context): List<TrashEntry> {
+        purgeExpiredTrash(context)
+        return trashRoot(context).listFiles()
+            ?.mapNotNull { readTrashMeta(it) }
+            ?.sortedByDescending { it.deletedAtMillis }
+            ?: emptyList()
+    }
+
     fun rename(file: File, newName: String): Boolean {
         if (!contains(file)) return false
         val parent = file.parentFile ?: return false
@@ -226,6 +410,7 @@ object VfsManager {
     private fun walk(dir: File, into: MutableList<File>, seen: MutableSet<String> = mutableSetOf(), depth: Int = 0) {
         if (depth >= MAX_WALK_DEPTH || !seen.add(dir.canonicalPath)) return
         val children = dir.listFiles()
+            ?.filterNot { it.name == TRASH_DIR_NAME } // TRASH-1, see list() above
             ?.sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
             ?: return
         for (child in children) {
@@ -252,6 +437,7 @@ object VfsManager {
     ) {
         if (into.size >= limit || depth >= MAX_WALK_DEPTH || !seen.add(dir.canonicalPath)) return
         val children = dir.listFiles()
+            ?.filterNot { it.name == TRASH_DIR_NAME } // TRASH-1, see list() above
             ?.sortedWith(compareBy({ !it.isDirectory }, { it.name.lowercase() }))
             ?: return
         for (child in children) {

--- a/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/mcp/McpTools.kt
+++ b/shared/src/androidMain/kotlin/com/hereliesaz/hg2gui/mcp/McpTools.kt
@@ -80,7 +80,11 @@ class McpTools(
             if (dir == null || !dir.isDirectory) {
                 ToolCallResult.Failure(McpJsonRpc.INVALID_PARAMS, "Not a directory: $path")
             } else {
-                val listing = (dir.listFiles() ?: emptyArray())
+                // TRASH-2: raw dir.listFiles() bypassed VfsManager's own trash-directory filter,
+                // the same gap vfsListDir (the GUI's own listing path) had - a paired agent could
+                // vfs.list the sandbox root, see ".trash", and vfs.write a stray file into it with
+                // no meta.json, which the next purgeExpiredTrash() sweep would silently delete.
+                val listing = VfsManager.listChildren(dir)
                     .sortedBy { it.name.lowercase() }
                     .joinToString("\n") { "${if (it.isDirectory) "d" else "f"} ${it.name}" }
                 ToolCallResult.Success(textContent(listing.ifEmpty { "(empty)" }))

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FilesScreen.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/FilesScreen.kt
@@ -136,6 +136,12 @@ fun FilesScreen(
     onCreateFolder: suspend (parentPath: String, name: String) -> Boolean,
     onCreateFile: suspend (parentPath: String, name: String) -> Boolean,
     onDelete: suspend (path: String) -> Boolean,
+    // TRASH-1: onDelete above no longer means "gone" - it moves into the trash, and these three
+    // are how the Storage screen's TRASH tab reads and reverses that.
+    trashedItems: suspend () -> List<VfsTrashEntry>,
+    onRestore: suspend (entry: VfsTrashEntry) -> Boolean,
+    onPurgeTrash: suspend (entry: VfsTrashEntry) -> Boolean,
+    onEmptyTrash: suspend () -> Int,
     onRename: suspend (path: String, newName: String) -> Boolean,
     onMove: suspend (path: String, targetDirPath: String) -> Boolean,
     onCopy: suspend (path: String, targetDirPath: String) -> Boolean,
@@ -182,6 +188,9 @@ fun FilesScreen(
     var createInput by remember { mutableStateOf("") }
 
     var storage by remember { mutableStateOf<StorageStats?>(null) }
+    // Refreshed alongside storage - both describe "what's using space right now," and a
+    // delete/restore/purge is exactly the kind of mutation refreshTick already exists to catch.
+    var trash by remember { mutableStateOf<List<VfsTrashEntry>>(emptyList()) }
     var opError by remember { mutableStateOf<String?>(null) }
 
     // F3: the one file currently expanded in place - re-tapping it, or tapping a different file,
@@ -232,7 +241,7 @@ fun FilesScreen(
     // F4: item hue is share-of-total-storage, so the total has to be known in the browse view
     // too, not just on the dedicated Storage screen - refreshed on every mutating op the same way
     // levelCache is, so a delete/move doesn't leave every remaining item's hue stale.
-    LaunchedEffect(refreshTick) { storage = storageStats() }
+    LaunchedEffect(refreshTick) { storage = storageStats(); trash = trashedItems() }
 
     // VFS-14: null means "this depth's listing hasn't come back from [listDir] yet," distinct
     // from a present-but-empty list ("it came back and there's genuinely nothing here") - the
@@ -405,7 +414,26 @@ fun FilesScreen(
             onDelete = { path ->
                 scope.launch {
                     if (!onDelete(path)) opError = "Couldn't delete that."
-                    storage = storageStats(); refresh()
+                    storage = storageStats(); trash = trashedItems(); refresh()
+                }
+            },
+            trash = trash,
+            onRestore = { entry ->
+                scope.launch {
+                    if (!onRestore(entry)) opError = "Couldn't restore ${entry.name}."
+                    storage = storageStats(); trash = trashedItems(); refresh()
+                }
+            },
+            onPurgeTrash = { entry ->
+                scope.launch {
+                    if (!onPurgeTrash(entry)) opError = "Couldn't delete ${entry.name}."
+                    trash = trashedItems()
+                }
+            },
+            onEmptyTrash = {
+                scope.launch {
+                    onEmptyTrash()
+                    trash = trashedItems()
                 }
             },
             onBack = { screen = FMScreen.Browse },
@@ -726,10 +754,11 @@ fun FilesScreen(
         deleteTarget?.let { entry ->
             ConfirmDialog(
                 title = "DELETE ${entry.name}?",
+                // TRASH-1: no longer final - moved into Storage > Trash, recoverable there.
                 message = if (entry.isDirectory) {
-                    "This deletes ${entry.name} and everything inside it. This can't be undone."
+                    "This moves ${entry.name} and everything inside it to the trash."
                 } else {
-                    "This deletes ${entry.name}. This can't be undone."
+                    "This moves ${entry.name} to the trash."
                 },
                 confirmLabel = "DELETE",
                 onConfirm = {
@@ -748,8 +777,9 @@ fun FilesScreen(
         if (batchDeleteConfirm) {
             ConfirmDialog(
                 title = "DELETE ${selected.size} THINGS?",
-                message = "This deletes everything selected, including the contents of any selected " +
-                    "folders. This can't be undone.",
+                // TRASH-1: no longer final - moved into Storage > Trash, recoverable there.
+                message = "This moves everything selected, including the contents of any selected " +
+                    "folders, to the trash.",
                 confirmLabel = "DELETE",
                 onConfirm = {
                     scope.launch {

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/StorageScreen.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/StorageScreen.kt
@@ -47,12 +47,17 @@ private val CATEGORY_HUES = mapOf(
     "Images" to 0, "Documents" to 2, "Code" to 9, "Archives" to 5, "Other" to 4
 )
 
-private enum class StorageTab { BY_TYPE, LARGEST }
+private enum class StorageTab { BY_TYPE, LARGEST, TRASH }
 
 @Composable
 fun StorageScreen(
     stats: StorageStats?,
     onDelete: (path: String) -> Unit,
+    // TRASH-1: onDelete above moves something in; these three are the trash's own lifecycle.
+    trash: List<VfsTrashEntry> = emptyList(),
+    onRestore: (VfsTrashEntry) -> Unit = {},
+    onPurgeTrash: (VfsTrashEntry) -> Unit = {},
+    onEmptyTrash: () -> Unit = {},
     onBack: () -> Unit,
     fullscreen: Boolean,
     onFreeUpSpace: () -> Unit = {},
@@ -67,6 +72,8 @@ fun StorageScreen(
 ) {
     var tab by remember { mutableStateOf(StorageTab.BY_TYPE) }
     var deleteTarget by remember { mutableStateOf<VfsEntry?>(null) }
+    var purgeTarget by remember { mutableStateOf<VfsTrashEntry?>(null) }
+    var confirmEmptyTrash by remember { mutableStateOf(false) }
 
     Column(
         modifier
@@ -168,6 +175,10 @@ fun StorageScreen(
         ) {
             Chip("BY TYPE", filled = tab == StorageTab.BY_TYPE, onClick = { tab = StorageTab.BY_TYPE })
             Chip("LARGEST", filled = tab == StorageTab.LARGEST, onClick = { tab = StorageTab.LARGEST })
+            Chip(
+                if (trash.isEmpty()) "TRASH" else "TRASH (${trash.size})",
+                filled = tab == StorageTab.TRASH, onClick = { tab = StorageTab.TRASH }
+            )
             // No bulk-cleanup flow of its own - the sensible existing action is just surfacing
             // the worst offenders, so this jumps to LARGEST (where DELETE is one tap away) and
             // also hands off to whatever the caller wants to do with it.
@@ -175,6 +186,12 @@ fun StorageScreen(
                 "FREE UP SPACE", background = Azphalt.hues[6], foreground = Azphalt.White,
                 onClick = { tab = StorageTab.LARGEST; onFreeUpSpace() }
             )
+            if (tab == StorageTab.TRASH && trash.isNotEmpty()) {
+                Chip(
+                    "EMPTY TRASH", background = Azphalt.hues[6], foreground = Azphalt.White,
+                    onClick = { confirmEmptyTrash = true }
+                )
+            }
         }
 
         when (tab) {
@@ -237,19 +254,84 @@ fun StorageScreen(
                     }
                 }
             }
+
+            // TRASH-1: each row offers both directions - RESTORE puts it back where it came
+            // from, × purges that one item for good (its own ConfirmDialog below, since unlike
+            // the soft delete above this one really is final).
+            StorageTab.TRASH -> if (trash.isEmpty()) {
+                Text(
+                    "NOTHING IN THE TRASH", color = Azphalt.currentGround.onPage.copy(alpha = .4f),
+                    fontSize = 12.sp, fontWeight = FontWeight.ExtraBold, letterSpacing = 0.1.em,
+                    modifier = Modifier.padding(start = 20.dp, top = 12.dp)
+                )
+            } else {
+                LazyColumn(
+                    Modifier.weight(1f).fillMaxWidth().padding(horizontal = 20.dp),
+                    verticalArrangement = Arrangement.spacedBy(8.dp)
+                ) {
+                    items(trash, key = { it.id }) { entry ->
+                        Row(
+                            Modifier
+                                .fillMaxWidth()
+                                .clip(RoundedCornerShape(percent = 50))
+                                .background(Azphalt.Ink.copy(alpha = .10f))
+                                .padding(start = 16.dp, end = 8.dp, top = 10.dp, bottom = 10.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.SpaceBetween
+                        ) {
+                            Column {
+                                Text(entry.name, color = Azphalt.currentGround.onPage, fontSize = 12.sp, fontWeight = FontWeight.Bold, maxLines = 1)
+                                Text(formatFileSize(entry.sizeBytes), color = Azphalt.currentGround.onPage.copy(alpha = .55f), fontSize = 9.sp)
+                            }
+                            Row(verticalAlignment = Alignment.CenterVertically, horizontalArrangement = Arrangement.spacedBy(10.dp)) {
+                                Chip("RESTORE", background = Azphalt.hues[3], foreground = Azphalt.White, onClick = { onRestore(entry) })
+                                Text(
+                                    "×", color = Azphalt.currentGround.onPage.copy(alpha = .7f), fontSize = 15.sp,
+                                    modifier = Modifier.clickable { purgeTarget = entry }.padding(start = 4.dp)
+                                )
+                            }
+                        }
+                    }
+                }
+            }
         }
 
         deleteTarget?.let { entry ->
             ConfirmDialog(
                 title = "DELETE ${entry.name}?",
+                // TRASH-1: no longer final - moved into the TRASH tab above, recoverable there.
+                message = if (entry.isDirectory) {
+                    "This moves ${entry.name} and everything inside it to the trash."
+                } else {
+                    "This moves ${entry.name} to the trash."
+                },
+                confirmLabel = "DELETE",
+                onConfirm = { onDelete(entry.path); deleteTarget = null },
+                onDismiss = { deleteTarget = null }
+            )
+        }
+
+        purgeTarget?.let { entry ->
+            ConfirmDialog(
+                title = "DELETE ${entry.name} FOR GOOD?",
                 message = if (entry.isDirectory) {
                     "This deletes ${entry.name} and everything inside it. This can't be undone."
                 } else {
                     "This deletes ${entry.name}. This can't be undone."
                 },
                 confirmLabel = "DELETE",
-                onConfirm = { onDelete(entry.path); deleteTarget = null },
-                onDismiss = { deleteTarget = null }
+                onConfirm = { onPurgeTrash(entry); purgeTarget = null },
+                onDismiss = { purgeTarget = null }
+            )
+        }
+
+        if (confirmEmptyTrash) {
+            ConfirmDialog(
+                title = "EMPTY TRASH?",
+                message = "This deletes everything in the trash for good. This can't be undone.",
+                confirmLabel = "EMPTY TRASH",
+                onConfirm = { onEmptyTrash(); confirmEmptyTrash = false },
+                onDismiss = { confirmEmptyTrash = false }
             )
         }
     }

--- a/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/VfsEntry.kt
+++ b/shared/src/commonMain/kotlin/com/hereliesaz/hg2gui/ui/files/VfsEntry.kt
@@ -22,6 +22,21 @@ data class VfsSearchResult(val entry: VfsEntry, val parentPath: String)
 
 data class StorageCategoryStat(val label: String, val bytes: Long)
 
+/**
+ * A trashed item, as this commonMain screen needs it - a copy of managers/VfsManager.kt's own
+ * (androidMain-only) TrashEntry, the same "shared UI, platform-only I/O" boundary [VfsEntry]
+ * itself already draws. [id] is opaque here; restoring/purging still happens by handing the
+ * whole entry back to the platform callback, not by this screen re-deriving anything from it.
+ */
+data class VfsTrashEntry(
+    val id: String,
+    val originalPath: String,
+    val name: String,
+    val isDirectory: Boolean,
+    val sizeBytes: Long,
+    val deletedAtMillis: Long
+)
+
 /** [totalCapacityBytes] and [usedCapacityBytes] are the real device/partition capacity and usage,
  *  when the platform can supply them (e.g. via `StatFs` on Android) - null when it can't, since
  *  commonMain has no cross-platform way to ask the OS how big the disk is or how full it is. The

--- a/version.properties
+++ b/version.properties
@@ -1,4 +1,4 @@
 versionMajor=0
 versionMinor=7
-versionPatch=89
-versionBuild=360
+versionPatch=95
+versionBuild=366


### PR DESCRIPTION
## Summary

Deleting a file or folder in the file explorer used to be immediate and final, gated only by a confirm dialog reading "This can't be undone" — the right trade-off for Termux's own `rm`, wrong for a touch-native graphical file manager where a confirmation only ever catches a mis-tap noticed in the same second, never "I didn't realize I needed that until tomorrow."

- `VfsManager` gains `trash(context, file)` / `restore` / `purgeTrash` / `emptyTrash`, backed by a reserved `.trash` folder at the sandbox root holding one UUID-named slot per trashed item (payload + a `meta.json` receipt recording where it came from). Entries older than 30 days are purged automatically.
- `StorageScreen` gets a new TRASH tab: restore or permanently purge individual items, or empty the whole trash (its own "this really is final" confirm).
- `TerminalActivity`'s `onDelete` callback now calls `trash()` instead of `delete()`; the file explorer's two delete confirmations were reworded since they're no longer accurate.

## Review

Three rounds of adversarial review (this repo's own GLEE convention — run cold, each a fresh pass) found real defects before this shipped, each fixed in turn:
- The GUI's actual file-listing path (`vfsListDir`) called `dir.listFiles()` directly rather than through `VfsManager`'s own filtered list, so with Show Hidden on, `.trash` was fully browsable, movable into, and deletable — a stray file dropped into it (outside a real slot) had no `meta.json` and got silently, permanently deleted by the next expiry sweep. The MCP `vfs.list` tool had the identical gap. Both now go through a shared, filtered `VfsManager.listChildren`.
- `trash()`'s failure path could destroy the file it had just moved, on a metadata-write failure after a successful move, or on a failed move-back after that. Restructured so the payload is only ever deleted when a move-back is confirmed to have actually happened; `purgeExpiredTrash` never touches a slot it can't read a receipt for.
- A trashed folder was recorded as `isDirectory=false`, because the check read a `File` reference after it had already been renamed away.

**Known, deliberately out of scope:** none of `VfsManager`'s file operations are locked against each other (trash/restore included) — matches every existing move/copy/rename in this file already. Fixing that means locking the whole manager, not just what's new here.

## Test plan
- [x] `:composeApp:assemblePlaystoreDebug` — clean build
- [x] `:shared:testAndroidHostTest` — the 3 pre-existing failures (`TypesetOutputTest` × 2, `ShellSessionTest` × 1) reproduce identically on unmodified `master`; unrelated to this change
- [x] Three cold GLEE passes, findings fixed each round, final pass clean modulo one comment correction (no code change)

---
_Generated by [Claude Code](https://claude.ai/code/session_01ATGfaTjEnJFNDazFJbt3nF)_